### PR TITLE
Correct index check in ratbag-command

### DIFF
--- a/tools/ratbag-command.c
+++ b/tools/ratbag-command.c
@@ -1457,7 +1457,7 @@ ratbag_cmd_profile_active_set(const struct ratbag_cmd *cmd,
 	}
 
 	num_profiles = ratbag_device_get_num_profiles(device);
-	if (index > num_profiles) {
+	if (index >= num_profiles) {
 		error("'%d' is not a valid profile\n", index);
 		goto out;
 	}


### PR DESCRIPTION
When initializing N profiles they are indexed 0 to N-1. However,
when setting the active profile to X the validation of X is a
check for X > N. Notice that N is invalid as the maximum index
is N-1.

Change the validation check of the new active profile to X >= N.

Signed-off-by: Palle Ravn <ravnzon@gmail.com>