### PR TITLE
Fix warning: ‘x’ may be used uninitialized in this function

### DIFF
--- a/src/libratbag-hidraw.c
+++ b/src/libratbag-hidraw.c
@@ -1405,7 +1405,7 @@ ratbag_find_hidraw_node(struct ratbag_device *device,
 	udev_enumerate_add_match_parent(e, parent_udev);
 	udev_enumerate_scan_devices(e);
 	udev_list_entry_foreach(entry, udev_enumerate_get_list_entry(e)) {
-		_cleanup_udev_device_unref_ struct udev_device *udev_device;
+		_cleanup_udev_device_unref_ struct udev_device *udev_device = NULL;
 
 		path = udev_list_entry_get_name(entry);
 		udev_device = udev_device_new_from_syspath(udev, path);

--- a/tools/hidpp10-dump-page.c
+++ b/tools/hidpp10-dump-page.c
@@ -80,7 +80,7 @@ usage(void)
 int
 main(int argc, char **argv)
 {
-	_cleanup_close_ int fd;
+	_cleanup_close_ int fd = 0;
 	const char *path;
 	size_t page = 0, offset = 0;
 	struct hidpp10_device *dev = NULL;

--- a/tools/hidpp20-dump-page.c
+++ b/tools/hidpp20-dump-page.c
@@ -92,7 +92,7 @@ usage(void)
 int
 main(int argc, char **argv)
 {
-	_cleanup_close_ int fd;
+	_cleanup_close_ int fd = 0;
 	const char *path;
 	size_t page = 0, offset = 0;
 	struct hidpp20_device *dev = NULL;

--- a/tools/ratbag-command.c
+++ b/tools/ratbag-command.c
@@ -605,7 +605,7 @@ ratbag_cmd_change_button(const struct ratbag_cmd *cmd,
 	int button_index;
 	enum ratbag_button_action_type action_type;
 	int rc = ERR_DEVICE;
-	unsigned int btnkey;
+	unsigned int btnkey = 0;
 	enum ratbag_button_action_special special;
 	struct macro macro = {0};
 


### PR DESCRIPTION
Few defects detected by compiling the rpms