### PR TITLE
Move the LED cap enum value to the end

### DIFF
--- a/src/libratbag.h
+++ b/src/libratbag.h
@@ -516,11 +516,6 @@ enum ratbag_device_capability {
 	RATBAG_DEVICE_CAP_BUTTON_KEY,
 
 	/**
-	 * The device supports assigning LED colors and effects
-	 */
-	RATBAG_DEVICE_CAP_LED,
-
-	/**
 	 * The device supports user-defined key or button sequences.
 	 */
 	RATBAG_DEVICE_CAP_BUTTON_MACROS,
@@ -558,6 +553,11 @@ enum ratbag_device_capability {
 	 * changed the next time ratbag runs if profiles are disabled.
 	 */
 	RATBAG_DEVICE_CAP_DISABLE_PROFILE,
+
+	/**
+	 * The device supports assigning LED colors and effects
+	 */
+	RATBAG_DEVICE_CAP_LED,
 };
 
 /**


### PR DESCRIPTION
Inserting a value in the middle of the enum breaks the ABI since it shifts
everything else backwards. This introduced an ABI break in 0.6.

Signed-off-by: Peter Hutterer <peter.hutterer@who-t.net>