### PR TITLE
Add circle.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,5 @@ libratbag is licensed under the MIT license.
 See the COPYING file for the full license information.
 
 [![Build Status](https://semaphoreci.com/api/v1/projects/7905244a-c0b5-468b-9071-d846de3ce9f1/545192/badge.svg)](https://semaphoreci.com/libratbag/libratbag)
+
+[![Build Status](https://circleci.com/gh/libratbag/libratbag.svg?style=shield&circle-token=d7c782e10d2d934b176da754f11b5105ea074f4a)](https://circleci.com/gh/bentiss/libratbag)

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,17 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/libratbag
+    docker:
+      - image: fedora:rawhide
+    steps:
+      - run:
+          command: |
+            dnf install -y git gcc gcc-c++ meson check-devel libudev-devel libevdev-devel doxygen graphviz
+      - checkout
+      - run:
+          command: |
+            meson build
+            ninja -C build test
+      - store_artifacts:
+          path: ~/libratbag/build/meson-logs


### PR DESCRIPTION
Semaphore CI is still using Ubuntu 14.04, and the shipped systemd version is just too old.
OTOH, Circle CI 2.0 (still beta as of today) allows to use any docker image as a base for running the tests. Meaning that we can have a fedora rawhide image as a base and we do not have to handle the update of systemd meson and others.

Ship a basic circle.yml for Circle CI to run our tests and add the badge in the README.

In the future, this could also allow us to add other distribution as base, so we could run and fix the tests on those other distributions.