### PR TITLE
hidpp10 as separate library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ test-context
 test-device
 test-*.log
 ratbag-command
+hidpp10-dump-page

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,5 @@
 lib_LTLIBRARIES = libratbag.la
+noinst_LTLIBRARIES = libhidpp10.la
 
 include_HEADERS =			\
 	libratbag.h
@@ -43,3 +44,11 @@ AM_CFLAGS = $(GCC_CFLAGS)
 
 DISTCLEANFILES = libratbag-version.h
 EXTRA_DIST = libratbag-version.h.in libratbag.sym
+
+# The hidpp libraries are static libraries only for in-tree tools. No API
+# stability is guaranteed here.
+libhidpp10_la_SOURCES = \
+			hidpp-generic.h	\
+			hidpp-generic.c	\
+			hidpp10.h	\
+			hidpp10.c

--- a/src/driver-hidpp10.c
+++ b/src/driver-hidpp10.c
@@ -197,12 +197,21 @@ hidpp10drv_test_hidraw(struct ratbag_device *device)
 	return ratbag_hidraw_has_report(device, REPORT_ID_SHORT);
 }
 
+static void
+hidpp10_log(void *userdata, enum hidpp_log_priority priority, const char *format, va_list args)
+{
+	struct ratbag_device *device = userdata;
+
+	log_msg_va(device->ratbag, priority, format, args);
+}
+
 static int
 hidpp10drv_probe(struct ratbag_device *device)
 {
 	int rc;
 	struct hidpp10drv_data *drv_data = NULL;
 	struct hidpp10_device *dev = NULL;
+	struct hidpp_device base;
 
 	rc = ratbag_find_hidraw(device, hidpp10drv_test_hidraw);
 	if (rc == -ENODEV) {
@@ -217,13 +226,16 @@ hidpp10drv_probe(struct ratbag_device *device)
 	}
 
 	drv_data = zalloc(sizeof(*drv_data));
+	base.log_handler = hidpp10_log;
+	base.userdata = device;
+	base.hidraw_fd = device->hidraw.fd;
 
 	/* We can treat all devices as wired devices here. If we talk to the
 	 * correct hidraw device the kernel adjusts the device index for us,
 	 * so even for unifying receiver devices we can just 0x00 as device
 	 * index.
 	 */
-	dev = hidpp10_device_new_from_idx(device, WIRED_DEVICE_IDX);
+	dev = hidpp10_device_new_from_idx(&base, WIRED_DEVICE_IDX);
 
 	if (!dev) {
 		log_error(device->ratbag,

--- a/src/driver-hidpp10.c
+++ b/src/driver-hidpp10.c
@@ -226,9 +226,9 @@ hidpp10drv_probe(struct ratbag_device *device)
 	}
 
 	drv_data = zalloc(sizeof(*drv_data));
+	hidpp_device_init(&base, device->hidraw.fd);
 	base.log_handler = hidpp10_log;
 	base.userdata = device;
-	base.hidraw_fd = device->hidraw.fd;
 
 	/* We can treat all devices as wired devices here. If we talk to the
 	 * correct hidraw device the kernel adjusts the device index for us,

--- a/src/driver-hidpp10.c
+++ b/src/driver-hidpp10.c
@@ -227,8 +227,7 @@ hidpp10drv_probe(struct ratbag_device *device)
 
 	drv_data = zalloc(sizeof(*drv_data));
 	hidpp_device_init(&base, device->hidraw.fd);
-	base.log_handler = hidpp10_log;
-	base.userdata = device;
+	hidpp_device_set_log_handler(&base, hidpp10_log, HIDPP_LOG_PRIORITY_RAW, device);
 
 	/* We can treat all devices as wired devices here. If we talk to the
 	 * correct hidraw device the kernel adjusts the device index for us,

--- a/src/hidpp-generic.c
+++ b/src/hidpp-generic.c
@@ -290,3 +290,17 @@ hidpp_log_buffer(struct hidpp_device *dev,
 
 	hidpp_log(dev, priority, "%s\n", output_buf);
 }
+
+static void
+simple_log(void *userdata, enum hidpp_log_priority priority, const char *format, va_list args)
+{
+	vprintf(format, args);
+}
+
+void
+hidpp_device_init(struct hidpp_device *dev, int fd)
+{
+	dev->hidraw_fd = fd;
+	dev->log_handler = simple_log;
+	dev->userdata = NULL;
+}

--- a/src/hidpp-generic.c
+++ b/src/hidpp-generic.c
@@ -258,6 +258,9 @@ hidpp_log(struct hidpp_device *dev,
 {
 	va_list args;
 
+	if (dev->log_priority > priority)
+		return;
+
 	va_start(args, format);
 	dev->log_handler(dev->userdata, priority, format, args);
 	va_end(args);
@@ -301,6 +304,16 @@ void
 hidpp_device_init(struct hidpp_device *dev, int fd)
 {
 	dev->hidraw_fd = fd;
-	dev->log_handler = simple_log;
-	dev->userdata = NULL;
+	hidpp_device_set_log_handler(dev, simple_log, HIDPP_LOG_PRIORITY_INFO, NULL);
+}
+
+void
+hidpp_device_set_log_handler(struct hidpp_device *dev,
+			     hidpp_log_handler log_handler,
+			     enum hidpp_log_priority priority,
+			     void *userdata)
+{
+	dev->log_handler = log_handler;
+	dev->log_priority = priority;
+	dev->userdata = userdata;
 }

--- a/src/hidpp-generic.h
+++ b/src/hidpp-generic.h
@@ -89,6 +89,10 @@ struct hidpp_device {
 	hidpp_log_handler log_handler;
 };
 
+
+void
+hidpp_device_init(struct hidpp_device *dev, int fd);
+
 extern const char *hidpp_errors[0xFF];
 
 const char *

--- a/src/hidpp-generic.h
+++ b/src/hidpp-generic.h
@@ -27,6 +27,7 @@
  */
 
 #include <stdint.h>
+#include <stddef.h>
 
 #ifndef HIDPP_GENERIC_H
 #define HIDPP_GENERIC_H
@@ -64,6 +65,10 @@
 #define ERR_INVALID_PARAM_VALUE			0x0B
 #define ERR_WRONG_PIN_CODE			0x0C
 
+struct hidpp_device {
+	int hidraw_fd;
+};
+
 extern const char *hidpp_errors[0xFF];
 
 const char *
@@ -80,5 +85,11 @@ hidpp20_1b04_get_logical_mapping(uint16_t value);
 
 uint16_t
 hidpp20_1b04_get_logical_control_id(const struct ratbag_button_action *action);
+
+int
+hidpp_write_command(struct hidpp_device *dev, uint8_t *cmd, int size);
+
+int
+hidpp_read_response(struct hidpp_device *dev, uint8_t *buf, size_t size);
 
 #endif /* HIDPP_GENERIC_H */

--- a/src/hidpp-generic.h
+++ b/src/hidpp-generic.h
@@ -87,11 +87,16 @@ struct hidpp_device {
 	int hidraw_fd;
 	void *userdata;
 	hidpp_log_handler log_handler;
+	enum hidpp_log_priority log_priority;
 };
-
 
 void
 hidpp_device_init(struct hidpp_device *dev, int fd);
+void
+hidpp_device_set_log_handler(struct hidpp_device *dev,
+			     hidpp_log_handler log_handler,
+			     enum hidpp_log_priority priority,
+			     void *userdata);
 
 extern const char *hidpp_errors[0xFF];
 

--- a/src/hidpp10.c
+++ b/src/hidpp10.c
@@ -43,6 +43,22 @@
 #include "libratbag-util.h"
 #include "libratbag-hidraw.h"
 
+struct _hidpp10_message {
+	uint8_t report_id;
+	uint8_t device_idx;
+	uint8_t sub_id;
+	uint8_t address;
+	union {
+		uint8_t parameters[3];
+		uint8_t string[16];
+	};
+} __attribute__((packed));
+
+union hidpp10_message {
+	struct _hidpp10_message msg;
+	uint8_t data[LONG_MESSAGE_LENGTH];
+};
+
 #define ERROR_MSG(__hidpp_msg, idx)	{ \
 	.msg = { \
 		.report_id = REPORT_ID_SHORT, \
@@ -86,7 +102,7 @@ const char *device_types[0xFF] = {
 	[0x0A ... 0xFE] = NULL,
 };
 
-int
+static int
 hidpp10_request_command(struct hidpp10_device *dev, union hidpp10_message *msg)
 {
 	union hidpp10_message read_buffer;

--- a/src/hidpp10.c
+++ b/src/hidpp10.c
@@ -1214,24 +1214,6 @@ hidpp10_get_firmare_information(struct hidpp10_device *dev,
 	return 0;
 }
 
-void hidpp10_list_devices(struct ratbag_device *device) {
-	struct hidpp10_device *dev;
-	int i;
-
-	for (i = 0; i < 6; ++i) {
-		dev = hidpp10_device_new_from_idx(device, i);
-		if (!dev)
-			continue;
-
-		log_info(device->ratbag, "[%d] %s	%s (Wireless PID: %04x)\n",
-			 i,
-			 device_types[dev->device_type] ? device_types[dev->device_type] : "",
-			 dev->name, dev->wpid);
-		hidpp10_device_destroy(dev);
-	}
-
-}
-
 /* -------------------------------------------------------------------------- */
 /* general device handling                                                    */
 /* -------------------------------------------------------------------------- */

--- a/src/hidpp10.c
+++ b/src/hidpp10.c
@@ -1203,20 +1203,25 @@ hidpp10_get_device_info(struct hidpp10_device *dev)
 	uint32_t feature_mask, notifications;
 	uint8_t reflect;
 	int i;
+	uint16_t xres, yres;
+	uint16_t refresh_rate;
+	enum hidpp10_led_status led[6];
+	int8_t current_profile;
+	struct hidpp10_profile profiles[HIDPP10_NUM_PROFILES];
 
 	hidpp10_get_individual_features(dev, &feature_mask);
 	hidpp10_get_hidpp_notifications(dev, &notifications);
 
-	hidpp10_get_current_resolution(dev, &dev->xres, &dev->yres);
-	hidpp10_get_led_status(dev, dev->led);
-	hidpp10_get_usb_refresh_rate(dev, &dev->refresh_rate);
+	hidpp10_get_current_resolution(dev, &xres, &yres);
+	hidpp10_get_led_status(dev, led);
+	hidpp10_get_usb_refresh_rate(dev, &refresh_rate);
 
 	hidpp10_get_optical_sensor_settings(dev, &reflect);
 
-	hidpp10_get_current_profile(dev, &dev->current_profile);
+	hidpp10_get_current_profile(dev, &current_profile);
 
 	for (i = 0; i < HIDPP10_NUM_PROFILES; i++)
-		hidpp10_get_profile(dev, i, &dev->profiles[i]);
+		hidpp10_get_profile(dev, i, &profiles[i]);
 
 	return 0;
 }

--- a/src/hidpp10.c
+++ b/src/hidpp10.c
@@ -193,9 +193,6 @@ out_err:
 /* HID++ 1.0 commands 10                                                      */
 /* -------------------------------------------------------------------------- */
 
-static inline void
-hidpp10_dump_all_pages(struct hidpp10_device *dev);
-
 /* -------------------------------------------------------------------------- */
 /* 0x00: Enable HID++ Notifications                                           */
 /* -------------------------------------------------------------------------- */
@@ -1033,30 +1030,6 @@ hidpp10_read_memory(struct hidpp10_device *dev, uint8_t page, uint8_t offset,
 	memcpy(bytes, readmem.msg.string, sizeof(readmem.msg.string));
 
 	return 0;
-}
-
-static inline void
-hidpp10_dump_all_pages(struct hidpp10_device *dev)
-{
-	uint16_t page, offset;
-	uint8_t bytes[16];
-	int res;
-
-	hidpp_log_info(&dev->base, "::::::: Dumping memory :::::\n");
-
-	for (page = 0; page < 512; page++) {
-		hidpp_log_info(&dev->base, ":: page %d\n", page);
-		for (offset = 0; offset < 256; offset += 16) {
-			res = hidpp10_read_memory(dev, page, offset, bytes);
-			if (res != 0)
-				goto out;
-
-			hidpp_log_buffer(&dev->base, HIDPP_LOG_PRIORITY_INFO, " ", bytes, ARRAY_LENGTH(bytes));
-		}
-	}
-
-out:
-	hidpp_log_info(&dev->base, "::::::: Dumping memory complete :::::\n");
 }
 
 /* -------------------------------------------------------------------------- */

--- a/src/hidpp10.h
+++ b/src/hidpp10.h
@@ -50,6 +50,7 @@ hidpp10_device_new_from_wpid(const struct hidpp_device *base,
 struct hidpp10_device*
 hidpp10_device_new_from_idx(const struct hidpp_device *base,
 			    int idx);
+
 void
 hidpp10_device_destroy(struct hidpp10_device *dev);
 

--- a/src/hidpp10.h
+++ b/src/hidpp10.h
@@ -33,8 +33,6 @@
 #include <stdbool.h>
 
 #include "hidpp-generic.h"
-#include "libratbag-private.h"
-#include "libratbag.h"
 
 struct hidpp10_device;
 
@@ -57,8 +55,10 @@ union hidpp10_message {
 void hidpp10_device_destroy(struct hidpp10_device *dev);
 
 int hidpp10_request_command(struct hidpp10_device *device, union hidpp10_message *msg);
-struct hidpp10_device *hidpp10_device_new_from_wpid(struct ratbag_device *device, uint16_t wpid);
-struct hidpp10_device *hidpp10_device_new_from_idx(struct ratbag_device *device, int idx);
+struct hidpp10_device *hidpp10_device_new_from_wpid(const struct hidpp_device *base,
+						    uint16_t wpid);
+struct hidpp10_device *hidpp10_device_new_from_idx(const struct hidpp_device *base,
+						   int idx);
 
 /* -------------------------------------------------------------------------- */
 /* 0x00: Enable HID++ Notifications                                           */
@@ -508,7 +508,6 @@ hidpp10_get_firmare_information(struct hidpp10_device *dev,
 #define HIDPP10_NUM_PROFILES 3
 struct hidpp10_device  {
 	struct hidpp_device base;
-	struct ratbag_device *ratbag_device;
 	unsigned index;
 	char name[15];
 	uint16_t wpid;

--- a/src/hidpp10.h
+++ b/src/hidpp10.h
@@ -509,17 +509,6 @@ hidpp10_get_firmare_information(struct hidpp10_device *dev,
 struct hidpp10_device  {
 	struct hidpp_device base;
 	unsigned index;
-	char name[15];
 	uint16_t wpid;
-	uint8_t report_interval;
-	uint8_t device_type;
-	uint8_t fw_major;
-	uint8_t fw_minor;
-	uint8_t build;
-	uint16_t xres, yres;
-	uint16_t refresh_rate;
-	enum hidpp10_led_status led[6];
-	int8_t current_profile;
-	struct hidpp10_profile profiles[HIDPP10_NUM_PROFILES];
 };
 #endif /* HIDPP_10_H */

--- a/src/hidpp10.h
+++ b/src/hidpp10.h
@@ -36,25 +36,8 @@
 
 struct hidpp10_device;
 
-struct _hidpp10_message {
-	uint8_t report_id;
-	uint8_t device_idx;
-	uint8_t sub_id;
-	uint8_t address;
-	union {
-		uint8_t parameters[3];
-		uint8_t string[16];
-	};
-} __attribute__((packed));
-
-union hidpp10_message {
-	struct _hidpp10_message msg;
-	uint8_t data[LONG_MESSAGE_LENGTH];
-};
-
 void hidpp10_device_destroy(struct hidpp10_device *dev);
 
-int hidpp10_request_command(struct hidpp10_device *device, union hidpp10_message *msg);
 struct hidpp10_device *hidpp10_device_new_from_wpid(const struct hidpp_device *base,
 						    uint16_t wpid);
 struct hidpp10_device *hidpp10_device_new_from_idx(const struct hidpp_device *base,

--- a/src/hidpp10.h
+++ b/src/hidpp10.h
@@ -507,6 +507,7 @@ hidpp10_get_firmare_information(struct hidpp10_device *dev,
  * 0 is zeroed, 1 and 2 are garbage, all above 6 is garbage */
 #define HIDPP10_NUM_PROFILES 3
 struct hidpp10_device  {
+	struct hidpp_device base;
 	struct ratbag_device *ratbag_device;
 	unsigned index;
 	char name[15];

--- a/src/hidpp10.h
+++ b/src/hidpp10.h
@@ -57,7 +57,6 @@ union hidpp10_message {
 void hidpp10_device_destroy(struct hidpp10_device *dev);
 
 int hidpp10_request_command(struct hidpp10_device *device, union hidpp10_message *msg);
-void hidpp10_list_devices(struct ratbag_device *device);
 struct hidpp10_device *hidpp10_device_new_from_wpid(struct ratbag_device *device, uint16_t wpid);
 struct hidpp10_device *hidpp10_device_new_from_idx(struct ratbag_device *device, int idx);
 

--- a/src/hidpp10.h
+++ b/src/hidpp10.h
@@ -34,14 +34,24 @@
 
 #include "hidpp-generic.h"
 
-struct hidpp10_device;
+/* FIXME: that's what my G500s supports, but only pages 3-5 are valid.
+ * 0 is zeroed, 1 and 2 are garbage, all above 6 is garbage */
+#define HIDPP10_NUM_PROFILES 3
 
-void hidpp10_device_destroy(struct hidpp10_device *dev);
+struct hidpp10_device  {
+	struct hidpp_device base;
+	unsigned index;
+	uint16_t wpid;
+};
 
-struct hidpp10_device *hidpp10_device_new_from_wpid(const struct hidpp_device *base,
-						    uint16_t wpid);
-struct hidpp10_device *hidpp10_device_new_from_idx(const struct hidpp_device *base,
-						   int idx);
+struct hidpp10_device*
+hidpp10_device_new_from_wpid(const struct hidpp_device *base,
+			     uint16_t wpid);
+struct hidpp10_device*
+hidpp10_device_new_from_idx(const struct hidpp_device *base,
+			    int idx);
+void
+hidpp10_device_destroy(struct hidpp10_device *dev);
 
 /* -------------------------------------------------------------------------- */
 /* 0x00: Enable HID++ Notifications                                           */
@@ -485,13 +495,4 @@ hidpp10_get_firmare_information(struct hidpp10_device *dev,
 				uint8_t *minor,
 				uint8_t *build_number);
 
-
-/* FIXME: that's what my G500s supports, but only pages 3-5 are valid.
- * 0 is zeroed, 1 and 2 are garbage, all above 6 is garbage */
-#define HIDPP10_NUM_PROFILES 3
-struct hidpp10_device  {
-	struct hidpp_device base;
-	unsigned index;
-	uint16_t wpid;
-};
 #endif /* HIDPP_10_H */

--- a/src/libratbag-util.h
+++ b/src/libratbag-util.h
@@ -86,6 +86,10 @@ cleanup_free(void *p) {
 }
 
 static inline void
+cleanup_close(int *p) {
+	close(*p);
+}
+static inline void
 cleanup_udev_unref(struct udev **udev) {
 	if (*udev)
 		udev_unref(*udev);
@@ -99,6 +103,7 @@ cleanup_udev_device_unref(struct udev_device **udev_device) {
 
 #define _cleanup_(x) __attribute__((cleanup(x)))
 #define _cleanup_free_ _cleanup_(cleanup_free)
+#define _cleanup_close_ _cleanup_(cleanup_close)
 #define _cleanup_udev_unref_ _cleanup_(cleanup_udev_unref)
 #define _cleanup_udev_device_unref_ _cleanup_(cleanup_udev_device_unref)
 

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,4 +1,4 @@
-noinst_PROGRAMS =
+noinst_PROGRAMS = hidpp10-dump-page
 bin_PROGRAMS = ratbag-command
 noinst_LTLIBRARIES = libshared.la
 
@@ -16,3 +16,8 @@ ratbag_command_SOURCES = ratbag-command.c
 ratbag_command_LDADD = ../src/libratbag.la libshared.la $(LIBUDEV_LIBS) $(LIBEVDEV_LIBS)
 ratbag_command_LDFLAGS = -no-install
 ratbag_command_CFLAGS = $(LIBUDEV_CFLAGS) $(LIBEVDEV_CFLAGS)
+
+hidpp10_dump_page_SOURCES = hidpp10-dump-page.c
+hidpp10_dump_page_LDADD = ../src/libhidpp10.la
+hidpp10_dump_page_LDFLAGS = -no-install
+hidpp10_dump_page_CFLAGS = -I$(top_srcdir)/src

--- a/tools/hidpp10-dump-page.c
+++ b/tools/hidpp10-dump-page.c
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2015 Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include <config.h>
+#include <errno.h>
+#include <error.h>
+#include <fcntl.h>
+
+#include <hidpp10.h>
+#include <libratbag-util.h>
+
+static inline int
+dump_page(struct hidpp10_device *dev, size_t page, size_t offset)
+{
+	int rc = 0;
+	uint8_t bytes[16];
+
+	while (offset < 256) {
+		hidpp_log_info(&dev->base, "page 0x%02zx off 0x%02zx: ", page, offset);
+		rc = hidpp10_read_memory(dev, page, offset, bytes);
+		if (rc != 0)
+			break;
+
+		hidpp_log_buffer(&dev->base, HIDPP_LOG_PRIORITY_INFO, " ", bytes, ARRAY_LENGTH(bytes));
+		offset += 16;
+	}
+
+	return rc;
+}
+
+static inline int
+dump_all_pages(struct hidpp10_device *dev)
+{
+	uint8_t page;
+	int rc = 0;
+
+	for (page = 0; page < 31; page++) {
+		rc = dump_page(dev, page, 0);
+		if (rc != 0)
+			break;
+	}
+
+	/* We dumped at least one page successfully and get EAGAIN, so we're
+	 * on the last page. Overwrite the last line with a blank one so it
+	 * doesn't look like an error */
+	if (page > 0 && rc == EAGAIN) {
+		hidpp_log_info(&dev->base, "\r                                   \n");
+		rc = 0;
+	}
+
+	return rc;
+}
+
+void
+usage(void)
+{
+	printf("Usage: %s [page] [offset] /dev/hidraw0\n", program_invocation_short_name);
+}
+
+int
+main(int argc, char **argv)
+{
+	_cleanup_close_ int fd;
+	const char *path;
+	size_t page = 0, offset = 0;
+	struct hidpp10_device *dev = NULL;
+	struct hidpp_device base;
+	int rc;
+
+	if (argc < 2 || argc > 4) {
+		usage();
+		return 1;
+	}
+
+	path = argv[argc - 1];
+	fd = open(path, O_RDWR);
+	if (fd < 0)
+		error(1, errno, "Failed to open path %s", path);
+
+	hidpp_device_init(&base, fd);
+	dev = hidpp10_device_new_from_idx(&base, WIRED_DEVICE_IDX);
+
+	if (argc == 2)
+		rc = dump_all_pages(dev);
+	else {
+		page = atoi(argv[1]);
+		if (argc > 3)
+			offset = atoi(argv[2]);
+		rc = dump_page(dev, page, offset);
+	}
+
+	hidpp10_device_destroy(dev);
+
+	return rc;
+}


### PR DESCRIPTION
This branch disentangles libratbag from the hidpp10 code so we can use hidpp10 functions on their own. Useful for a bunch of debugging tools or, long-term, for providing things like pairing/unpairing tools, etc.