### PR TITLE
Remove the default profile capability

### DIFF
--- a/src/driver-etekcity.c
+++ b/src/driver-etekcity.c
@@ -303,12 +303,6 @@ etekcity_set_current_profile(struct ratbag_device *device, unsigned int index)
 }
 
 static int
-etekcity_set_default_profile(struct ratbag_device *device, unsigned int index)
-{
-	return -ENOTSUP;
-}
-
-static int
 etekcity_set_config_profile(struct ratbag_device *device, uint8_t profile, uint8_t type)
 {
 	uint8_t buf[] = {ETEKCITY_REPORT_ID_CONFIGURE_PROFILE, profile, type};
@@ -729,7 +723,6 @@ struct ratbag_driver etekcity_driver = {
 	.read_profile = etekcity_read_profile,
 	.write_profile = etekcity_write_profile,
 	.set_active_profile = etekcity_set_current_profile,
-	.set_default_profile = etekcity_set_default_profile,
 	.has_capability = etekcity_has_capability,
 	.read_button = etekcity_read_button,
 	.write_button = etekcity_write_button,

--- a/src/driver-hidpp10.c
+++ b/src/driver-hidpp10.c
@@ -348,12 +348,6 @@ hidpp10drv_set_current_profile(struct ratbag_device *device, unsigned int index)
 	return hidpp10_set_current_profile(hidpp10, index);
 }
 
-static int
-hidpp10drv_set_default_profile(struct ratbag_device *device, unsigned int index)
-{
-	return -ENOTSUP;
-}
-
 static void
 hidpp10drv_read_profile(struct ratbag_profile *profile, unsigned int index)
 {
@@ -591,7 +585,6 @@ hidpp10drv_probe(struct ratbag_device *device)
 		ratbag_device_init_profiles(device, 1, 3);
 		profile = ratbag_device_get_profile(device, 0);
 		profile->is_active = true;
-		profile->is_default = true;
 		ratbag_profile_unref(profile);
 	}
 
@@ -629,7 +622,6 @@ struct ratbag_driver hidpp10_driver = {
 	.read_profile = hidpp10drv_read_profile,
 	.write_profile = hidpp10drv_write_profile,
 	.set_active_profile = hidpp10drv_set_current_profile,
-	.set_default_profile = hidpp10drv_set_default_profile,
 	.has_capability = hidpp10drv_has_capability,
 	.read_button = hidpp10drv_read_button,
 	.write_button = hidpp10drv_write_button,

--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -392,12 +392,6 @@ hidpp20drv_set_current_profile(struct ratbag_device *device, unsigned int index)
 }
 
 static int
-hidpp20drv_set_default_profile(struct ratbag_device *device, unsigned int index)
-{
-	return -ENOTSUP;
-}
-
-static int
 hidpp20drv_read_resolution_dpi(struct ratbag_profile *profile)
 {
 	struct ratbag_device *device = profile->device;
@@ -847,7 +841,6 @@ struct ratbag_driver hidpp20_driver = {
 	.read_profile = hidpp20drv_read_profile,
 	.write_profile = hidpp20drv_write_profile,
 	.set_active_profile = hidpp20drv_set_current_profile,
-	.set_default_profile = hidpp20drv_set_default_profile,
 	.has_capability = hidpp20drv_has_capability,
 	.read_button = hidpp20drv_read_button,
 	.write_button = hidpp20drv_write_button,

--- a/src/driver-test.c
+++ b/src/driver-test.c
@@ -71,7 +71,6 @@ test_read_profile(struct ratbag_profile *profile, unsigned int index)
 	}
 
 	profile->is_active = p->active;
-	profile->is_default = p->dflt;
 }
 
 static int

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -155,14 +155,6 @@ struct ratbag_driver {
 	int (*set_active_profile)(struct ratbag_device *device, unsigned int index);
 
 	/**
-	 * Called to mark a previously writen profile as the default.
-	 *
-	 * There should be no need to write the profile here, a
-	 * .write_profile() call is issued before calling this.
-	 */
-	int (*set_default_profile)(struct ratbag_device *device, unsigned int index);
-
-	/**
 	 * This should return a boolean whether or not the device
 	 * supports the given capability.
 	 *
@@ -237,7 +229,6 @@ struct ratbag_profile {
 	} resolution;
 
 	bool is_active;		/**< profile is the currently active one */
-	bool is_default;	/**< profile is the default one */
 };
 
 #define BUTTON_ACTION_NONE \

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -209,7 +209,6 @@ ratbag_sanity_check_device(struct ratbag_device *device)
 	_cleanup_profile_ struct ratbag_profile *profile = NULL;
 	_cleanup_resolution_ struct ratbag_resolution *res = NULL;
 	bool has_active = false;
-	bool has_default = false;
 	unsigned int nres, nprofiles;
 	bool rc = false;
 	unsigned int i;
@@ -230,17 +229,6 @@ ratbag_sanity_check_device(struct ratbag_device *device)
 		profile = ratbag_device_get_profile(device, i);
 		if (!profile)
 			goto out;
-
-		/* Allow max 1 default profile */
-		if (profile->is_default) {
-			if (has_default) {
-				log_bug_libratbag(ratbag,
-						  "%s: multiple default profiles\n",
-						  device->name);
-				goto out;
-			}
-			has_default = true;
-		}
 
 		/* Allow max 1 active profile */
 		if (profile->is_active) {
@@ -670,14 +658,6 @@ ratbag_profile_is_active(struct ratbag_profile *profile)
 	return profile->is_active;
 }
 
-LIBRATBAG_EXPORT int
-ratbag_profile_is_default(struct ratbag_profile *profile)
-{
-	/* FIXME: unclear if any device actually supports this function */
-
-	return profile->is_default;
-}
-
 LIBRATBAG_EXPORT unsigned int
 ratbag_device_get_num_profiles(struct ratbag_device *device)
 {
@@ -722,35 +702,6 @@ ratbag_profile_set_active(struct ratbag_profile *profile)
 		p->is_active = false;
 	}
 	profile->is_active = true;
-	return rc;
-}
-
-LIBRATBAG_EXPORT int
-ratbag_profile_set_default(struct ratbag_profile *profile)
-{
-	struct ratbag_device *device = profile->device;
-	struct ratbag_profile *p;
-	int rc;
-
-	/* FIXME: unclear if any device actually supports this function */
-
-	assert(device->driver->write_profile);
-	rc = device->driver->write_profile(profile);
-	if (rc)
-		return rc;
-
-	if (ratbag_device_has_capability(device, RATBAG_DEVICE_CAP_SWITCHABLE_PROFILE)) {
-		assert(device->driver->set_default_profile);
-		rc = device->driver->set_default_profile(device, profile->index);
-	}
-
-	if (rc)
-		return rc;
-
-	list_for_each(p, &device->profiles, link) {
-		p->is_default = false;
-	}
-	profile->is_default = true;
 	return rc;
 }
 

