### PR TITLE
G900

### DIFF
--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -592,13 +592,17 @@ hidpp20drv_read_profile_8100(struct ratbag_profile *profile, unsigned int index)
 	struct hidpp20drv_data *drv_data = ratbag_get_drv_data(device);
 	struct ratbag_resolution *res;
 	struct hidpp20_profile *p;
-	unsigned i, dpi;
+	unsigned i, dpi = 0;
 
 	hidpp20drv_read_onboard_profile(device, profile->index);
 
 	profile->is_active = false;
 	if ((int)index == hidpp20drv_current_profile(device))
 		profile->is_active = true;
+
+	/* retrieve the resolution through 220X as the profile doesn't has it */
+	if (profile->is_active)
+		hidpp20drv_read_resolution_dpi(profile);
 
 	dpi = ratbag_resolution_get_dpi(profile->resolution.modes);
 

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -1571,7 +1571,7 @@ hidpp20_onboard_profiles_find_and_read_profile(struct hidpp20_device *device,
 							  index + 1,
 							  i * 0x10,
 							  data + i * 0x10);
-		if (rc < 0)
+		if (rc != 0)
 			return rc;
 	}
 
@@ -1761,7 +1761,7 @@ int hidpp20_onboard_profiles_read(struct hidpp20_device *device,
 		return -EINVAL;
 
 	rc = hidpp20_onboard_profiles_find_and_read_profile(device, index, data);
-	if (rc < 0)
+	if (rc != 0)
 		return rc;
 
 	profile->report_rate = 1000 / max(1, pdata.profile.report_rate);

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -929,6 +929,7 @@ int hidpp20_adjustable_dpi_set_sensor_dpi(struct hidpp20_device *device,
 #define HIDPP20_ONBOARD_PROFILES_MEMORY_TYPE_G402	0x01
 #define HIDPP20_ONBOARD_PROFILES_PROFILE_TYPE_G402	0x01
 #define HIDPP20_ONBOARD_PROFILES_PROFILE_TYPE_G303	0x02
+#define HIDPP20_ONBOARD_PROFILES_PROFILE_TYPE_G900	0x03
 #define HIDPP20_ONBOARD_PROFILES_MACRO_TYPE_G402	0x01
 
 struct hidpp20_onboard_profiles_info {
@@ -1242,7 +1243,8 @@ hidpp20_onboard_profiles_initialize(struct hidpp20_device *device,
 	}
 
 	if ((info->profile_format_id != HIDPP20_ONBOARD_PROFILES_PROFILE_TYPE_G402) &&
-	    (info->profile_format_id != HIDPP20_ONBOARD_PROFILES_PROFILE_TYPE_G303)) {
+	    (info->profile_format_id != HIDPP20_ONBOARD_PROFILES_PROFILE_TYPE_G303) &&
+	    (info->profile_format_id != HIDPP20_ONBOARD_PROFILES_PROFILE_TYPE_G900)) {
 		hidpp_log_error(&device->base,
 				"Profile layout not supported: 0x%02x.\n",
 				info->profile_format_id);
@@ -1300,8 +1302,6 @@ hidpp20_onboard_profiles_initialize(struct hidpp20_device *device,
 		profiles->wireless = 1;
 		break;
 	}
-
-	
 
 	*profiles_list = profiles;
 

--- a/src/hidpp20.h
+++ b/src/hidpp20.h
@@ -362,6 +362,7 @@ struct hidpp20_profile {
 
 struct hidpp20_profiles {
 	uint8_t num_profiles;
+	uint8_t num_rom_profiles;
 	uint8_t num_buttons;
 	uint8_t num_modes;
 	uint8_t has_g_shift;


### PR DESCRIPTION
Few fixes for HID++ 2.0 and adding support of the G900.

Most of the fixes are for the "out-of-the-box" G900 before it has been ever configured (illegal ROM access, illegal macro readings, etc...)