### PR TITLE
Remove has_capability driver stub

### DIFF
--- a/src/driver-etekcity.c
+++ b/src/driver-etekcity.c
@@ -251,24 +251,6 @@ etekcity_button_action_to_raw(const struct ratbag_button_action *action)
 }
 
 static int
-etekcity_has_capability(const struct ratbag_device *device,
-			enum ratbag_device_capability cap)
-{
-	switch (cap) {
-	case RATBAG_DEVICE_CAP_NONE:
-		return 0;
-	case RATBAG_DEVICE_CAP_SWITCHABLE_RESOLUTION:
-	case RATBAG_DEVICE_CAP_SWITCHABLE_PROFILE:
-	case RATBAG_DEVICE_CAP_BUTTON_KEY:
-	case RATBAG_DEVICE_CAP_BUTTON_MACROS:
-		return 1;
-	case RATBAG_DEVICE_CAP_DEFAULT_PROFILE:
-		return 0;
-	}
-	return 0;
-}
-
-static int
 etekcity_current_profile(struct ratbag_device *device)
 {
 	uint8_t buf[3];
@@ -685,6 +667,8 @@ etekcity_probe(struct ratbag_device *device)
 				    ETEKCITY_NUM_DPI,
 				    ETEKCITY_BUTTON_MAX + 1);
 
