### PR TITLE
hidpp10: Add button mappings for G9

### DIFF
--- a/src/driver-hidpp10.c
+++ b/src/driver-hidpp10.c
@@ -248,6 +248,27 @@ hidpp10drv_read_button(struct ratbag_button *button)
 		}
 		hidpp10drv_map_button(device, hidpp10, button);
 		break;
+	case HIDPP10_PROFILE_G9:
+		switch (button->index) {
+		case 0: type = RATBAG_BUTTON_TYPE_LEFT; break;
+		case 1: type = RATBAG_BUTTON_TYPE_RIGHT; break;
+		case 2: type = RATBAG_BUTTON_TYPE_MIDDLE; break;
+		case 3: type = RATBAG_BUTTON_TYPE_THUMB; break;
+		case 4: type = RATBAG_BUTTON_TYPE_THUMB2; break;
+		case 5: type = RATBAG_BUTTON_TYPE_UNKNOWN; break;
+		case 6: type = RATBAG_BUTTON_TYPE_WHEEL_LEFT; break;
+		case 7: type = RATBAG_BUTTON_TYPE_WHEEL_RIGHT; break;
+		case 8: type = RATBAG_BUTTON_TYPE_RESOLUTION_UP; break;
+		case 9: type = RATBAG_BUTTON_TYPE_RESOLUTION_DOWN; break;
+		case 10:
+		case 11:
+		case 12: /* these don't actually exist on the device */
+			type = RATBAG_BUTTON_TYPE_UNKNOWN; break;
+		default:
+			break;
+		}
+		hidpp10drv_map_button(device, hidpp10, button);
+		break;
 	default:
 		switch (button->index) {
 		case 0: type = RATBAG_BUTTON_TYPE_LEFT; break;


### PR DESCRIPTION
There are 10 buttons defined in the profile but only 9 physical
buttons. LGS also only allows to configure 9 of them. Button 5
is the "dead" button in the list.