### PR TITLE
hidpp20: take into account sectors on 16bits

### DIFF
--- a/src/hidpp20.h
+++ b/src/hidpp20.h
@@ -533,7 +533,7 @@ int
 hidpp20_onboard_profiles_read_memory(struct hidpp20_device *device,
 				     uint8_t read_rom,
 				     uint8_t page,
-				     uint8_t section,
+				     uint16_t section,
 				     uint8_t result[16]);
 
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
First part of fixing #122.

Still missing the dynamically allocation of the sector size, but at least now the hidpp low level calls are correct.
Currently the G402 will not work with libratbag if the sector size is different because we reject any device that has a sector size different than 256.