### PR TITLE
fix meson complaints

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -22,7 +22,7 @@ fedora_settings: &fedora_settings
   steps:
     - run:
         name: Install prerequisites
-        command: dnf install -y git gcc gcc-c++ meson check-devel libudev-devel libevdev-devel doxygen graphviz
+        command: dnf install -y git gcc gcc-c++ meson check-devel libudev-devel libevdev-devel doxygen graphviz valgrind
     - checkout
     - *build_and_test
     - *install
@@ -39,7 +39,7 @@ ubuntu_settings: &ubuntu_settings
           apt-get install -y software-properties-common
           add-apt-repository universe
           apt-get update
-          apt-get install -y git gcc g++ pkg-config meson check libudev-dev libevdev-dev libsystemd-dev doxygen graphviz
+          apt-get install -y git gcc g++ pkg-config meson check libudev-dev libevdev-dev libsystemd-dev doxygen graphviz valgrind
     - checkout
     - *build_and_test
     - *install

--- a/meson.build
+++ b/meson.build
@@ -301,11 +301,8 @@ if enable_tests
 	dep_check = dependency('check', version: '>= 0.9.10')
 
 	config_h.set('BUILD_TESTS', '1')
-	env_test = ['RATBAG_TEST=1']
-	valgrind_args = [ '--leak-check=full',
-			  '--quiet',
-			  '--error-exitcode=3',
-			  '--suppressions=@0@/test/valgrind.suppressions'.format(meson.current_source_dir()) ]
+	env_test = environment()
+	env_test.set('RATBAG_TEST', '1')
 
 	test_context = executable('test-context',
 				  ['test/test-context.c'],
@@ -324,9 +321,21 @@ if enable_tests
 						 dep_libutil],
 				include_directories : include_directories('src'),
 				install : false)
-	test('test-context', test_context, env : env_test, valgrind_args : valgrind_args)
-	test('test-device', test_device, env : env_test, valgrind_args : valgrind_args)
-	test('test-iconv-helper', test_iconv_helper, env : env_test, valgrind_args : valgrind_args)
+	test('test-context', test_context, env : env_test)
+	test('test-device', test_device, env : env_test)
+	test('test-iconv-helper', test_iconv_helper, env : env_test)
+
+	valgrind = find_program('valgrind')
+	valgrind_suppressions_file = join_paths(meson.source_root(), 'test', 'valgrind.suppressions')
+	add_test_setup('valgrind',
+		       exe_wrapper : [
+			       valgrind,
+			       '--leak-check=full',
+			       '--quiet',
+			       '--error-exitcode=3',
+			       '--suppressions=' + valgrind_suppressions_file ],
+		       env : env_test,
+		       timeout_multiplier: 100)
 
 	executable('test-build-cxx',
 		   ['test/build-cxx.cc'],

--- a/meson.build
+++ b/meson.build
@@ -472,7 +472,6 @@ configure_file(input : 'dbus/org.freedesktop.ratbag1.service.in',
 	       configuration : config_bindir,
 	       install_dir : join_paths(dbusdir, 'system-services'))
 install_data('dbus/org.freedesktop.ratbag1.conf',
-	     configuration : config_bindir,
 	     install_dir : join_paths(dbusdir, 'system.d'))
 
 #### tools ####


### PR DESCRIPTION
meson git master added warnings for the places where unsupported keywords are in use. And we were using them (outrageous, I know!), so here's a PR to remove the warning. Because there's already enough shouting going on in the world, we don't need more from meson.