### PR TITLE
hidpp10: make the fallback profile active and default

### DIFF
--- a/src/driver-hidpp10.c
+++ b/src/driver-hidpp10.c
@@ -234,7 +234,13 @@ hidpp10drv_probe(struct ratbag_device *device, const struct ratbag_id id)
 
 	if (hidpp10drv_fill_from_profile(device, dev)) {
 		/* Fall back to something that every mouse has */
+		struct ratbag_profile *profile;
+
 		ratbag_device_init_profiles(device, 1, 3);
+		profile = ratbag_device_get_profile_by_index(device, 0);
+		profile->is_active = true;
+		profile->is_default = true;
+		ratbag_profile_unref(profile);
 	}
 
 	return 0;


### PR DESCRIPTION
This fixes a problem with the logitech G5