### PR TITLE
Copy all three bytes from parameters

### DIFF
--- a/src/hidpp10.c
+++ b/src/hidpp10.c
@@ -305,7 +305,7 @@ hidpp10_get_hidpp_notifications(struct hidpp10_device *dev,
 		return res;
 
 	*reporting_flags = notifications.msg.parameters[0];
-	*reporting_flags |= (notifications.msg.parameters[0] & 0x1F) << 8;
+	*reporting_flags |= (notifications.msg.parameters[1] & 0x1F) << 8;
 	*reporting_flags |= (notifications.msg.parameters[2] & 0x7 ) << 16;
 
 	return res;


### PR DESCRIPTION
In hidpp10_get_hidpp_notifications(), we want all three bytes from
parameters[], not parameters[0] twice. This matches
hidpp10_set_hidpp_notifications().

Signed-off-by: Stephen Kitt <skitt@redhat.com>