### PR TITLE
Remove auto-detection of features from configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -134,7 +134,7 @@ if test "x$build_tests" = "xyes"; then
 	AC_PATH_PROG(VALGRIND, [valgrind])
 fi
 
-AC_DEFINE(BUILD_TESTS, [1], ["Build the test suite])
+AC_DEFINE(BUILD_TESTS, [1], [Build the test suite])
 AM_CONDITIONAL(HAVE_VALGRIND, [test "x$VALGRIND" != "x"])
 AM_CONDITIONAL(BUILD_TESTS, [test "x$build_tests" = "xyes"])
 AM_CONDITIONAL(BUILD_DOCS, [test "x$build_documentation" = "xyes"])

--- a/configure.ac
+++ b/configure.ac
@@ -107,20 +107,12 @@ if test "x$build_documentation" = "xyes"; then
 fi
 
 AC_ARG_ENABLE(tests,
-	      AS_HELP_STRING([--enable-tests], [Build the tests (default=auto)]),
+	      AS_HELP_STRING([--enable-tests], [Build the tests (default=yes)]),
 	      [build_tests="$enableval"],
-	      [build_tests="auto"])
+	      [build_tests="yes"])
 
-PKG_CHECK_MODULES(CHECK, [check >= 0.9.10], [HAVE_CHECK="yes"], [HAVE_CHECK="no"])
-
-if test "x$build_tests" = "xauto"; then
-	build_tests="$HAVE_CHECK"
-fi
 if test "x$build_tests" = "xyes"; then
-	if test "x$HAVE_CHECK" = "xno"; then
-		AC_MSG_ERROR([Cannot build tests, check is missing])
-	fi
-
+	PKG_CHECK_MODULES(CHECK, [check >= 0.9.10])
 	AC_PATH_PROG(VALGRIND, [valgrind])
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -68,51 +68,41 @@ AC_SUBST(UDEV_BASE_DIR)
 
 AC_ARG_ENABLE([documentation],
 	      [AC_HELP_STRING([--enable-documentation],
-		              [Enable building the documentation (default=auto)])],
+		              [Enable building the documentation (default=yes)])],
 	      [build_documentation="$enableval"],
-	      [build_documentation="auto"])
+	      [build_documentation="yes"])
 
-if test "x$build_documentation" = "xyes" -o "x$build_documentation" = "xauto"; then
+if test "x$build_documentation" = "xyes"; then
 	AC_PATH_PROG(DOXYGEN, doxygen)
 	if test "x$DOXYGEN" = "x"; then
-		if test "x$build_documentation" = "xyes"; then
-			AC_MSG_ERROR([Documentation build requested but doxygen not found. Install doxygen or disable the documentation using --disable-documentation])
-		fi
-	else
-		AC_MSG_CHECKING([for compatible doxygen version])
-		doxygen_version=`$DOXYGEN --version`
-		AS_VERSION_COMPARE([$doxygen_version], [1.6.0],
-		                   [AC_MSG_RESULT([no])
-		                    DOXYGEN=""],
-		                   [AC_MSG_RESULT([yes])],
-		                   [AC_MSG_RESULT([yes])])
-		if test "x$DOXYGEN" = "x" -a "x$build_documentation" = "xyes"; then
-			AC_MSG_ERROR([Doxygen $doxygen_version too old. Doxygen 1.6+ required for documentation build. Install required doxygen version or disable the documentation using --disable-documentation])
-		fi
+		AC_MSG_ERROR([Documentation build requested but doxygen not found. Install doxygen or disable the documentation using --disable-documentation])
+	fi
+
+	AC_MSG_CHECKING([for compatible doxygen version])
+	doxygen_version=`$DOXYGEN --version`
+	AS_VERSION_COMPARE([$doxygen_version], [1.6.0],
+			   [AC_MSG_RESULT([no])
+			    DOXYGEN=""],
+			   [AC_MSG_RESULT([yes])],
+			   [AC_MSG_RESULT([yes])])
+	if test "x$DOXYGEN" = "x"; then
+		AC_MSG_ERROR([Doxygen $doxygen_version too old. Doxygen 1.6+ required for documentation build. Install required doxygen version or disable the documentation using --disable-documentation])
 	fi
 
 	AC_PATH_PROG(DOT, dot)
 	if test "x$DOT" = "x"; then
-		if test "x$build_documentation" = "xyes"; then
-			AC_MSG_ERROR([Documentation build requested but graphviz's dot not found. Install graphviz or disable the documentation using --disable-documentation])
-		fi
-	else
-		AC_MSG_CHECKING([for compatible dot version])
-		dot_version=`$DOT -V 2>&1|$GREP -oP '(?<=version\W)@<:@0-9.@:>@*(?=\W(.*))'`
-		AS_VERSION_COMPARE([$dot_version], [2.26.0],
-		                   [AC_MSG_RESULT([no])
-		                    DOT=""],
-		                   [AC_MSG_RESULT([yes])],
-		                   [AC_MSG_RESULT([yes])])
-		if test "x$DOT" = "x" -a "x$build_documentation" = "xyes"; then
-			AC_MSG_ERROR([Graphviz dot $dot_version too old. Graphviz 2.26+ required for documentation build. Install required graphviz version or disable the documentation using --disable-documentation])
-		fi
+		AC_MSG_ERROR([Documentation build requested but graphviz's dot not found. Install graphviz or disable the documentation using --disable-documentation])
 	fi
 
-	if test "x$DOXYGEN" != "x" -a "x$DOT" != "x"; then
-		build_documentation="yes"
-	else
-		build_documentation="no"
+	AC_MSG_CHECKING([for compatible dot version])
+	dot_version=`$DOT -V 2>&1|$GREP -oP '(?<=version\W)@<:@0-9.@:>@*(?=\W(.*))'`
+	AS_VERSION_COMPARE([$dot_version], [2.26.0],
+			   [AC_MSG_RESULT([no])
+			    DOT=""],
+			   [AC_MSG_RESULT([yes])],
+			   [AC_MSG_RESULT([yes])])
+	if test "x$DOT" = "x"; then
+		AC_MSG_ERROR([Graphviz dot $dot_version too old. Graphviz 2.26+ required for documentation build. Install required graphviz version or disable the documentation using --disable-documentation])
 	fi
 fi
 


### PR DESCRIPTION
We only have two auto-detected dependencies, for documentation and tests. During the work with meson I realised this is not really a good solution. Our dependencies should be well-defined for what is considered 'normal' and explicitly defined for any deviation from that normal build.

The normal build *includes* docs and tests, because we expect developers to find errors in either. A distribution build may exclude either or both, but it should be explicitly specified by the distribution rather than having our build system guess what's not needed.

So this PR removes the auto-detection for doc/test builds and replaces them with a default enabled.