### PR TITLE
tools: memory offset are in half bytes

### DIFF
--- a/tools/hidpp10-dump-page.c
+++ b/tools/hidpp10-dump-page.c
@@ -35,9 +35,9 @@ dump_page(struct hidpp10_device *dev, size_t page, size_t offset)
 	int rc = 0;
 	uint8_t bytes[16];
 
-	while (offset < 256) {
-		hidpp_log_info(&dev->base, "page 0x%02zx off 0x%02zx: ", page, offset);
-		rc = hidpp10_read_memory(dev, page, offset, bytes);
+	while (offset < 512) {
+		hidpp_log_info(&dev->base, "page 0x%02zx off 0x%03zx: ", page, offset);
+		rc = hidpp10_read_memory(dev, page, offset / 2, bytes);
 		if (rc != 0)
 			break;
 


### PR DESCRIPTION
As I understand the offset for byte i must be given as i/2.
Also bump the limit of the loop so we read the full 512 bytes of
the page.

With this change a dump of the memory of the G9 matches the profile layout we documented in @cvuchener's repo.