### PR TITLE
hidpp10: convert resolution according to sensor type

### DIFF
--- a/src/hidpp10.h
+++ b/src/hidpp10.h
@@ -38,10 +38,18 @@
  * 0 is zeroed, 1 and 2 are garbage, all above 6 is garbage */
 #define HIDPP10_NUM_PROFILES 3
 
+enum hidpp10_sensor {
+	HIDPP10_SENSOR_S6006,
+	HIDPP10_SENSOR_A6090,
+	HIDPP10_SENSOR_S9500,
+	HIDPP10_SENSOR_S9808,
+};
+
 struct hidpp10_device  {
 	struct hidpp_device base;
 	unsigned index;
 	uint16_t wpid;
+	enum hidpp10_sensor sensor;
 };
 
 struct hidpp10_device*


### PR DESCRIPTION
Here is a proposition for handling the different resolution formats. It was tested with G500 and G500s only.

You may want to change the way the device info is retrieved (maybe in the base hidpp_device or in another function).

For invalid resolution values, hidpp10_sensor_to_dpi silently returns 0. Because of disabled dpi modes, it would output a lot of error messages if I logged errors there.