### PR TITLE
data: add toned-down SVG for Logitech G500/G500s

### DIFF
--- a/data/gnome/logitech-g500.svg
+++ b/data/gnome/logitech-g500.svg
@@ -1,0 +1,484 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="461.86667"
+   height="437.33334"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92+devel unknown"
+   sodipodi:docname="logitech-g500.svg"
+   viewBox="0 0 433 410">
+  <style
+     id="style5346" />
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="4.0000004"
+     inkscape:cx="184.69456"
+     inkscape:cy="292.7786"
+     inkscape:document-units="px"
+     inkscape:current-layer="Device"
+     showgrid="false"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1853"
+     inkscape:window-height="1016"
+     inkscape:window-x="1507"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     units="px"
+     fit-margin-top="20"
+     fit-margin-left="-40"
+     fit-margin-right="-40"
+     fit-margin-bottom="20"
+     inkscape:document-rotation="0">
+    <sodipodi:guide
+       orientation="-0.98480775,-0.17364818"
+       position="118.1781,220.98096"
+       id="guide4656"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       orientation="-0.98480775,-0.17364818"
+       position="124.47548,146.18232"
+       id="guide4658"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="-115.05694,410.68446"
+       id="guide5340"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="-338.2349,374.49999"
+       id="guide5342"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="-411.98489,294.5"
+       id="guide5344"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="-447.39711,334.5"
+       id="guide5346"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="-458.85989,254.5"
+       id="guide5348"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="-443.23489,214.5"
+       id="guide5350"
+       inkscape:locked="false" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid5352"
+       empspacing="4"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true"
+       originx="0"
+       originy="0"
+       spacingx="1"
+       spacingy="1" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="-305.47013,174.5"
+       id="guide5354"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Device"
+     id="Device"
+     transform="translate(-39.484902,-592.98552)"
+     style="display:inline"
+     inkscape:groupmode="layer">
+    <path
+       style="fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 256.36569,614.54742 c 62.08413,0.89801 96.39946,43.63605 97.13045,100.21395 0.55781,43.17356 -0.71866,53.46001 -1.54175,67.83715 -2.26656,39.59053 13.49465,51.18855 14.64665,88.65081 1.15816,37.66265 -45.5866,110.51959 -94.81782,110.23536 -65.62864,-0.3789 -122.38269,-97.81594 -122.56938,-158.02971 -0.0782,-25.23502 4.46146,-43.80053 13.87577,-79.40029 -9.23186,-76.55096 33.02958,-130.37871 93.27608,-129.50727 z"
+       id="path3154"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssssscs" />
+    <path
+       style="fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 256.8125,620.48588 c 65.06567,0.698 86.46352,49.92709 87.43313,85.02498 1.40678,50.92328 -31.00828,141.5762 -14.64667,177.30163 8.51955,18.60234 18.50105,43.3618 18.50105,43.3618 0,0 -32.07332,55.55238 -76.12407,55.3104 -47.75882,-0.26237 -83.25468,-52.61233 -83.25468,-52.61233 0,0 18.17404,-39.75596 19.0792,-60.70654 2.21242,-51.20828 -34.1177,-72.31129 -37.00208,-127.19463 -2.92063,-55.57291 17.50781,-121.18975 83.17598,-120.48531 v 47.86067 h -5.96621 c -1.88766,0 -4.0051,2.17484 -4.0051,4.0625 v 39.96094 c 0,1.86907 2.13603,3.98438 4.0051,3.98438 h 5.96621 v 28.98005 h -4.03271 c -0.93786,0 -1.9335,1.10612 -1.9335,2.04398 v 16.95951 c 0,0.93786 0.99564,2.04398 1.9335,2.04398 h 4.03271 v 46.07243 h 2.83814 v -46.07243 h 3.98434 c 0.95705,0 2.01636,-1.08693 2.01636,-2.04398 V 747.3784 c 0,-0.95705 -1.05931,-2.04398 -2.01636,-2.04398 h -3.98434 v -28.98005 h 6.0007 c 1.88748,0 4.0051,-2.0969 4.0051,-3.98438 v -39.96094 c 0,-1.9059 -2.0992,-4.0625 -4.0051,-4.0625 h -6.0007 z"
+       id="path3156"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csscscssccssssccssssccccssssccsssscc" />
+    <path
+       style="fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:2.13333344;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 228.78906,209.52734 v -24.57031 h -4.30273 c -1.00039,0 -2.0625,-1.18126 -2.0625,-2.18164 v -18.08984 c 0,-1.00039 1.06211,-2.17969 2.0625,-2.17969 h 4.30273 v -30.91211 h -6.36523 c -1.99368,0 -4.27149,-2.25633 -4.27149,-4.25 v -42.625 c 0,-2.013504 2.25798,-4.333984 4.27149,-4.333984 h 6.36523 V 29.333984 C 191.43799,28.933309 167.81063,48.64998 154.36133,76.128906 l 6.78125,13.011719 c 0.88314,1.694805 1.15123,3.956361 0.41211,5.71875 -4.4888,10.703155 -7.116,17.605295 -7.34571,28.384765 -0.037,1.73622 -0.81139,4.42706 -1.86718,4.68164 l -8.53907,1.96094 c -2.34577,34.22551 0.78777,54.03726 19.46485,92.625 l 8.17383,0.56055 c 0.9494,0.0651 1.95013,0.3512 2.86523,0.80273"
+       transform="matrix(0.93749999,0,0,0.93749999,39.484902,592.98552)"
+       id="button0"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccssssccssssccccccccccc" />
+    <path
+       sodipodi:nodetypes="ccssssccssssccsc"
+       inkscape:connector-curvature="0"
+       id="button1"
+       d="m 256.8125,789.41811 v -23.03622 h 3.98434 c 0.95705,0 2.01636,-1.08693 2.01636,-2.04398 V 747.3784 c 0,-0.95705 -1.05931,-2.04398 -2.01636,-2.04398 h -3.98434 v -28.98005 h 6.0007 c 1.88748,0 4.0051,-2.0969 4.0051,-3.98438 v -39.96094 c 0,-1.9059 -2.0992,-4.0625 -4.0051,-4.0625 h -6.0007 v -47.86067 c 65.06567,0.698 86.46353,49.92709 87.43313,85.02498 0.70339,25.46164 -7.04868,60.85569 -12.9314,94.35001"
+       style="fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:label="#path5337" />
+    <path
+       style="fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:2.13333344;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 154.36133,76.128906 c -11.77275,24.053464 -15.7471,54.053924 -14.29297,81.722654 2.85731,54.3682 36.47683,77.66427 39.36719,124.46094 l 10.40625,-11.33594 c 1.8935,-2.06288 1.8635,-5.57497 1.24804,-8.30664 -3.12898,-13.88786 -7.08345,-21.76245 -13.9707,-36.16406 -0.95424,-1.99536 -3.47112,-3.28232 -5.67773,-3.43359 l -8.17383,-0.56055 C 144.5905,183.92398 141.45767,164.11281 143.80344,129.8873 l 8.53836,-1.96152 c 1.05579,-0.25458 1.83017,-2.94542 1.86718,-4.68164 0.22971,-10.77947 2.85691,-17.68161 7.34571,-28.384765 0.73912,-1.762389 0.47103,-4.023945 -0.41211,-5.71875 z"
+       transform="matrix(0.93749999,0,0,0.93749999,39.484902,592.98552)"
+       id="path4640"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cscccccccccccc" />
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:2;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="button2"
+       width="16"
+       height="40"
+       x="247.44788"
+       y="672.31464"
+       rx="4"
+       ry="4"
+       inkscape:label="#rect4642" />
+    <rect
+       style="fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:2;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4644"
+       width="8"
+       height="15"
+       x="251.34375"
+       y="748.26843"
+       rx="2"
+       ry="2" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1"
+       d="m 184.45535,669.33767 c -2.23196,5.12412 -4.80484,11.95291 -6.46149,18.61989 l 7.35715,1.95705 c 1.0372,-3.57697 2.03018,-5.75654 2.91825,-7.91351 0.52031,-1.26376 0.20456,-3.91971 -0.38116,-5.19416 z"
+       id="button8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccssc"
+       inkscape:label="#path4646" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1"
+       d="m 174.03907,712.2528 c 0.52083,-6.80199 1.39322,-13.37092 2.65623,-18.35938 l 6.99498,1.53292 c -1.25795,4.82258 -1.66687,8.88981 -1.774,12.75056 -0.0294,1.05941 -0.59464,2.39181 -1.62721,2.6306 z"
+       id="button9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccssc"
+       inkscape:label="#path4648" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 159.55083,740.00544 c -1.24751,0.22588 -2.18342,2.00899 -1.96327,3.25754 l 2.97337,16.86281 4.53764,-0.94696 3.46041,18.3604 1.8943,-0.39559 -6.68317,-37.90213 z"
+       id="button4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sscccccs"
+       inkscape:label="#path4650" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:#bdbab6;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 169.00092,779.7656 1.83239,-0.46666 6.87338,38.98084 -4.17452,1.07194 c -1.15216,0.29585 -2.68927,-0.91399 -2.89583,-2.08545 l -3.45729,-19.60726 4.8521,-1.10345 z"
+       id="button3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccssccc"
+       inkscape:label="#path4652" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 162.19674,761.50057 6.01776,34.31296 2.99355,-0.71424 -3.77818,-20.44043 -2.54859,-13.7678 z"
+       id="button5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc"
+       inkscape:label="#path4654" />
+    <path
+       inkscape:label="#path1148"
+       style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.9375;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="m 238.49468,688.57611 v 7.47706 l -3.59361,-3.59364 z"
+       id="button6"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:label="#path1146"
+       inkscape:connector-curvature="0"
+       id="button7"
+       d="m 272.40108,688.57611 v 7.47706 l 3.5936,-3.59364 z"
+       style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.9375;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+  </g>
+  <g
+     id="Buttons"
+     inkscape:label="Buttons"
+     style="display:inline"
+     transform="translate(-39.484902,-52.623025)"
+     inkscape:groupmode="layer">
+    <g
+       id="button8-path">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path5328"
+         d="M 183.46993,142.07026 170.4849,128.12301 H 40.484902"
+         style="fill:none;stroke:#888a85;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;marker:none"
+         id="rect968-0"
+         width="6.999999"
+         height="6.999999"
+         x="180.25464"
+         y="138.46088" />
+      <rect
+         inkscape:label="#rect5374"
+         y="127.62303"
+         x="39.484901"
+         height="1"
+         width="1"
+         id="button8-leader"
+         style="text-align:end;fill:#888a85;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="button3-path">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path5338"
+         d="m 171.875,267.3125 -20.3901,20.81051 H 40.484902"
+         style="fill:none;stroke:#888a85;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;marker:none"
+         id="rect968-4"
+         width="6.999999"
+         height="6.999999"
+         x="168.53668"
+         y="263.65982" />
+      <rect
+         inkscape:label="#rect5376"
+         transform="translate(39.484902,52.674496)"
+         y="234.94852"
+         x="0"
+         height="1"
+         width="1"
+         id="button3-leader"
+         style="text-align:end;fill:#888a85;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="button5-path">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path5334"
+         d="m 166.54255,238.69695 -9.05765,9.42606 H 40.484902"
+         style="fill:none;stroke:#888a85;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;marker:none"
+         id="rect968-3"
+         width="6.999999"
+         height="6.999999"
+         x="163.02351"
+         y="235.40237" />
+      <rect
+         inkscape:label="#rect5378"
+         transform="translate(39.484902,52.674496)"
+         y="194.94852"
+         x="0"
+         height="1"
+         width="1"
+         id="button5-leader"
+         style="text-align:end;fill:#888a85;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="button4-path">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path5332"
+         d="M 161.4849,208.12301 H 40.484902"
+         style="fill:none;stroke:#888a85;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;marker:none"
+         id="rect968-68"
+         width="6.999999"
+         height="6.999999"
+         x="158.37202"
+         y="204.55347" />
+      <rect
+         inkscape:label="#rect5380"
+         transform="translate(39.484902,52.674496)"
+         y="154.94852"
+         x="0"
+         height="1"
+         width="1"
+         id="button4-leader"
+         style="text-align:end;fill:#888a85;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="button9-path">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path5330"
+         d="m 178.4278,162.96866 -4.9429,5.15435 H 40.484902"
+         style="fill:none;stroke:#888a85;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;marker:none"
+         id="rect968-99"
+         width="6.999999"
+         height="6.999999"
+         x="175.10759"
+         y="159.39299" />
+      <rect
+         inkscape:label="#rect5382"
+         transform="translate(39.484902,52.674496)"
+         y="114.94852"
+         x="0"
+         height="1"
+         width="1"
+         id="button9-leader"
+         style="text-align:end;fill:#888a85;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="button6-path">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path5324"
+         d="m 244.4849,152.62303 95,95.5 132,-2e-5"
+         style="fill:none;stroke:#888a85;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;marker:none"
+         id="rect968-5"
+         width="6.999999"
+         height="6.999999"
+         x="240.37251"
+         y="148.45215" />
+      <rect
+         inkscape:label="#rect5384"
+         transform="translate(39.484902,52.623025)"
+         y="195"
+         x="432"
+         height="1"
+         width="1"
+         id="button6-leader"
+         style="text-align:start;fill:#888a85;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="button7-path">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path5322"
+         d="m 267.4849,152.62303 55,55.5 149,-1e-5"
+         style="fill:none;stroke:#888a85;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;marker:none"
+         id="rect968-1"
+         width="6.999999"
+         height="6.999999"
+         x="263.49133"
+         y="148.45215" />
+      <rect
+         inkscape:label="#rect5386"
+         transform="translate(39.484902,52.623025)"
+         y="155"
+         x="432"
+         height="1"
+         width="1"
+         id="button7-leader"
+         style="text-align:start;fill:#888a85;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="button2-path">
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path5326"
+         d="m 255.4849,141.62303 h 39 l 27,26.5 150,-1e-5"
+         style="fill:none;stroke:#888a85;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;marker:none"
+         id="rect968-6"
+         width="6.999999"
+         height="6.999999"
+         x="251.93195"
+         y="138.13458" />
+      <rect
+         inkscape:label="#rect5388"
+         transform="translate(39.484902,52.623025)"
+         y="115"
+         x="432"
+         height="1"
+         width="1"
+         id="button2-leader"
+         style="text-align:start;fill:#888a85;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="button1-path">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path5320"
+         d="m 290.625,110.67188 16.8599,17.45114 h 164"
+         style="fill:none;stroke:#888a85;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;marker:none"
+         id="rect968-9"
+         width="6.999999"
+         height="6.999999"
+         x="287.23676"
+         y="107.42233" />
+      <rect
+         inkscape:label="#rect5390"
+         transform="translate(39.484902,52.623025)"
+         y="75"
+         x="432"
+         height="1"
+         width="1"
+         id="button1-leader"
+         style="text-align:start;fill:#888a85;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="button0-path">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path5318"
+         d="M 226.27417,106.9604 246.4849,88.123025 h 225"
+         style="fill:none;stroke:#888a85;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;marker:none"
+         id="rect968"
+         width="6.999999"
+         height="6.999999"
+         x="222.83652"
+         y="103.6103" />
+      <rect
+         inkscape:label="#rect5392"
+         transform="translate(39.484902,52.623025)"
+         y="35"
+         x="432"
+         height="1"
+         width="1"
+         id="button0-leader"
+         style="text-align:start;fill:#888a85;fill-opacity:1;stroke:none" />
+    </g>
+  </g>
+  <g
+     id="LEDs"
+     inkscape:label="LEDs"
+     inkscape:groupmode="layer" />
+</svg>

