### PR TITLE
tools: fix ratbagctl error when dbus isn't available

### DIFF
--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -508,10 +508,10 @@ def main(argv):
         r = Ratbagd()
         if not r.devices:
             print("No devices available.")
+
+        cmd.func(r, cmd)
     except RatbagdDBusUnavailable:
         print("Unable to connect to ratbagd over dbus")
-
-    cmd.func(r, cmd)
 
 if __name__ == "__main__":
     main(sys.argv[1:])


### PR DESCRIPTION
File "./build/ratbagctl", line 713, in main
    cmd.func(r, cmd)
UnboundLocalError: local variable 'r' referenced before assignment

Signed-off-by: Peter Hutterer <peter.hutterer@who-t.net>