### PR TITLE
Add theming support to ratbagd

### DIFF
--- a/DBusInterface.md
+++ b/DBusInterface.md
@@ -14,6 +14,8 @@ Interfaces:
 The **org.freedesktop.ratbag1.Manager** interface provides:
 - Properties:
   - Devices -> array of object paths with interface Device
+  - Themes -> array of strings with theme names. The theme 'default' is
+              guaranteed to be available.
 - Signals:
   - DeviceNew -> new device available, carries object path
   - DeviceRemoved -> device removed, carries object path
@@ -30,6 +32,12 @@ The **org.freedesktop.ratbag1.Device** interface provides:
 - Methods:
   - GetProfileByIndex(uint) -> returns the object path for the given index
   - Commit() -> commit the changes to the device
+  - GetSvg(string) -> returns the full path to the SVG for the given theme
+       or an empty string if none is available.  The theme must be one of
+       org.freedesktop.ratbag1.Manager.Themes. The theme 'default' is
+       guaranteed to be available. ratbagd may return the path to a
+       file that doesn't exist. This is the case if the device has SVGs
+       available but not for the given theme.
 
 The **org.freedesktop.ratbag1.Profile** interface provides:
 - Properties:

--- a/ratbagd/ratbagd-device.c
+++ b/ratbagd/ratbagd-device.c
@@ -187,6 +187,34 @@ out:
 	return sd_bus_message_append(reply, "s", svg_path);
 }
 
+static int ratbagd_device_get_theme_svg(sd_bus_message *m,
+					void *userdata,
+					sd_bus_error *error)
+{
+	struct ratbagd_device *device = userdata;
+	char svg_path[PATH_MAX] = {0};
+	const char *theme;
+	const char *svg;
+	int r;
+
+	r = sd_bus_message_read(m, "s", &theme);
+	if (r < 0)
+		return r;
+
+
+	svg = ratbag_device_get_svg_name(device->lib_device);
+	if (!svg) {
+		log_error("Unable to fetch SVG for %s\n",
+			  ratbagd_device_get_name(device));
+		goto out;
+	}
+
+	sprintf(svg_path, "%s/%s/%s", LIBRATBAG_DATA_DIR, theme, svg);
+
+out:
+	return sd_bus_reply_method_return(m, "s", svg_path);
+}
+
 static int ratbagd_device_get_profiles(sd_bus *bus,
 				       const char *path,
 				       const char *interface,
@@ -332,6 +360,7 @@ const sd_bus_vtable ratbagd_device_vtable[] = {
 	SD_BUS_PROPERTY("Profiles", "ao", ratbagd_device_get_profiles, 0, SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_PROPERTY("ActiveProfile", "u", ratbagd_device_get_active_profile, 0, 0),
 	SD_BUS_METHOD("GetProfileByIndex", "u", "o", ratbagd_device_get_profile_by_index, SD_BUS_VTABLE_UNPRIVILEGED),
+	SD_BUS_METHOD("GetSvg", "s", "s", ratbagd_device_get_theme_svg, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("Commit", "", "u", ratbagd_device_commit, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_VTABLE_END,
 };

--- a/ratbagd/ratbagd.h
+++ b/ratbagd/ratbagd.h
@@ -167,4 +167,6 @@ struct ratbagd {
 
 	RBTree device_map;
 	size_t n_devices;
+
+	const char **themes; /* NULL-terminated */
 };


### PR DESCRIPTION
Two new DBus interfaces:
org.freedesktop.ratbagd1.Manager.Themes -> string array
org.freedesktop.ratbagd1.Device.GetSvg('theme') -> string

The Themes property is a static list of available themes. These are currently
hardcoded in ratbagd, but the theme 'default' is guaranteed to exist.

The GetSvg() method takes a theme name and returns the full file path to the
themed SVG.

Longer-term this will deprecate the Svg and SvgPath properties in the Device
but for now we leave them there.

https://github.com/libratbag/libratbag/issues/204

Signed-off-by: Peter Hutterer <peter.hutterer@who-t.net>