### PR TITLE
Add the ability to disable profiles

### DIFF
--- a/src/driver-gskill.c
+++ b/src/driver-gskill.c
@@ -313,6 +313,14 @@ struct gskill_data {
 	struct gskill_profile_data profile_data[GSKILL_PROFILE_MAX];
 };
 
+static inline struct gskill_profile_data *
+profile_to_pdata(struct ratbag_profile *profile)
+{
+	struct gskill_data *drv_data = profile->device->drv_data;
+
+	return &drv_data->profile_data[profile->index];
+}
+
 static const struct ratbag_button_action *
 gskill_button_function_to_action(enum gskill_button_function_type type)
 {
@@ -1037,9 +1045,7 @@ static void
 gskill_read_resolutions(struct ratbag_profile *profile,
 			struct gskill_profile_report *report)
 {
-	struct gskill_data *drv_data = ratbag_get_drv_data(profile->device);
-	struct gskill_profile_data *pdata =
-		&drv_data->profile_data[profile->index];
+	struct gskill_profile_data *pdata = profile_to_pdata(profile);
 	struct ratbag_resolution *resolution;
 	int dpi_x, dpi_y, hz, i;
 
@@ -1089,7 +1095,7 @@ gskill_read_profile(struct ratbag_profile *profile, unsigned int index)
 {
 	struct ratbag_device *device = profile->device;
 	struct gskill_data *drv_data = ratbag_get_drv_data(device);
-	struct gskill_profile_data *pdata = &drv_data->profile_data[index];
+	struct gskill_profile_data *pdata = profile_to_pdata(profile);
 	struct gskill_profile_report *report = &pdata->report;
 	uint8_t checksum;
 	int rc, retries;
@@ -1144,9 +1150,7 @@ static int
 gskill_update_resolutions(struct ratbag_profile *profile)
 {
 	struct ratbag_device *device = profile->device;
-	struct gskill_data *drv_data = ratbag_get_drv_data(device);
-	struct gskill_profile_data *pdata =
-		&drv_data->profile_data[profile->index];
+	struct gskill_profile_data *pdata = profile_to_pdata(profile);
 	struct gskill_profile_report *report = &pdata->report;
 	int i;
 
@@ -1207,9 +1211,8 @@ gskill_read_button(struct ratbag_button *button)
 {
 	struct ratbag_profile *profile = button->profile;
 	struct ratbag_device *device = profile->device;
-	struct gskill_data *drv_data = ratbag_get_drv_data(device);
 	struct gskill_profile_report *report =
-		&drv_data->profile_data[profile->index].report;
+		&profile_to_pdata(profile)->report;
 	struct gskill_macro_report *macro_report;
 	struct ratbag_button_macro *macro;
 	struct gskill_button_cfg *bcfg;
@@ -1308,9 +1311,7 @@ gskill_update_button(struct ratbag_button *button)
 	struct ratbag_device *device = profile->device;
 	struct ratbag_button_action *action = &button->action;
 	struct ratbag_button_macro *macro = NULL;
-	struct gskill_data *drv_data = ratbag_get_drv_data(device);
-	struct gskill_profile_data *pdata =
-		&drv_data->profile_data[profile->index];
+	struct gskill_profile_data *pdata = profile_to_pdata(profile);
 	struct gskill_button_cfg *bcfg = &pdata->report.btn_cfgs[button->index];
 	uint16_t code = 0;
 
@@ -1401,9 +1402,7 @@ gskill_update_profile(struct ratbag_profile *profile)
 {
 	struct ratbag_device *device = profile->device;
 	struct ratbag_button *button;
-	struct gskill_data *drv_data = ratbag_get_drv_data(device);
-	struct gskill_profile_data *pdata =
-		&drv_data->profile_data[profile->index];
+	struct gskill_profile_data *pdata = profile_to_pdata(profile);
 	struct gskill_profile_report *report = &pdata->report;
 	int rc;
 

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -231,6 +231,7 @@ struct ratbag_profile {
 	} resolution;
 
 	bool is_active;		/**< profile is the currently active one */
+	bool is_enabled;
 	bool dirty;       /**< profile changed since last commit */
 };
 

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -610,6 +610,7 @@ ratbag_create_profile(struct ratbag_device *device,
 	profile->resolution.modes = zalloc(num_resolutions *
 					   sizeof(*profile->resolution.modes));
 	profile->resolution.num_modes = num_resolutions;
+	profile->is_enabled = true;
 
 	list_insert(&device->profiles, &profile->link);
 	list_init(&profile->buttons);
@@ -714,10 +715,29 @@ ratbag_device_get_profile(struct ratbag_device *device, unsigned int index)
 	return NULL;
 }
 
+LIBRATBAG_EXPORT enum ratbag_error_code
+ratbag_profile_set_enabled(struct ratbag_profile *profile, bool enabled)
+{
+	if (!ratbag_device_has_capability(profile->device,
+					  RATBAG_DEVICE_CAP_DISABLE_PROFILE))
+		return RATBAG_ERROR_CAPABILITY;
+
+	profile->is_enabled = enabled;
+	profile->dirty = true;
+
+	return RATBAG_SUCCESS;
+}
+
 LIBRATBAG_EXPORT int
 ratbag_profile_is_active(struct ratbag_profile *profile)
 {
 	return profile->is_active;
+}
+
+LIBRATBAG_EXPORT bool
+ratbag_profile_is_enabled(const struct ratbag_profile *profile)
+{
+	return profile->is_enabled;
 }
 
 LIBRATBAG_EXPORT unsigned int

--- a/src/libratbag.h
+++ b/src/libratbag.h
@@ -30,6 +30,7 @@ extern "C" {
 
 #include <stdlib.h>
 #include <stdarg.h>
+#include <stdbool.h>
 #include <libudev.h>
 
 #define LIBRATBAG_ATTRIBUTE_PRINTF(_format, _args) \
@@ -519,6 +520,15 @@ enum ratbag_device_capability {
 	 * libratbag can be used to query the device as normal.
 	 */
 	RATBAG_DEVICE_CAP_QUERY_CONFIGURATION,
+
+	/**
+	 * The device has the capability to disable and enable profiles.  While
+	 * profiles are not immediately deleted after being disabled, it is not
+	 * guaranteed that the device will remember any disabled profiles the
+	 * next time ratbag runs. Furthermore, the order of profiles may get
+	 * changed the next time ratbag runs if profiles are disabled.
+	 */
+	RATBAG_DEVICE_CAP_DISABLE_PROFILE,
 };
 
 /**
@@ -602,6 +612,34 @@ ratbag_profile_ref(struct ratbag_profile *profile);
  */
 struct ratbag_profile *
 ratbag_profile_unref(struct ratbag_profile *profile);
+
+/**
+ * @ingroup profile
+ *
+ * Enable/disable the ratbag profile. For this to work, the device must support
+ * @ref RATBAG_DEVICE_CAP_DISABLE_PROFILE.
+ *
+ * @param profile A previously initialized ratbag profile
+ * @param enable Whether to enable or disable the profile
+ *
+ * @return 0 on success or an error code otherwise
+ */
+enum ratbag_error_code
+ratbag_profile_set_enabled(struct ratbag_profile *profile, bool enabled);
+
+/**
+ * @ingroup profile
+ *
+ * Check whether the ratbag profile is enabled or not. For devices that don't
+ * support @ref RATBAG_DEVICE_CAP_DISABLE_PROFILE the profile will always be
+ * set to enabled.
+ *
+ * @param profile A previously initialized ratbag profile
+ *
+ * @return Whether the profile is enabled or not.
+ */
+bool
+ratbag_profile_is_enabled(const struct ratbag_profile *profile);
 
 /**
  * @ingroup profile

--- a/src/libratbag.sym
+++ b/src/libratbag.sym
@@ -50,9 +50,11 @@ global:
 	ratbag_profile_get_resolution;
 	ratbag_profile_get_user_data;
 	ratbag_profile_is_active;
+	ratbag_profile_is_enabled;
 	ratbag_profile_ref;
 	ratbag_profile_set_user_data;
 	ratbag_profile_set_active;
+	ratbag_profile_set_enabled;
 	ratbag_profile_unref;
 	ratbag_resolution_get_dpi;
 	ratbag_resolution_get_dpi_x;


### PR DESCRIPTION
This allows us to enable and disable profiles on mice which support it. As well, this includes the required modifications to support this with the G.Skill driver. This is pretty nice since we can get rid of the ugly hack of enabling all profiles that we've had to use in the driver.