### PR TITLE
Added G502 support and small fix

### DIFF
--- a/hwdb/70-libratbag-mouse.hwdb
+++ b/hwdb/70-libratbag-mouse.hwdb
@@ -108,10 +108,14 @@ mouse:usb:v046dpc24e:name:*:
  RATBAG_HIDPP10_DPI=0:8200@50
  RATBAG_HIDPP10_PROFILE=G500
 
-# G502 over USB
+# G502 Proteus Core over USB
 mouse:usb:v046dpc07d:name:*:
  RATBAG_DRIVER=hidpp20
  RATBAG_SVG=logitech-g502.svg
+
+# G502 Proteus Spectrum over USB
+mouse:usb:v046dpc332:name:*:
+ RATBAG_DRIVER=hidpp20
 
 # G700 over USB
 mouse:usb:v046dpc06b:name:*:

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -1286,7 +1286,7 @@ hidpp20_onboard_profiles_initialize(struct hidpp20_device *device,
 	profiles->num_buttons = msg.msg.parameters[5] <= 16 ? msg.msg.parameters[5] : 16;
 	profiles->num_modes = HIDPP20_DPI_COUNT;
 	profiles->has_g_shift = (info->mechanical_layout & 0x03) == 2;
-	profiles->has_dpi_shift = (info->mechanical_layout & 0x0c) == 2;
+	profiles->has_dpi_shift = ((info->mechanical_layout & 0x0c) >> 2) == 2;
 	switch(info->various_info & 0x07) {
 	case 1:
 		profiles->corded = 1;


### PR DESCRIPTION
Added the product ID for the new G502 (with rgb LEDs) in hwdb. I hope I guessed correctly the version from the already present G502 product ID.

The profile format seems to be the one already supported. I will test that more later.

While reading the code I also found a incoherent comparison, I added the obvious bit shift, it looks coherent with the value in my G502's description.