### PR TITLE
build: kill -no-install for installed binaries

### DIFF
--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -14,7 +14,6 @@ libshared_la_LIBADD = $(LIBUDEV_CFLAGS) $(LIBEVDEV_LIBS)
 
 ratbag_command_SOURCES = ratbag-command.c
 ratbag_command_LDADD = ../src/libratbag.la libshared.la $(LIBUDEV_LIBS) $(LIBEVDEV_LIBS)
-ratbag_command_LDFLAGS = -no-install
 ratbag_command_CFLAGS = $(LIBUDEV_CFLAGS) $(LIBEVDEV_CFLAGS)
 
 hidpp10_dump_page_SOURCES = hidpp10-dump-page.c


### PR DESCRIPTION
With -no-install present in ratbag_command_LDFLAGS, the program would
get directly copied from .libs/ratbag-command to /usr/bin, retaining
the undesired rpath tag in the ELF file.

Signed-off-by: Jan Engelhardt <jengelh@inai.de>