### PR TITLE
Replace ifndef include guards with pragma once

### DIFF
--- a/src/hidpp-generic.h
+++ b/src/hidpp-generic.h
@@ -26,12 +26,11 @@
  *   https://drive.google.com/folderview?id=0BxbRzx7vEV7eWmgwazJ3NUFfQ28&usp=sharing
  */
 
+#pragma once
+
 #include <stdint.h>
 #include <stdarg.h>
 #include <stddef.h>
-
-#ifndef HIDPP_GENERIC_H
-#define HIDPP_GENERIC_H
 
 #define HIDPP_RECEIVER_IDX			0xFF
 #define HIDPP_WIRED_DEVICE_IDX			0x00
@@ -211,5 +210,3 @@ hidpp_get_unaligned_be_u32(uint8_t *buf)
 {
 	return (buf[0] << 24) | (buf[1] << 16) | (buf[2] << 8) | buf[3];
 }
-
-#endif /* HIDPP_GENERIC_H */

--- a/src/hidpp10.h
+++ b/src/hidpp10.h
@@ -26,8 +26,7 @@
  *   https://drive.google.com/folderview?id=0BxbRzx7vEV7eWmgwazJ3NUFfQ28&usp=sharing
  */
 
-#ifndef HIDPP_10_H
-#define HIDPP_10_H
+#pragma once
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -695,5 +694,3 @@ hidpp10_get_firmare_information(struct hidpp10_device *dev,
 				uint8_t *major,
 				uint8_t *minor,
 				uint8_t *build_number);
-
-#endif /* HIDPP_10_H */

--- a/src/hidpp20.h
+++ b/src/hidpp20.h
@@ -26,8 +26,7 @@
  *   https://drive.google.com/folderview?id=0BxbRzx7vEV7eWmgwazJ3NUFfQ28&usp=sharing
  */
 
-#ifndef HIDPP_20_H
-#define HIDPP_20_H
+#pragma once
 
 #include <stdint.h>
 
@@ -544,5 +543,3 @@ hidpp20_onboard_profiles_read_memory(struct hidpp20_device *device,
 #define HIDPP_PAGE_MOUSE_BUTTON_SPY			0x8110
 
 
-
-#endif /* HIDPP_20_H */

--- a/src/liblur.h
+++ b/src/liblur.h
@@ -23,8 +23,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef _LIBLUR_H_
-#define _LIBLUR_H_ 1
+#pragma once
 
 #ifdef __cplusplus
 extern "C" {
@@ -267,5 +266,4 @@ lur_device_get_user_data(const struct lur_device *dev);
 
 #ifdef __cplusplus
 }
-#endif
 #endif

--- a/src/libratbag-hidraw.h
+++ b/src/libratbag-hidraw.h
@@ -21,8 +21,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef LIBRATBAG_HIDRAW_H
-#define LIBRATBAG_HIDRAW_H
+#pragma once
 
 #include <linux/hid.h>
 #include <stdint.h>
@@ -186,4 +185,3 @@ ratbag_hidraw_get_keycode_from_consumer_usage(struct ratbag_device *device,
 uint16_t
 ratbag_hidraw_get_consumer_usage_from_keycode(struct ratbag_device *device,
 					      unsigned keycode);
-#endif /* LIBRATBAG_HIDRAW_H */

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -21,8 +21,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef LIBRATBAG_PRIVATE_H
-#define LIBRATBAG_PRIVATE_H
+#pragma once
 
 #include <linux/input.h>
 #include <stdint.h>
@@ -490,6 +489,4 @@ ratbag_register_driver(struct ratbag *ratbag, struct ratbag_driver *driver);
 void
 ratbag_button_copy_macro(struct ratbag_button *button,
 			 const struct ratbag_button_macro *macro);
-
-#endif /* LIBRATBAG_PRIVATE_H */
 

--- a/src/libratbag-test.h
+++ b/src/libratbag-test.h
@@ -22,8 +22,7 @@
  */
 
 
-#ifndef LIBRATBAG_TEST_H
-#define LIBRATBAG_TEST_H
+#pragma once
 
 #include "libratbag.h"
 
@@ -84,4 +83,3 @@ struct ratbag_test_device {
 struct ratbag_device* ratbag_device_new_test_device(struct ratbag *ratbag,
 						    struct ratbag_test_device *test_device);
 
-#endif /* LIBRATBAG_TEST_H */

--- a/src/libratbag-util.h
+++ b/src/libratbag-util.h
@@ -21,8 +21,7 @@
  * OF THIS SOFTWARE.
  */
 
-#ifndef LIBRATBAG_UTIL_H
-#define LIBRATBAG_UTIL_H
+#pragma once
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -217,4 +216,3 @@ ratbag_utf8_to_enc(char *buf, size_t buf_len, const char *to_enc,
 ssize_t
 ratbag_utf8_from_enc(char *in_buf, size_t in_len, const char *from_enc,
 		     char **out);
-#endif /* LIBRATBAG_UTIL_H */

--- a/src/libratbag.h
+++ b/src/libratbag.h
@@ -21,8 +21,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef LIBRATBAG_H
-#define LIBRATBAG_H
+#pragma once
 
 #ifdef __cplusplus
 extern "C" {
@@ -1818,4 +1817,3 @@ ratbag_led_unref(struct ratbag_led *led);
 #ifdef __cplusplus
 }
 #endif
-#endif /* LIBRATBAG_H */

--- a/src/usb-ids.h
+++ b/src/usb-ids.h
@@ -20,10 +20,7 @@
  * OF THIS SOFTWARE.
  */
 
-#ifndef USB_IDS_H
-#define USB_IDS_H
+#pragma once
 
 #define USB_VENDOR_ID_LOGITECH			0x046d
-
-#endif
 

--- a/tools/shared.h
+++ b/tools/shared.h
@@ -21,6 +21,8 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
+#pragma once
+
 #include "config.h"
 
 #include <errno.h>


### PR DESCRIPTION
Now that we use meson exclusively and meson uses this for its config.h, you
wouldn't get around it anyway. Besides, the main compilers support it and
libratbag is too niche to worry about others.

Signed-off-by: Peter Hutterer <peter.hutterer@who-t.net>