+	ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_BUTTON_MACROS);
+
 	active_idx = etekcity_current_profile(device);
 	if (active_idx < 0) {
 		log_error(device->ratbag,
@@ -731,7 +715,6 @@ struct ratbag_driver etekcity_driver = {
 	.write_profile = etekcity_write_profile,
 	.set_active_profile = etekcity_set_current_profile,
 	.set_default_profile = etekcity_set_default_profile,
-	.has_capability = etekcity_has_capability,
 	.read_button = etekcity_read_button,
 	.write_button = etekcity_write_button,
 	.write_resolution_dpi = etekcity_write_resolution_dpi,

--- a/src/driver-etekcity.c
+++ b/src/driver-etekcity.c
@@ -387,9 +387,7 @@ etekcity_read_profile(struct ratbag_profile *profile, unsigned int index)
 		report_rate = 0;
 	}
 
-	profile->resolution.num_modes = ETEKCITY_NUM_DPI;
-
-	for (i = 0; i < ETEKCITY_NUM_DPI; i++) {
+	for (i = 0; i < profile->resolution.num_modes; i++) {
 		dpi_x = setting_report->xres[i] * 50;
 		dpi_y = setting_report->yres[i] * 50;
 		hz = report_rate;
@@ -682,7 +680,10 @@ etekcity_probe(struct ratbag_device *device)
 	log_debug(device->ratbag, "device is at %d ms of latency\n", drv_data->speed_setting[2]);
 
 	/* profiles are 0-indexed */
-	ratbag_device_init_profiles(device, ETEKCITY_PROFILE_MAX + 1, ETEKCITY_BUTTON_MAX + 1);
+	ratbag_device_init_profiles(device,
+				    ETEKCITY_PROFILE_MAX + 1,
+				    ETEKCITY_NUM_DPI,
+				    ETEKCITY_BUTTON_MAX + 1);
 
 	active_idx = etekcity_current_profile(device);
 	if (active_idx < 0) {

--- a/src/driver-hidpp10.c
+++ b/src/driver-hidpp10.c
@@ -381,8 +381,7 @@ hidpp10drv_read_profile(struct ratbag_profile *profile, unsigned int index)
 	if (rc)
 		xres = 0xffff;
 
-	profile->resolution.num_modes = p.num_dpi_modes;
-	for (i = 0; i < p.num_dpi_modes; i++) {
+	for (i = 0; i < profile->resolution.num_modes; i++) {
 		res = ratbag_resolution_init(profile, i,
 					     p.dpi_modes[i].xres,
 					     p.dpi_modes[i].yres,
@@ -467,7 +466,10 @@ hidpp10drv_fill_from_profile(struct ratbag_device *device, struct hidpp10_device
 	if (rc)
 		return rc;
 
-	ratbag_device_init_profiles(device, count, profile.num_buttons);
+	ratbag_device_init_profiles(device,
+				    count,
+				    profile.num_dpi_modes,
+				    profile.num_buttons);
 
 	return 0;
 }
@@ -588,7 +590,7 @@ hidpp10drv_probe(struct ratbag_device *device)
 		/* Fall back to something that every mouse has */
 		struct ratbag_profile *profile;
 
-		ratbag_device_init_profiles(device, 1, 3);
+		ratbag_device_init_profiles(device, 1, 1, 3);
 		profile = ratbag_device_get_profile(device, 0);
 		profile->is_active = true;
 		profile->is_default = true;

--- a/src/driver-hidpp10.c
+++ b/src/driver-hidpp10.c
@@ -318,28 +318,6 @@ hidpp10drv_write_button(struct ratbag_button *button,
 }
 
 static int
-hidpp10drv_has_capability(const struct ratbag_device *device,
-			  enum ratbag_device_capability cap)
-{
-	/* we force a non const device to shut up a warning, but we won't change anything */
-	struct hidpp10drv_data *drv_data = ratbag_get_drv_data((struct ratbag_device *)device);
-	struct hidpp10_device *hidpp10 = drv_data->dev;
-
-	switch (cap) {
-	case RATBAG_DEVICE_CAP_NONE:
-		abort();
-		break;
-	case RATBAG_DEVICE_CAP_SWITCHABLE_PROFILE:
-	case RATBAG_DEVICE_CAP_SWITCHABLE_RESOLUTION:
-	case RATBAG_DEVICE_CAP_BUTTON_KEY:
-	case RATBAG_DEVICE_CAP_BUTTON_MACROS:
-	case RATBAG_DEVICE_CAP_DEFAULT_PROFILE:
-		return (hidpp10->profile_type != HIDPP10_PROFILE_UNKNOWN);
-	}
-	return 0;
-}
-
-static int
 hidpp10drv_set_current_profile(struct ratbag_device *device, unsigned int index)
 {
 	struct hidpp10drv_data *drv_data = ratbag_get_drv_data(device);
@@ -470,6 +448,9 @@ hidpp10drv_fill_from_profile(struct ratbag_device *device, struct hidpp10_device
 				    count,
 				    profile.num_dpi_modes,
 				    profile.num_buttons);
+
+	if (dev->profile_type != HIDPP10_PROFILE_UNKNOWN)
+		ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_BUTTON_MACROS);
 
 	return 0;
 }
@@ -632,7 +613,6 @@ struct ratbag_driver hidpp10_driver = {
 	.write_profile = hidpp10drv_write_profile,
 	.set_active_profile = hidpp10drv_set_current_profile,
 	.set_default_profile = hidpp10drv_set_default_profile,
-	.has_capability = hidpp10drv_has_capability,
 	.read_button = hidpp10drv_read_button,
 	.write_button = hidpp10drv_write_button,
 	.write_resolution_dpi = hidpp10drv_write_resolution_dpi,

--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -428,9 +428,6 @@ hidpp20drv_read_resolution_dpi_2201(struct ratbag_device *device)
 		  drv_data->sensors[0].dpi_max);
 
 	drv_data->num_sensors = rc;
-	if (drv_data->num_sensors > MAX_RESOLUTIONS)
-		drv_data->num_sensors = MAX_RESOLUTIONS;
-
 	drv_data->num_resolutions = drv_data->num_sensors;
 
 	return 0;
@@ -465,7 +462,6 @@ hidpp20drv_read_resolution_dpi(struct ratbag_profile *profile)
 		rc = hidpp20drv_read_resolution_dpi_2201(device);
 		if (rc < 0)
 			return rc;
-		profile->resolution.num_modes = drv_data->num_resolutions;
 		for (i = 0; i < profile->resolution.num_modes; i++) {
 			int dpi = drv_data->sensors[i].dpi;
 			/* FIXME: retrieve the refresh rate */
@@ -627,7 +623,6 @@ hidpp20drv_read_profile_8100(struct ratbag_profile *profile, unsigned int index)
 
 	p = &drv_data->profiles->profiles[index];
 
-	profile->resolution.num_modes = drv_data->num_resolutions;
 	for (i = 0; i < profile->resolution.num_modes; i++) {
 		res = ratbag_resolution_init(profile, i,
 					     p->dpi[i],
@@ -854,6 +849,7 @@ hidpp20drv_probe(struct ratbag_device *device)
 
 	ratbag_device_init_profiles(device,
 				    drv_data->num_profiles,
+				    drv_data->num_resolutions,
 				    drv_data->num_buttons);
 
 	return rc;

--- a/src/driver-roccat.c
+++ b/src/driver-roccat.c
@@ -308,23 +308,6 @@ roccat_wait_ready(struct ratbag_device *device)
 }
 
 static int
-roccat_has_capability(const struct ratbag_device *device,
-		      enum ratbag_device_capability cap)
-{
-	switch (cap) {
-	case RATBAG_DEVICE_CAP_NONE:
-	case RATBAG_DEVICE_CAP_DEFAULT_PROFILE:
-		return 0;
-	case RATBAG_DEVICE_CAP_SWITCHABLE_RESOLUTION:
-	case RATBAG_DEVICE_CAP_SWITCHABLE_PROFILE:
-	case RATBAG_DEVICE_CAP_BUTTON_KEY:
-	case RATBAG_DEVICE_CAP_BUTTON_MACROS:
-		return 1;
-	}
-	return 0;
-}
-
-static int
 roccat_current_profile(struct ratbag_device *device)
 {
 	uint8_t buf[3];
@@ -816,6 +799,8 @@ roccat_probe(struct ratbag_device *device)
 				    ROCCAT_NUM_DPI,
 				    ROCCAT_BUTTON_MAX + 1);
 
+	ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_BUTTON_MACROS);
+
 	active_idx = roccat_current_profile(device);
 	if (active_idx < 0) {
 		log_error(device->ratbag,
@@ -861,7 +846,6 @@ struct ratbag_driver roccat_driver = {
 	.read_profile = roccat_read_profile,
 	.write_profile = roccat_write_profile,
 	.set_active_profile = roccat_set_current_profile,
-	.has_capability = roccat_has_capability,
 	.read_button = roccat_read_button,
 	.write_button = roccat_write_button,
 	.write_resolution_dpi = roccat_write_resolution_dpi,

--- a/src/driver-roccat.c
+++ b/src/driver-roccat.c
@@ -446,9 +446,7 @@ roccat_read_profile(struct ratbag_profile *profile, unsigned int index)
 		report_rate = 0;
 	}
 
-	profile->resolution.num_modes = ROCCAT_NUM_DPI;
-
-	for (i = 0; i < ROCCAT_NUM_DPI; i++) {
+	for (i = 0; i < profile->resolution.num_modes; i++) {
 		dpi_x = setting_report->xres[i] * 50;
 		dpi_y = setting_report->yres[i] * 50;
 		hz = report_rate;
@@ -813,7 +811,10 @@ roccat_probe(struct ratbag_device *device)
 	ratbag_set_drv_data(device, drv_data);
 
 	/* profiles are 0-indexed */
-	ratbag_device_init_profiles(device, ROCCAT_PROFILE_MAX + 1, ROCCAT_BUTTON_MAX + 1);
+	ratbag_device_init_profiles(device,
+				    ROCCAT_PROFILE_MAX + 1,
+				    ROCCAT_NUM_DPI,
+				    ROCCAT_BUTTON_MAX + 1);
 
 	active_idx = roccat_current_profile(device);
 	if (active_idx < 0) {

--- a/src/driver-test.c
+++ b/src/driver-test.c
@@ -57,8 +57,7 @@ test_read_profile(struct ratbag_profile *profile, unsigned int index)
 	assert(index < d->num_profiles);
 
 	p = &d->profiles[index];
-	profile->resolution.num_modes = p->num_resolutions;
-	for (i = 0; i < p->num_resolutions; i++) {
+	for (i = 0; i < d->num_resolutions; i++) {
 		struct ratbag_resolution *res;
 
 		r = &p->resolutions[i];
@@ -96,6 +95,7 @@ test_probe(struct ratbag_device *device, void *data)
 	ratbag_set_drv_data(device, test_device);
 	ratbag_device_init_profiles(device,
 				    test_device->num_profiles,
+				    test_device->num_resolutions,
 				    test_device->num_buttons);
 	return 0;
 }

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -208,7 +208,6 @@ struct ratbag_driver {
 	struct list link;
 };
 
-#define MAX_RESOLUTIONS 10
 struct ratbag_resolution{
 	struct ratbag_profile *profile;
 	int refcount;
@@ -232,7 +231,7 @@ struct ratbag_profile {
 	void *drv_data;
 	void *user_data;
 	struct {
-		struct ratbag_resolution modes[MAX_RESOLUTIONS];
+		struct ratbag_resolution *modes;
 		unsigned int num_modes;
 	} resolution;
 
@@ -332,6 +331,7 @@ ratbag_get_drv_data(struct ratbag_device *device)
 int
 ratbag_device_init_profiles(struct ratbag_device *device,
 			    unsigned int num_profiles,
+			    unsigned int num_resolutions,
 			    unsigned int num_buttons);
 
 static inline void

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -89,6 +89,7 @@ struct ratbag_device {
 	struct input_id ids;
 	struct ratbag_driver *driver;
 	struct ratbag *ratbag;
+	unsigned long capabilities;
 
 	unsigned num_profiles;
 	struct list profiles;
@@ -161,17 +162,6 @@ struct ratbag_driver {
 	 * .write_profile() call is issued before calling this.
 	 */
 	int (*set_default_profile)(struct ratbag_device *device, unsigned int index);
-
-	/**
-	 * This should return a boolean whether or not the device
-	 * supports the given capability.
-	 *
-	 * In most cases, the .probe() should store a list of capabilities
-	 * for each device, but most of the time, it can be statically
-	 * stored.
-	 */
-	int (*has_capability)(const struct ratbag_device *device,
-			      enum ratbag_device_capability cap);
 
 	/**
 	 * For the given button, fill in the struct ratbag_button
@@ -333,6 +323,10 @@ ratbag_device_init_profiles(struct ratbag_device *device,
 			    unsigned int num_profiles,
 			    unsigned int num_resolutions,
 			    unsigned int num_buttons);
+
+void
+ratbag_device_set_capability(struct ratbag_device *device,
+			     enum ratbag_device_capability cap);
 
 static inline void
 ratbag_profile_set_drv_data(struct ratbag_profile *profile, void *drv_data)

--- a/src/libratbag-test.h
+++ b/src/libratbag-test.h
@@ -43,7 +43,6 @@ struct ratbag_test_resolution {
 };
 
 struct ratbag_test_profile {
-	unsigned int num_resolutions;
 	struct ratbag_test_button buttons[RATBAG_TEST_MAX_BUTTONS];
 	struct ratbag_test_resolution resolutions[RATBAG_TEST_MAX_RESOLUTIONS];
 	bool active;
@@ -52,6 +51,7 @@ struct ratbag_test_profile {
 
 struct ratbag_test_device {
 	unsigned int num_profiles;
+	unsigned int num_resolutions;
 	unsigned int num_buttons;
 	struct ratbag_test_profile profiles[RATBAG_TEST_MAX_PROFILES];
 	void (*destroyed)(struct ratbag_device *device, void *data);

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -606,6 +606,17 @@ ratbag_device_init_profiles(struct ratbag_device *device,
 
 	device->num_profiles = num_profiles;
 
+	if (num_profiles > 1) {
+		ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_SWITCHABLE_PROFILE);
+
+		/* having more than one profile means we can remap the buttons
+		 * at least */
+		ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_BUTTON_KEY);
+	}
+
+	if (num_resolutions > 1)
+		ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_SWITCHABLE_RESOLUTION);
+
 	return 0;
 }
 
@@ -694,12 +705,21 @@ ratbag_device_get_num_buttons(struct ratbag_device *device)
 	return device->num_buttons;
 }
 
+void
+ratbag_device_set_capability(struct ratbag_device *device,
+			     enum ratbag_device_capability cap)
+{
+	device->capabilities |= (1UL << cap);
+}
+
 LIBRATBAG_EXPORT int
 ratbag_device_has_capability(const struct ratbag_device *device,
 			     enum ratbag_device_capability cap)
 {
-	assert(device->driver->has_capability);
-	return device->driver->has_capability(device, cap);
+	if (cap == RATBAG_DEVICE_CAP_NONE)
+		abort();
+
+	return !!(device->capabilities & (1UL << cap));
 }
 
 LIBRATBAG_EXPORT int

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -564,6 +564,7 @@ ratbag_profile_init_buttons(struct ratbag_profile *profile, unsigned int count)
 static struct ratbag_profile *
 ratbag_create_profile(struct ratbag_device *device,
 		      unsigned int index,
+		      unsigned int num_resolutions,
 		      unsigned int num_buttons)
 {
 	struct ratbag_profile *profile;
@@ -573,13 +574,15 @@ ratbag_create_profile(struct ratbag_device *device,
 	profile->refcount = 0;
 	profile->device = device;
 	profile->index = index;
+	profile->resolution.modes = zalloc(num_resolutions *
+					   sizeof(*profile->resolution.modes));
+	profile->resolution.num_modes = num_resolutions;
 
 	list_insert(&device->profiles, &profile->link);
 	list_init(&profile->buttons);
 
-	for (i = 0; i < MAX_RESOLUTIONS; i++)
+	for (i = 0; i < num_resolutions; i++)
 		ratbag_resolution_init(profile, i, 0, 0, 0);
-	profile->resolution.num_modes = 1;
 
 	assert(device->driver->read_profile);
 	device->driver->read_profile(profile, index);
@@ -592,12 +595,13 @@ ratbag_create_profile(struct ratbag_device *device,
 int
 ratbag_device_init_profiles(struct ratbag_device *device,
 			    unsigned int num_profiles,
+			    unsigned int num_resolutions,
 			    unsigned int num_buttons)
 {
 	unsigned int i;
 
 	for (i = 0; i < num_profiles; i++) {
-		ratbag_create_profile(device, i, num_buttons);
+		ratbag_create_profile(device, i, num_resolutions, num_buttons);
 	}
 
 	device->num_profiles = num_profiles;
@@ -626,7 +630,7 @@ ratbag_profile_destroy(struct ratbag_profile *profile)
 	list_for_each_safe(button, next, &profile->buttons, link)
 		ratbag_button_destroy(button);
 
-	/* Resolution is a fixed list of structs, no freeing required */
+	free(profile->resolution.modes);
 
 	list_remove(&profile->link);
 	free(profile);

--- a/test/test-device.c
+++ b/test/test-device.c
@@ -51,10 +51,10 @@ device_destroyed(struct ratbag_device *device, void *data)
  */
 const struct ratbag_test_device sane_device = {
 	.num_profiles = 3,
+	.num_resolutions = 3,
 	.num_buttons = 1,
 	.profiles = {
 		{
-		.num_resolutions = 3,
 		.resolutions = {
 			{ .xres = 100, .yres = 200, .hz = 1000 },
 			{ .xres = 200, .yres = 300, .hz = 1000 },
@@ -64,7 +64,6 @@ const struct ratbag_test_device sane_device = {
 		.dflt = false,
 		},
 		{
-		.num_resolutions = 3,
 		.resolutions = {
 			{ .xres = 1100, .yres = 1200, .hz = 2000 },
 			{ .xres = 1200, .yres = 1300, .hz = 2000 },
@@ -74,7 +73,6 @@ const struct ratbag_test_device sane_device = {
 		.dflt = true,
 		},
 		{
-		.num_resolutions = 3,
 		.resolutions = {
 			{ .xres = 2100, .yres = 2200, .hz = 3000 },
 			{ .xres = 2200, .yres = 2300, .hz = 3000 },
@@ -330,10 +328,10 @@ START_TEST(device_resolutions)
 
 	struct ratbag_test_device td = {
 		.num_profiles = 3,
+		.num_resolutions = 3,
 		.num_buttons = 1,
 		.profiles = {
 			{
-			.num_resolutions = 3,
 			.resolutions = {
 				{ .xres = 100, .yres = 200, .hz = 1000 },
 				{ .xres = 200, .yres = 300, .hz = 1000, .active = true },
@@ -342,7 +340,6 @@ START_TEST(device_resolutions)
 			.active = true,
 			},
 			{
-			.num_resolutions = 3,
 			.resolutions = {
 				{ .xres = 1100, .yres = 1200, .hz = 2000 },
 				{ .xres = 1200, .yres = 1300, .hz = 2000, .active = true },
@@ -350,7 +347,6 @@ START_TEST(device_resolutions)
 			},
 			},
 			{
-			.num_resolutions = 3,
 			.resolutions = {
 				{ .xres = 2100, .yres = 2200, .hz = 3000 },
 				{ .xres = 2200, .yres = 2300, .hz = 3000, .active = true },
@@ -429,9 +425,9 @@ START_TEST(device_resolutions_num_0)
 	struct ratbag_test_device td = {
 		.num_profiles = 1,
 		.num_buttons = 1,
+		.num_resolutions = 0, /* failure trigger */
 		.profiles = {
 			{
-			.num_resolutions = 0, /* failure trigger */
 			.active = true,
 			},
 		},


### PR DESCRIPTION
This driver stub feels wrong. We can infer most of the capabilities by looking into the device. If a device has more than one profile, it is obvious is supports switchable profiles.

Plus this allows to have a common capability check between the drivers.

Submitting as a PR for comments before the merge.