### PR TITLE
Add a QUERY_CONFIGURATION capability

### DIFF
--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -172,6 +172,13 @@ ratbag_device_new(struct ratbag *ratbag, struct udev_device *udev_device,
 
 	list_insert(&ratbag->devices, &device->link);
 
+	/* We assume that most devices have this capability, so let's set it
+	 * by default. The few devices that miss this capability should
+	 * unset it instead.
+	 */
+	ratbag_device_set_capability(device,
+				     RATBAG_DEVICE_CAP_QUERY_CONFIGURATION);
+
 	return device;
 }
 

--- a/src/libratbag.h
+++ b/src/libratbag.h
@@ -443,6 +443,23 @@ enum ratbag_device_capability {
 	 * last-used profile or a specific profile (usually the first).
 	 */
 	RATBAG_DEVICE_CAP_DEFAULT_PROFILE,
+
+	/**
+	 * The device has the capability to query the current hardware
+	 * configuration. If this capability is missing, libratbag cannot
+	 * query the device for its current configuration and the
+	 * configured resolutions and button mappings are unknown.
+	 * libratbag will still provide information about the structure of
+	 * the device such as the number of buttons and resolutions.
+	 * Clients that encounter a device without this resolution are
+	 * encouraged to upload a configuration stored on-disk to the
+	 * device to reset the device to a known state.
+	 *
+	 * Any changes uploaded to the device will be cached in libratbag,
+	 * once a client has sent a full configuration to the device
+	 * libratbag can be used to query the device as normal.
+	 */
+	RATBAG_DEVICE_CAP_QUERY_CONFIGURATION,
 };
 
 /**


### PR DESCRIPTION
Designates a device that can be queried for the current configuration. Some
devices lack this ability so we rely on the caller to upload a known
configuration to the device before we can really proceed.

Set by default, devices without that capability should be the exception, not
the norm.

This patch just adds the capability, actual handling for this needs to be
added when we add the first device without this capability.

Signed-off-by: Peter Hutterer <peter.hutterer@who-t.net>