--- a/data/gnome/logitech-g500s.svg
+++ b/data/gnome/logitech-g500s.svg
@@ -1,0 +1,1 @@
+logitech-g500.svg

--- a/data/gnome/logitech-g700.svg
+++ b/data/gnome/logitech-g700.svg
@@ -14,7 +14,7 @@
    viewBox="0 0 467.83105 401.98727"
    version="1.1"
    id="svg8"
-   inkscape:version="0.92.1 r"
+   inkscape:version="0.92+devel unknown"
    sodipodi:docname="logitech-g700.svg"
    inkscape:export-filename="/home/jimmac/logitech-g403.png"
    inkscape:export-xdpi="96"
@@ -28,11 +28,11 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="16"
-     inkscape:cx="448.44799"
-     inkscape:cy="381.5888"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="187.43137"
+     inkscape:cy="258.73512"
      inkscape:document-units="px"
-     inkscape:current-layer="Buttons"
+     inkscape:current-layer="Device"
      inkscape:document-rotation="0"
      showgrid="false"
      units="px"
@@ -40,9 +40,9 @@
      inkscape:showpageshadow="false"
      inkscape:pagecheckerboard="false"
      showguides="true"
-     inkscape:window-width="1366"
-     inkscape:window-height="704"
-     inkscape:window-x="0"
+     inkscape:window-width="1853"
+     inkscape:window-height="1016"
+     inkscape:window-x="1507"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
      inkscape:snap-global="false"