--- a/src/libratbag.h
+++ b/src/libratbag.h
@@ -604,18 +604,6 @@ ratbag_profile_is_default(struct ratbag_profile *profile);
 /**
  * @ingroup profile
  *
- * Make the given profile the default profile
- *
- * @param profile The profile to make the default profile.
- *
- * @return 0 on success or nonzero otherwise.
- */
-int
-ratbag_profile_set_default(struct ratbag_profile *profile);
-
-/**
- * @ingroup profile
- *
  * Get the number of @ref ratbag_resolution available in this profile. A
  * resolution mode is a tuple of (resolution, report rate), each mode can be
  * fetched with ratbag_profile_get_resolution_by_idx().

--- a/src/libratbag.sym
+++ b/src/libratbag.sym
@@ -45,11 +45,9 @@ global:
 	ratbag_profile_get_resolution;
 	ratbag_profile_get_user_data;
 	ratbag_profile_is_active;
-	ratbag_profile_is_default;
 	ratbag_profile_ref;
 	ratbag_profile_set_user_data;
 	ratbag_profile_set_active;
-	ratbag_profile_set_default;
 	ratbag_profile_unref;
 	ratbag_resolution_get_dpi;
 	ratbag_resolution_get_dpi_x;

--- a/test/test-device.c
+++ b/test/test-device.c
@@ -197,7 +197,7 @@ START_TEST(device_profiles)
 	struct ratbag_profile *p;
 	int nprofiles;
 	int i;
-	bool is_active, is_default;
+	bool is_active;
 	int device_freed_count = 0;
 
 	struct ratbag_test_device td = sane_device;
@@ -216,8 +216,6 @@ START_TEST(device_profiles)
 
 		is_active = ratbag_profile_is_active(p);
 		ck_assert_int_eq(is_active, (i == 0));
-		is_default = ratbag_profile_is_default(p);
-		ck_assert_int_eq(is_default, (i == 1));
 		ratbag_profile_unref(p);
 	}
 	ratbag_device_unref(d);

--- a/tools/ratbag-command.c
+++ b/tools/ratbag-command.c
@@ -351,9 +351,8 @@ ratbag_cmd_info(const struct ratbag_cmd *cmd,
 		if (!profile)
 			continue;
 
-		printf("  Profile %d%s%s\n", i,
-		       ratbag_profile_is_active(profile) ? " (active)" : "",
-		       ratbag_profile_is_default(profile) ? " (default)" : "");
+		printf("  Profile %d%s\n", i,
+		       ratbag_profile_is_active(profile) ? " (active)" : "");
 		printf("    Resolutions:\n");
 		for (j = 0; j < ratbag_profile_get_num_resolutions(profile); j++) {
 			struct ratbag_resolution *res;


### PR DESCRIPTION
We do not have any driver using it, and we are not sure this will even
be required. Before releasing a version with this, remove it. We
can always re-add this later if the need appears.

API change, so submitting it as a PR.