### PR TITLE
Fixes timeout problems with M705 and adds G9

### DIFF
--- a/src/driver-hidpp10.c
+++ b/src/driver-hidpp10.c
@@ -285,6 +285,9 @@ static const struct ratbag_id hidpp10drv_table[] = {
 	/* G5 */
 	{ .id = LOGITECH_DEVICE(BUS_USB, 0xc041) },
 
+	/* G9 */
+	{ .id = LOGITECH_DEVICE(BUS_USB, 0xc048) },
+
 	/* G500s */
 	{ .id = LOGITECH_DEVICE(BUS_USB, 0xc24e),
 	  .svg_filename = "logitech-g500s.svg" },

--- a/src/hidpp10.c
+++ b/src/hidpp10.c
@@ -151,7 +151,7 @@ hidpp10_request_command(struct hidpp10_device *dev, union hidpp10_message *msg)
 		 */
 		read_buffer.msg.device_idx = msg->msg.device_idx;
 
-		log_buf_raw(ratbag, " *** received: ", read_buffer.data, ret);
+		log_buf_raw(ratbag, " *** received: ", read_buffer.data, ret > 0 ? ret : 0);
 
 
 		/* actual answer */

--- a/src/hidpp10.c
+++ b/src/hidpp10.c
@@ -138,6 +138,12 @@ hidpp10_request_command(struct hidpp10_device *dev, union hidpp10_message *msg)
 	do {
 		ret = ratbag_hidraw_read_input_report(device, read_buffer.data, LONG_MESSAGE_LENGTH);
 
+		/* Wait and retry if the USB timed out */
+		if (ret == -ETIMEDOUT) {
+			msleep(10);
+			ret = ratbag_hidraw_read_input_report(device, read_buffer.data, LONG_MESSAGE_LENGTH);
+		}
+
 		/* Overwrite the return device index with ours. The kernel
 		 * sets our device index on write, but gives us the real
 		 * device index on reply. Overwrite it with our index so the

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -116,6 +116,13 @@ hidpp20_request_command_allow_error(struct ratbag_device *device, union hidpp20_
 	 */
 	do {
 		ret = ratbag_hidraw_read_input_report(device, read_buffer.data, LONG_MESSAGE_LENGTH);
+
+		/* Wait and retry if the USB timed out */
+		if (ret == -ETIMEDOUT) {
+			msleep(10);
+			ret = ratbag_hidraw_read_input_report(device, read_buffer.data, LONG_MESSAGE_LENGTH);
+		}
+
 		log_buf_raw(ratbag, " *** received: ", read_buffer.data, ret);
 
 		if (read_buffer.msg.report_id != REPORT_ID_SHORT &&

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -123,7 +123,7 @@ hidpp20_request_command_allow_error(struct ratbag_device *device, union hidpp20_
 			ret = ratbag_hidraw_read_input_report(device, read_buffer.data, LONG_MESSAGE_LENGTH);
 		}
 
-		log_buf_raw(ratbag, " *** received: ", read_buffer.data, ret);
+		log_buf_raw(ratbag, " *** received: ", read_buffer.data, ret > 0 ? ret : 0);
 
 		if (read_buffer.msg.report_id != REPORT_ID_SHORT &&
 		    read_buffer.msg.report_id != REPORT_ID_LONG)


### PR DESCRIPTION
I hit a buffer overflow when using my M705 and using --verbose=raw. I protected against that and also dealt with a timeout issue I saw with that mouse. I did a similar but untested fix for hidpp20 - I don't have any mice with that protocol.

Also added the logitech G9 for hidpp10.