### PR TITLE
hidpp10 individual features/enable hid++ reporting cleanup

### DIFF
--- a/src/hidpp10.c
+++ b/src/hidpp10.c
@@ -275,8 +275,7 @@ hidpp10_set_hidpp_notifications(struct hidpp10_device *dev,
 
 int
 hidpp10_get_individual_features(struct hidpp10_device *dev,
-				uint8_t *feature_bit_r0,
-				uint8_t *feature_bit_r2)
+				uint32_t *feature_mask)
 {
 	unsigned idx = dev->index;
 	union hidpp10_message features = CMD_ENABLE_INDIVIDUAL_FEATURES(idx, GET_REGISTER_REQ);
@@ -288,16 +287,18 @@ hidpp10_get_individual_features(struct hidpp10_device *dev,
 	if (res)
 		return res;
 
-	*feature_bit_r0 = features.msg.parameters[0];
-	*feature_bit_r2 = features.msg.parameters[2];
+	*feature_mask = features.msg.parameters[0];
+	/* bits 0 and 4-7 are reserved */
+	*feature_mask |= (features.msg.parameters[1] & 0x0E) << 8;
+	/* bits 6-7 are reserved */
+	*feature_mask |= (features.msg.parameters[2] & 0x3F) << 16;
 
 	return 0;
 }
 
 int
-hidpp10_set_individual_feature(struct hidpp10_device *dev,
-			       uint8_t feature_bit_r0,
-			       uint8_t feature_bit_r2)
+hidpp10_set_individual_features(struct hidpp10_device *dev,
+				uint32_t feature_mask)
 {
 	unsigned idx = RECEIVER_IDX;
 	union hidpp10_message mode = CMD_ENABLE_INDIVIDUAL_FEATURES(idx, SET_REGISTER_REQ);
@@ -307,8 +308,9 @@ hidpp10_set_individual_feature(struct hidpp10_device *dev,
 
 	mode.msg.device_idx = dev->index;
 
-	mode.msg.parameters[0] = feature_bit_r0;
-	mode.msg.parameters[1] = feature_bit_r2;
+	mode.msg.parameters[0] = feature_mask & 0xFF;
+	mode.msg.parameters[1] = (feature_mask >> 8) & 0x0E;
+	mode.msg.parameters[2] = (feature_mask >> 16) & 0x3F;
 
 	res = hidpp10_request_command(dev, &mode);
 
@@ -1240,11 +1242,12 @@ void hidpp10_list_devices(struct ratbag_device *device) {
 static int
 hidpp10_get_device_info(struct hidpp10_device *dev)
 {
+	uint32_t feature_mask;
 	uint8_t f1, f2;
 	uint8_t reflect;
 	int i;
 
-	hidpp10_get_individual_features(dev, &f1, &f2);
+	hidpp10_get_individual_features(dev, &feature_mask);
 	hidpp10_get_hidpp_notifications(dev, &f1, &f2);
 
 	hidpp10_get_current_resolution(dev, &dev->xres, &dev->yres);

--- a/src/hidpp10.c
+++ b/src/hidpp10.c
@@ -219,8 +219,7 @@ hidpp10_dump_all_pages(struct hidpp10_device *dev);
 
 int
 hidpp10_get_hidpp_notifications(struct hidpp10_device *dev,
-				uint8_t *reporting_flags_r0,
-				uint8_t *reporting_flags_r2)
+				uint32_t *reporting_flags)
 {
 	unsigned idx = dev->index;
 	union hidpp10_message notifications = CMD_HIDPP_NOTIFICATIONS(idx, GET_REGISTER_REQ);
@@ -232,16 +231,16 @@ hidpp10_get_hidpp_notifications(struct hidpp10_device *dev,
 	if (res)
 		return res;
 
-	*reporting_flags_r0 = notifications.msg.parameters[0];
-	*reporting_flags_r2 = notifications.msg.parameters[2];
+	*reporting_flags = notifications.msg.parameters[0];
+	*reporting_flags |= (notifications.msg.parameters[0] & 0x1F) << 8;
+	*reporting_flags |= (notifications.msg.parameters[2] & 0x7 ) << 16;
 
 	return res;
 }
 
 int
 hidpp10_set_hidpp_notifications(struct hidpp10_device *dev,
-				uint8_t reporting_flags_r0,
-				uint8_t reporting_flags_r2)
+				uint32_t reporting_flags)
 {
 	unsigned idx = dev->index;
 	union hidpp10_message notifications = CMD_HIDPP_NOTIFICATIONS(idx, SET_REGISTER_REQ);
@@ -249,8 +248,9 @@ hidpp10_set_hidpp_notifications(struct hidpp10_device *dev,
 
 	log_raw(dev->ratbag_device->ratbag, "Setting HID++ notifications\n");
 
-	notifications.msg.parameters[0] = reporting_flags_r0;
-	notifications.msg.parameters[2] = reporting_flags_r2;
+	notifications.msg.parameters[0] = reporting_flags & 0xFF;
+	notifications.msg.parameters[1] = (reporting_flags >> 8) & 0x1F;
+	notifications.msg.parameters[2] = (reporting_flags >> 16) & 0x7;
 
 	res = hidpp10_request_command(dev, &notifications);
 
@@ -1242,13 +1242,12 @@ void hidpp10_list_devices(struct ratbag_device *device) {
 static int
 hidpp10_get_device_info(struct hidpp10_device *dev)
 {
-	uint32_t feature_mask;
-	uint8_t f1, f2;
+	uint32_t feature_mask, notifications;
 	uint8_t reflect;
 	int i;
 
 	hidpp10_get_individual_features(dev, &feature_mask);
-	hidpp10_get_hidpp_notifications(dev, &f1, &f2);
+	hidpp10_get_hidpp_notifications(dev, &notifications);
 
 	hidpp10_get_current_resolution(dev, &dev->xres, &dev->yres);
 	hidpp10_get_led_status(dev, dev->led);

--- a/src/hidpp10.h
+++ b/src/hidpp10.h
@@ -89,24 +89,117 @@ hidpp10_set_hidpp_notifications(struct hidpp10_device *dev,
 /* -------------------------------------------------------------------------- */
 /* 0x01: Enable Individual Features                                           */
 /* -------------------------------------------------------------------------- */
-#define FEATURE_BIT_R0_SPECIAL_BUTTON_FUNCTION		1
-#define FEATURE_BIT_R0_ENHANCED_KEY_USAGE		2
-#define FEATURE_BIT_R0_FAST_FORWARD_REWIND		3
-#define FEATURE_BIT_R0_SCROLLING_ACCELERATION		6
-#define FEATURE_BIT_R0_BUTTONS_CONTROL_THE_RESOLUTION	7
-#define FEATURE_BIT_R2_INHIBIT_LOCK_KEY_SOUND		0
-#define FEATURE_BIT_R2_3D_ENGINE			2
-#define FEATURE_BIT_R2_HOST_SW_CONTROLS_LEDS		3
+
+enum hidpp10_individual_features {
+	HIDPP10_FEATURE_BIT_MOUSE_SENSOR_RESOLUTION = (1 << 0),
+	/**
+	 * disabled: buttons send button codes
+	 * enabled: buttons have special functions (default)
+	 * @note Do not use, use 0x63 instead
+	 */
+	HIDPP10_FEATURE_BIT_SPECIAL_BUTTON_FUNCTION = (1 << 1),
+	/**
+	 * disabled: normal key usage (default)
+	 * enabled: enhanced key usage
+	 */
+	HIDPP10_FEATURE_BIT_ENHANCED_KEY_USAGE      = (1 << 2),
+	/**
+	 * disabled: (default)
+	 * enabled:
+	 */
+	HIDPP10_FEATURE_BIT_FAST_FORWARD_REWIND     = (1 << 3),
+	/**
+	 * disabled: (default)
+	 * enabled:
+	 */
+	HIDPP10_FEATURE_BIT_SEND_CALCULATOR_RESULT  = (1 << 4),
+	/**
+	 * disabled:
+	 * enabled: (default)
+	 */
+	HIDPP10_FEATURE_BIT_MOTION_WAKEUP           = (1 << 5),
+	/**
+	 * disabled: (default)
+	 * enabled:
+	 */
+	HIDPP10_FEATURE_BIT_FAST_SCROLLING          = (1 << 6),
+	/**
+	 * disabled: work as buttons
+	 * enabled: control the resolution (default)
+	 */
+	HIDPP10_FEATURE_BIT_BUTTONS_CONTROL_RESOLUTION = (1 << 7),
+
+	/* 1 << 8 is reserved */
+
+	/**
+	 * disabled: (default)
+	 * enabled:
+	 */
+	HIDPP10_FEATURE_BIT_RECEIVER_MULTIPLE_RF_LOCK = (1 << 9),
+
+	/**
+	 * disabled: (default)
+	 * enabled:
+	 */
+	HIDPP10_FEATURE_BIT_RECEIVER_DISABLE_RFSCAN_IN_SUSPEND = (1 << 10),
+
+	/**
+	 * disabled: (default)
+	 * enabled:
+	 *
+	 * When enabled,removes all compatibility checks.
+	 */
+	HIDPP10_FEATURE_BIT_RECEIVER_ACCEPT_ALL_DEVICES_IN_PAIRING = (1 << 11),
+
+	/* 1 << 12 is reserved */
+	/* 1 << 13 is reserved */
+	/* 1 << 14 is reserved */
+	/* 1 << 15 is reserved */
+
+	/**
+	 * disabled: (default)
+	 * enabled: no sound
+	 */
+	HIDPP10_FEATURE_BIT_INHIBIT_LOCK_KEY_SOUND  = (1 << 16),
+
+	/**
+	 * disabled: (default)
+	 * enabled:
+	 */
+	HIDPP10_FEATURE_BIT_INHIBIT_TOUCHPAD        = (1 << 17),
+
+	/**
+	 * disabled:
+	 * enabled: (default)
+	 */
+	HIDPP10_FEATURE_BIT_3D_ENGINE               = (1 << 18),
+
+	/**
+	 * disabled: (disabled)
+	 * enabled:
+	 */
+	HIDPP10_FEATURE_BIT_SW_CONTROLS_LEDS        = (1 << 19),
+
+	/**
+	 * disabled: (disabled)
+	 * enabled:
+	 */
+	HIDPP10_FEATURE_BIT_NO_NUMLOCK_TOGGLE       = (1 << 20),
+
+	/**
+	 * disabled: (disabled)
+	 * enabled:
+	 */
+	HIDPP10_FEATURE_BIT_INHIBIT_PRESENCE_DETECTION = (1 << 21),
+};
 
 int
 hidpp10_get_individual_features(struct hidpp10_device *dev,
-				uint8_t *feature_bit_r0,
-				uint8_t *feature_bit_r2);
+				uint32_t *feature_mask);
 
 int
-hidpp10_set_individual_feature(struct hidpp10_device *dev,
-			       uint8_t feature_bit_r0,
-			       uint8_t feature_bit_r2);
+hidpp10_set_individual_features(struct hidpp10_device *dev,
+				uint32_t feature_mask);
 
 /* -------------------------------------------------------------------------- */
 /* 0x07: Battery Status                                                       */

--- a/src/hidpp10.h
+++ b/src/hidpp10.h
@@ -66,25 +66,102 @@ struct hidpp10_device *hidpp10_device_new_from_idx(struct ratbag_device *device,
 /* -------------------------------------------------------------------------- */
 /* 0x00: Enable HID++ Notifications                                           */
 /* -------------------------------------------------------------------------- */
-#define REPORTING_FLAGS_R0_CONSUMER_SPECIFIC_CONTROL	0
-#define REPORTING_FLAGS_R0_POWER_KEYS			1
-#define REPORTING_FLAGS_R0_VERTICAL_SCROLL		2
-#define REPORTING_FLAGS_R0_MOUSE_EXTRA_BUTTONS		3
-#define REPORTING_FLAGS_R0_BATTERY_STATUS		4
-#define REPORTING_FLAGS_R0_HORIZONTAL_SCROLL		5
-#define REPORTING_FLAGS_R0_F_LOCK_STATUS		6
-#define REPORTING_FLAGS_R0_NUMPAD_NUMERIC_KEYS		7
-#define REPORTING_FLAGS_R2_3D_GESTURES			0
+
+/**
+ * All notifications are disabled by default on powerup.
+ */
+enum hidpp10_hidpp_notifications {
+	/**
+	 * enabled: Multimedia and MS vendor specific keys are reported as
+	 * HID++ notification 0x03
+	 * disabled: reported as normal HID reports
+	 */
+	HIDPP10_NOTIFICATIONS_CONSUMER_VENDOR_SPECIFIC_CONTROL      = (1 << 0),
+	/**
+	 * enabled: power keys are reported as HID++ notification 0x04
+	 * disabled: reported as normal HID reports
+	 */
+	HIDPP10_NOTIFICATIONS_POWER_KEYS                            = (1 << 1),
+	/**
+	 * enabled: Vertical scroll wheel/iNav are reported as HID++
+	 * notification 0x05
+	 * disabled: reported as normal HID reports
+	 */
+	HIDPP10_NOTIFICATIONS_ROLLER_V                              = (1 << 2),
+	/**
+	 * enabled: buttons not available in standard HID are reported as
+	 * HID++ notification 0x06
+	 * disabled: buttons not available in standard HID are not reported
+	 */
+	HIDPP10_NOTIFICATIONS_MOUSE_EXTRA_BUTTONS                   = (1 << 3),
+	/**
+	 * enabled: battery status/milage are reported as HID++ notification
+	 * 0x07 or 0x0D (device-dependent)
+	 * disabled: battery status/milage are not reported
+	 */
+	HIDPP10_NOTIFICATIONS_BATTERY_STATUS                        = (1 << 4),
+	/**
+	 * enabled: Horizontal scroll wheel/iNav are reported as HID++
+	 * notification 0x05
+	 * disabled: reported as normal HID reports
+	 */
+	HIDPP10_NOTIFICATIONS_ROLLER_H                              = (1 << 5),
+	/**
+	 * enabled: F-Lock status is reported as HID++ notification 0x09
+	 * disabled: F-Lock status is not reported
+	 */
+	HIDPP10_NOTIFICATIONS_F_LOCK_STATUS                         = (1 << 6),
+	/**
+	 * enabled: Numpad keys are reported as buttons in HID++
+	 * notification 0x03
+	 * disabled: reported as normal keys
+	 */
+	HIDPP10_NOTIFICATIONS_NUMPAD_NUMERIC_KEYS                   = (1 << 7),
+	/**
+	 * enabled: Device arrival/removal/... are reported as HID++
+	 * notifications 0x40, 0x41, 0x46 or 0x78
+	 * disabled: these events are not reported
+	 */
+	HIDPP10_NOTIFICATIONS_WIRELESS_NOTIFICATIONS                = (1 << 8),
+	/**
+	 * enabled: User interface events are reported as HID++ notification
+	 * 0x08
+	 * disabled: these events are not reported
+	 */
+	HIDPP10_NOTIFICATIONS_UI_NOTIFICATIONS                      = (1 << 9),
+	/**
+	 * enabled: Quad link quality info events are reported as HID++ notification
+	 * 0x49
+	 * disabled: these events are not reported
+	 */
+	HIDPP10_NOTIFICATIONS_QUAD_LINK_QUALITY_INFO                = (1 << 10),
+	HIDPP10_NOTIFICATIONS_SOFTWARE_PRESENT                      = (1 << 11),
+	HIDPP10_NOTIFICATIONS_TOUCHPAD_MULTITOUCH_NOTIFICATIONS     = (1 << 12),
+	/* 1 << 13 is reserved */
+	/* 1 << 14 is reserved */
+	/* 1 << 15 is reserved */
+
+	/**
+	 * enabled: 3D gestures are reported as HID++ notification 0x65
+	 * disabled: these events are not reported
+	 */
+	HIDPP10_NOTIFICATIONS_3D_GESTURE                            = (1 << 16),
+	HIDPP10_NOTIFICATIONS_VOIP_TELEPHONY                        = (1 << 17),
+	HIDPP10_NOTIFICATIONS_CONFIGURATION_COMPLETE                = (1 << 18),
+	/* 1 << 19 is reserved */
+	/* 1 << 20 is reserved */
+	/* 1 << 21 is reserved */
+	/* 1 << 22 is reserved */
+	/* 1 << 23 is reserved */
+};
 
 int
 hidpp10_get_hidpp_notifications(struct hidpp10_device *dev,
-				uint8_t *reporting_flags_r0,
-				uint8_t *reporting_flags_r2);
+				uint32_t *reporting_flags);
 
 int
 hidpp10_set_hidpp_notifications(struct hidpp10_device *dev,
-				uint8_t reporting_flags_r0,
-				uint8_t reporting_flags_r2);
+				uint32_t reporting_flags);
 
 /* -------------------------------------------------------------------------- */
 /* 0x01: Enable Individual Features                                           */


### PR DESCRIPTION
Fixes for the 0x00 and 0x01 requests. Doesn't add anything new, it just moves from register-specific #defines to a single enum each with all the values. Nicer for a potential caller.