### PR TITLE
Fix HID++2.0/1b04 divert and remapping

### DIFF
--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -300,7 +300,7 @@ hidpp20drv_write_button_1b04(struct ratbag_button *button,
 	if (!mapping)
 		return -EINVAL;
 
-	control->reporting.divert = 1;
+	control->reporting.divert = 0;
 	control->reporting.remapped = mapping;
 	control->reporting.updated = 1;
 

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -785,12 +785,15 @@ hidpp20_special_key_mouse_set_control(struct hidpp20_device *device,
 		return -ENOTSUP;
 
 	msg.msg.sub_id = feature_index;
+	msg.msg.parameters[2] |= 0x02;
 	if (control->reporting.divert)
-		msg.msg.parameters[2] |= 0x03;
+		msg.msg.parameters[2] |= 0x01;
+	msg.msg.parameters[2] |= 0x08;
 	if (control->reporting.persist)
-		msg.msg.parameters[2] |= 0x0c;
+		msg.msg.parameters[2] |= 0x04;
+	msg.msg.parameters[2] |= 0x20;
 	if (control->reporting.raw_XY)
-		msg.msg.parameters[2] |= 0x20;
+		msg.msg.parameters[2] |= 0x10;
 
 	return hidpp20_request_command(device, &msg);
 }


### PR DESCRIPTION
Partially fixes issue #124.

Remapped buttons were diverted at the same time, resulting in a disabled button (diverted buttons don't send their remapped event).

This fixes both remapping the button and changing the divert state correctly.