@@ -200,6 +200,18 @@
            id="path1418"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="ccscccccc" />
+        <path
+           sodipodi:nodetypes="ccsccccccccccsssc"
+           inkscape:connector-curvature="0"
+           id="button1"
+           d="m 674.1855,590.4286 -4.08726,-12.49046 c 0,0 2.54921,-4.39682 3.08963,-6.83936 1.19851,-5.41691 0.18619,-16.64269 0.18619,-16.64269 l -10.87259,-0.44848 -0.60938,-17.27195 6.24524,-0.76363 c 4.06456,0.38511 6.77965,-4.10902 6.66305,-6.86494 l -0.33252,-39.01044 c 0.28048,-3.6366 -2.07788,-7.62472 -5.83705,-7.98954 l -8.47677,-0.49546 0.62854,-18.36184 13.79884,0.89971 c 0,0 6.34522,-14.40167 10.99085,-13.74957 4.64563,0.6521 24.41467,6.6986 27.51233,10.86999 3.09765,4.17138 18.99439,49.84112 18.07202,75.55481 -0.46118,12.85684 -2.85453,42.02774 -5.13257,70.79203"
+           style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+        <path
+           style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+           d="m 590.48316,608.5506 c -12.66468,-31.04352 -15.74874,-51.61667 -15.74874,-51.61667 l 23.05147,-8.93851 c 0,0 -7.96118,-20.18219 -6.17273,-34.80102 1.78845,-14.61884 8.3562,-33.93274 8.3562,-33.93274 l -21.43054,-2.36243 c 0,0 5.83261,-22.58934 16.60092,-28.15233 10.76831,-5.56298 19.23914,-5.81466 28.58237,-6.42699 7.5605,-0.4955 15.97198,18.16221 15.97198,18.16221 l 16.26808,2.17394 -0.32704,18.44984 -5.25454,-0.5654 c -3.67431,-0.56751 -4.4221,1.65708 -4.4841,3.99801 l 0.59236,44.46703 c 0.17877,3.31112 2.72713,6.15312 5.36572,6.27812 l 5.67576,0.87203 1.14008,17.91322 -11.71232,-0.0529 c 0,0 0.46941,10.73577 1.62541,15.95522 0.58121,2.62422 2.64643,7.61678 2.64643,7.61678 l -5.41105,14.14438"
+           id="button0"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccsccssccccccccccscc" />
       </g>
       <path
          style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"

