### PR TITLE
hidpp10: fix fetching of serial number

### DIFF
--- a/src/hidpp-generic.h
+++ b/src/hidpp-generic.h
@@ -200,4 +200,10 @@ hidpp_cpu_to_le_u16(uint16_t data)
 	return result;
 }
 
+static inline uint32_t
+hidpp_get_unaligned_be_u32(uint8_t *buf)
+{
+	return (buf[0] << 24) | (buf[1] << 16) | (buf[2] << 8) | buf[3];
+}
+
 #endif /* HIDPP_GENERIC_H */

--- a/src/hidpp10.c
+++ b/src/hidpp10.c
@@ -2555,8 +2555,7 @@ hidpp10_get_extended_pairing_information(struct hidpp10_device *dev,
 	if (res)
 		return -1;
 
-	*serial = hidpp_get_unaligned_be_u16(&info.msg.string[2]) << 16;
-	*serial |= hidpp_get_unaligned_be_u16(&info.msg.string[4]);
+	*serial = hidpp_get_unaligned_be_u32(&info.msg.string[1]);
 
 	return 0;
 }


### PR DESCRIPTION
Was off by one, the message content only includes one byte of extra information
before the serial number. And add a BE 32-bit helper while we're at it.