### PR TITLE
documentation cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-/*!@mainpage
-
 libratbag
 =========
 
@@ -122,5 +120,3 @@ libratbag is licensed under the MIT license.
 See the COPYING file for the full license information.
 
 [![Build Status](https://semaphoreci.com/api/v1/projects/7905244a-c0b5-468b-9071-d846de3ce9f1/545192/badge.svg)](https://semaphoreci.com/libratbag/libratbag)
-
-*/

--- a/doc/libratbag.doxygen.in
+++ b/doc/libratbag.doxygen.in
@@ -25,3 +25,4 @@ HTML_HEADER = @top_srcdir@/doc/style/header.html
 HTML_FOOTER = @top_srcdir@/doc/style/footer.html
 HTML_EXTRA_STYLESHEET = @top_srcdir@/doc/style/customdoxygen.css \
 			@top_srcdir@/doc/style/bootstrap.css
+USE_MDFILE_AS_MAINPAGE = README.md

--- a/doc/libratbag.doxygen.in
+++ b/doc/libratbag.doxygen.in
@@ -8,6 +8,7 @@ EXTRACT_ALL            = YES
 EXTRACT_STATIC         = YES
 MAX_INITIALIZER_LINES  = 0
 QUIET                  = YES
+# Keep this list in sync with meson.build
 INPUT                  = @top_srcdir@/src/libratbag.h \
 			 @top_srcdir@/README.md
 GENERATE_HTML          = YES

--- a/meson.build
+++ b/meson.build
@@ -369,8 +369,11 @@ if enable_doc
 				  output : 'libratbag.doxygen',
 				  configuration : doc_config,
 				  install : false)
+	src_doxygen = [ doxyfile,
+			'src/libratbag.h',
+			'README.md']
 	custom_target('doxygen',
-			input : [ doxyfile ],
+			input : src_doxygen,
 			output : [ 'html' ],
 			command : [ cmd_doxygen, doxyfile ],
 			install : false,

--- a/meson.build
+++ b/meson.build
@@ -351,13 +351,19 @@ if enable_doc
 
 	v = run_command(cmd_doxygen, ['--version']).stdout()
 	if not v.version_compare('>=1.8.3')
-		error('Doxygen $doxygen_version too old. Doxygen 1.8.3+ required for documentation build. Install required doxygen version or disable the documentation using --disable-documentation')
+		error('Doxygen $doxygen_version too old. ' +
+		      'Doxygen 1.8.3+ required for documentation build. ' +
+		      'Install required doxygen version or ' +
+		      'disable the documentation using --disable-documentation')
 	endif
 
 	v = run_command(cmd_dot, ['-V']).stderr()
 	v = v.split(' ')[4]
 	if v.version_compare('<2.26.0')
-		error('Graphviz dot $dot_version too old. Graphviz 2.26+ required for documentation build. Install required graphviz version or disable the documentation using --disable-documentation')
+		error('Graphviz dot $dot_version too old. ' +
+		      'Graphviz 2.26+ required for documentation build. ' +
+		      'Install required graphviz version or ' +
+		      'disable the documentation using --disable-documentation')
 	endif
 
 	doc_config = configuration_data()

--- a/meson.build
+++ b/meson.build
@@ -350,8 +350,8 @@ if enable_doc
 	cmd_dot = find_program('dot')
 
 	v = run_command(cmd_doxygen, ['--version']).stdout()
-	if not v.version_compare('>1.6.0')
-		error('Doxygen $doxygen_version too old. Doxygen 1.6+ required for documentation build. Install required doxygen version or disable the documentation using --disable-documentation')
+	if not v.version_compare('>=1.8.3')
+		error('Doxygen $doxygen_version too old. Doxygen 1.8.3+ required for documentation build. Install required doxygen version or disable the documentation using --disable-documentation')
 	endif
 
 	v = run_command(cmd_dot, ['-V']).stderr()


### PR DESCRIPTION
Fixes source detection for documentation rebuilds, drops the doxygen tags from the readme and breaks up two long messages