--- a/hwdb/70-libratbag-mouse.hwdb
+++ b/hwdb/70-libratbag-mouse.hwdb
@@ -108,6 +108,7 @@ mouse:usb:v046dpc082:name:*:
 # G500
 mouse:usb:v046dpc068:name:*:
  RATBAG_DRIVER=hidpp10
+ RATBAG_SVG=logitech-g500.svg
  RATBAG_HIDPP10_DPI=0:5700@23.53
  RATBAG_HIDPP10_PROFILE=G500
 

--- a/meson.build
+++ b/meson.build
@@ -301,6 +301,8 @@ install_data(default_svg_files,
 
 gnome_svg_files = [
 	'data/gnome/logitech-g403.svg',
+	'data/gnome/logitech-g500.svg',
+	'data/gnome/logitech-g500s.svg',
 	'data/gnome/logitech-g502.svg',
 	'data/gnome/logitech-g700.svg',
 ]


### PR DESCRIPTION
Still WIP, do not merge yet. But I open the pull request for discussion.

The `text-align` properties are not set on the leaders. I did not find how to add that on rectangles in Inkscape.

I named the layers but that set the `inkscape:label` attribute not the `id` one. I guess the `id` is needed although the readme is not clear about that.

For the main buttons, I added open paths (copied from the light gray area) so there is no border on the bottom. The buttons should be there although not visible.

Since the G500 and the G500s are exactly the same when removing details. They should use the same file. Because of the themes I cannot set the same svg file from the hwdb, so I added a symlink. What is the preferred way to achieve that? meson installs a copy of the file instead of the symlink.

@Hjdskes, I wanted to test your version of piper, but the ledsandbuttons branch is broken, because of lack of theme support, I guess. The ratbagd-themes branch does not seem to work (crashes with `bAttributeError: 'RatbagdDevice' object has no attribute 'svg_path'`).