### PR TITLE
Fix dumping memory pages

### DIFF
--- a/src/hidpp10.c
+++ b/src/hidpp10.c
@@ -541,7 +541,7 @@ hidpp10_get_profile(struct hidpp10_device *dev, int8_t number, struct hidpp10_pr
 
 	for (i = 0; i < sizeof(data); i += 16) {
 		/* each sector contains 16 bytes of data */
-		res = hidpp10_read_memory(dev, number, i / 2,  &data.data[i]);
+		res = hidpp10_read_memory(dev, number, i,  &data.data[i]);
 		if (res)
 			return res;
 	}
@@ -1011,12 +1011,17 @@ hidpp10_set_usb_refresh_rate(struct hidpp10_device *dev,
 }
 
 int
-hidpp10_read_memory(struct hidpp10_device *dev, uint8_t page, uint8_t offset,
+hidpp10_read_memory(struct hidpp10_device *dev, uint8_t page, uint16_t offset,
 		    uint8_t bytes[16])
 {
 	unsigned idx = dev->index;
-	union hidpp10_message readmem = CMD_READ_MEMORY(idx, page, offset);
+	union hidpp10_message readmem = CMD_READ_MEMORY(idx, page, offset / 2);
 	int res;
+
+	if (offset % 2 != 0) {
+		hidpp_log_error(&dev->base, "Reading memory with odd offset is not supported.\n");
+		return -EINVAL;
+	}
 
 	if (page > 31)
 		return -EINVAL;

--- a/src/hidpp10.h
+++ b/src/hidpp10.h
@@ -462,7 +462,7 @@ hidpp10_set_usb_refresh_rate(struct hidpp10_device *dev,
 int
 hidpp10_read_memory(struct hidpp10_device *dev,
 		    uint8_t page,
-		    uint8_t offset,
+		    uint16_t offset,
 		    uint8_t bytes[16]);
 
 /* -------------------------------------------------------------------------- */

--- a/tools/hidpp10-dump-page.c
+++ b/tools/hidpp10-dump-page.c
@@ -35,8 +35,8 @@ dump_page(struct hidpp10_device *dev, size_t page, size_t offset)
 	int rc = 0;
 	uint8_t bytes[16];
 
-	while (offset < 256) {
-		hidpp_log_info(&dev->base, "page 0x%02zx off 0x%02zx: ", page, offset);
+	while (offset < 512) {
+		hidpp_log_info(&dev->base, "page 0x%02zx off 0x%03zx: ", page, offset);
 		rc = hidpp10_read_memory(dev, page, offset, bytes);
 		if (rc != 0)
 			break;


### PR DESCRIPTION
Update the hidpp10_read_memory API to take a single byte offset.

Also increase the size of each page dump to the full 512 size.

This PR is a continuation of PR #41 