### PR TITLE
circle.yml: uninstall and checks if there are any leftovers

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,6 +12,19 @@ libratbag_references:
     run:
       name: Installing
       command: ninja -C build install
+  check_uninstall: &check_uninstall
+    run:
+      name: Checking if any files are left after uninstall
+      command: |
+        PREFIX=/root/test_install
+        meson build_install --prefix=$PREFIX
+        ninja -C build_install install
+        ninja -C build_install uninstall
+        if [ -d $PREFIX ]
+        then
+          tree $PREFIX
+          exit 1
+        fi
   export_logs: &export_logs
     store_artifacts:
       path: ~/libratbag/build/meson-logs
@@ -22,10 +35,11 @@ fedora_settings: &fedora_settings
   steps:
     - run:
         name: Install prerequisites
-        command: dnf install -y git gcc gcc-c++ meson check-devel libudev-devel libevdev-devel doxygen graphviz
+        command: dnf install -y tree git gcc gcc-c++ meson check-devel libudev-devel libevdev-devel doxygen graphviz
     - checkout
     - *build_and_test
     - *install
+    - *check_uninstall
     - *export_logs
 
 
@@ -39,10 +53,11 @@ ubuntu_settings: &ubuntu_settings
           apt-get install -y software-properties-common
           add-apt-repository universe
           apt-get update
-          apt-get install -y git gcc g++ pkg-config meson check libudev-dev libevdev-dev libsystemd-dev doxygen graphviz
+          apt-get install -y tree git gcc g++ pkg-config meson check libudev-dev libevdev-dev libsystemd-dev doxygen graphviz
     - checkout
     - *build_and_test
     - *install
+    - *check_uninstall
     - *export_logs
 
 

--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,10 @@ libratbag_references:
       name: Checking if any files are left after uninstall
       command: |
         PREFIX=/root/test_install
-        meson build_install --prefix=$PREFIX
+        # workaround until https://github.com/mesonbuild/meson/pull/2033 is merged
+        # and a new release appears
+        git clone https://github.com/whot/meson -b wip/remove-directories-on-uninstall
+        ./meson/meson.py build_install --prefix=$PREFIX
         ninja -C build_install install
         ninja -C build_install uninstall
         if [ -d $PREFIX ]


### PR DESCRIPTION
Try to uninstall and see if there are leftovers.

Currently the tests fail as `/usr/share/ratbagd` is not uninstalled.
I couldn't find out what magic is required for it to be removed by meson, so submitting the PR in the hope someone tells me what to fix in `meson.build`.