### PR TITLE
G602 fixes

### DIFF
--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -668,13 +668,13 @@ hidpp20drv_init_feature(struct ratbag_device *device, uint16_t feature)
 	}
 	case HIDPP_PAGE_ADJUSTABLE_DPI: {
 		log_debug(ratbag, "device has adjustable dpi\n");
-		ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_SWITCHABLE_RESOLUTION);
-		drv_data->capabilities |= HIDPP_CAP_SWITCHABLE_RESOLUTION_2201;
 		/* we read the profile once to get the correct number of
 		 * supported resolutions. */
 		rc = hidpp20drv_read_resolution_dpi_2201(device);
 		if (rc < 0)
-			return rc;
+			return 0; /* this is not a hard failure */
+		ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_SWITCHABLE_RESOLUTION);
+		drv_data->capabilities |= HIDPP_CAP_SWITCHABLE_RESOLUTION_2201;
 		break;
 	}
 	case HIDPP_PAGE_SPECIAL_KEYS_BUTTONS: {

--- a/tools/hidpp20-dump-page.c
+++ b/tools/hidpp20-dump-page.c
@@ -111,6 +111,8 @@ main(int argc, char **argv)
 
 	hidpp_device_init(&base, fd);
 	dev = hidpp20_device_new(&base, 0xff);
+	if (!dev)
+		error(1, 0, "Failed to open %s as a HID++ 2.0 device", path);
 
 	if (argc == 2)
 		rc = dump_everything(dev);


### PR DESCRIPTION
The G602 fails at retrieving feature 0x2201. This is not an issue as the info will be in the profile itself (hopefully).

Also fixes an embarrassing segfault with hidpp20-dump-page when called against a non hid++ 2.0 device.