### PR TITLE
ratbagd: drop the ActiveResolutionChanged signal generation

### DIFF
--- a/ratbagd/ratbagd-profile.c
+++ b/ratbagd/ratbagd-profile.c
@@ -314,7 +314,7 @@ static int ratbagd_profile_set_active(sd_bus_message *m,
 
 	(void) sd_bus_emit_signal(sd_bus_message_get_bus(m),
 				  "/org/freedesktop/ratbag1",
-				  "/org.freedesktop.ratbag1.Profile",
+				  "org.freedesktop.ratbag1.Profile",
 				  "ActiveProfileChanged",
 				  "u",
 				  profile->index);

--- a/ratbagd/ratbagd-resolution.c
+++ b/ratbagd/ratbagd-resolution.c
@@ -109,7 +109,7 @@ static int ratbagd_resolution_set_default(sd_bus_message *m,
 
 	(void) sd_bus_emit_signal(sd_bus_message_get_bus(m),
 				  "/org/freedesktop/ratbag1",
-				  "/org.freedesktop.ratbag1.Resolution",
+				  "org.freedesktop.ratbag1.Resolution",
 				  "DefaultResolutionChanged",
 				  "u",
 				  resolution->index);

--- a/ratbagd/ratbagd-resolution.c
+++ b/ratbagd/ratbagd-resolution.c
@@ -95,13 +95,6 @@ static int ratbagd_resolution_set_resolution(sd_bus_message *m,
 		resolution->yres = yres;
 	}
 
-	(void) sd_bus_emit_signal(sd_bus_message_get_bus(m),
-				  "/org/freedesktop/ratbag1",
-				  "/org.freedesktop.ratbag1.Resolution",
-				  "ActiveResolutionChanged",
-				  "u",
-				  resolution->index);
-
 	return sd_bus_reply_method_return(m, "u", r);
 }
 


### PR DESCRIPTION
Leave the signal in the DBus API for now so we can hook it up later, but
stop the signal being generated. Changing the dpi does not change the active
resolution.

https://github.com/libratbag/libratbag/issues/205

Signed-off-by: Peter Hutterer <peter.hutterer@who-t.net>