### PR TITLE
tools: rename led mode from breathing to breath

### DIFF
--- a/tools/ratbag-command.c
+++ b/tools/ratbag-command.c
@@ -157,7 +157,7 @@ usage(void)
 	       "  led N {COMMAND}\n"
 	       "                      get                                print the LED properties\n"
 	       "                      set {COMMAND}                      sets LED properties\n"
-	       "                           mode [on|off|cycle|breath]    sets LED mode\n"
+	       "                           mode [on|off|cycle|breathing] sets LED mode\n"
 	       "                           color COLOR                   sets LED's color in hex format\n"
 	       "                           rate N                        sets LED's effect rate in Hz\n"
 	       "                           brightness N                  sets LED's effect brightness\n"

--- a/tools/shared.c
+++ b/tools/shared.c
@@ -83,7 +83,7 @@ led_mode_to_str(enum ratbag_led_mode mode)
 		str = "cycle";
 		break;
 	case RATBAG_LED_BREATHING:
-		str = "breath";
+		str = "breathing";
 		break;
 	}
 


### PR DESCRIPTION
The help calls the mode "breath" and the mode will also be reported
as such (via led_mode_to_str).

If you prefer it the other way around (rename other locations to "breathing"), let me know.