### PR TITLE
ratbagctl rewrite and test suite

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+ignore = E402,E501
+exclude = .git,__pycache__,build,data,piper/piper.py

--- a/meson.build
+++ b/meson.build
@@ -528,6 +528,9 @@ config_ratbagctl_devel.set('MESON_BUILD_ROOT', meson.build_root())
 configure_file(input : 'tools/ratbagctl.devel.in',
 	       output : 'ratbagctl.devel',
 	       configuration : config_ratbagctl_devel)
+configure_file(input : 'tools/ratbagctl.test.in',
+	       output : 'ratbagctl.test',
+	       configuration : config_ratbagctl_devel)
 
 #### output files ####
 configure_file(output: 'config.h', install: false, configuration: config_h)

--- a/meson.build
+++ b/meson.build
@@ -524,7 +524,7 @@ install_man('tools/ratbagctl.1')
 
 config_ratbagctl_devel = configuration_data()
 config_ratbagctl_devel.set('ratbagd_sha', ratbagd_sha)
-config_ratbagctl_devel.set_quoted('MESON_BUILD_ROOT', meson.build_root())
+config_ratbagctl_devel.set('MESON_BUILD_ROOT', meson.build_root())
 configure_file(input : 'tools/ratbagctl.devel.in',
 	       output : 'ratbagctl.devel',
 	       configuration : config_ratbagctl_devel)

--- a/ratbagd/ratbagd.c
+++ b/ratbagd/ratbagd.c
@@ -193,6 +193,7 @@ static struct ratbag_test_device ratbagd_test_device_descr = {
 	.num_resolutions = 3,
 	.num_buttons = 4,
 	.num_leds = 3,
+	.svg = "logitech-g500.svg",
 	.profiles = {
 		{
 			.buttons = {

--- a/ratbagd/ratbagd.h
+++ b/ratbagd/ratbagd.h
@@ -40,6 +40,8 @@
 
 #ifndef RATBAG_DBUS_INTERFACE
 #define RATBAG_DBUS_INTERFACE	"ratbag1"
+#else
+#define RATBAG_DEVELOPER_EDITION
 #endif
 
 #define RATBAGD_OBJ_ROOT "/org/freedesktop/" RATBAG_DBUS_INTERFACE

--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -737,8 +737,11 @@ hidpp20drv_read_profile_8100(struct ratbag_profile *profile, unsigned int index)
 		if (profile->is_active &&
 		    res->dpi_x == dpi)
 			res->is_active = true;
-		if (i == p->default_dpi)
+		if (i == p->default_dpi) {
 			res->is_default = true;
+			if (!profile->is_active)
+				res->is_active = true;
+		}
 
 		ratbag_resolution_set_range(res, sensor->dpi_min, sensor->dpi_max);
 	}

--- a/src/driver-test.c
+++ b/src/driver-test.c
@@ -184,9 +184,12 @@ test_fake_probe(struct ratbag_device *device)
 }
 
 static int
-test_probe(struct ratbag_device *device, void *data)
+test_probe(struct ratbag_device *device, const void *data)
 {
-	struct ratbag_test_device *test_device = data;
+	struct ratbag_test_device *test_device;
+
+	test_device = zalloc(sizeof(*test_device));
+	memcpy(test_device, data, sizeof(*test_device));
 
 	ratbag_set_drv_data(device, test_device);
 	ratbag_device_init_profiles(device,
@@ -210,6 +213,7 @@ test_remove(struct ratbag_device *device)
 	if (d->destroyed)
 		d->destroyed(device, d->destroyed_data);
 	ratbag_set_drv_data(device, NULL);
+	free(d);
 }
 
 struct ratbag_driver test_driver = {

--- a/src/driver-test.c
+++ b/src/driver-test.c
@@ -170,6 +170,13 @@ test_write_led(struct ratbag_led *led,
 	return 0;
 }
 
+static const char* test_get_svg_name(const struct ratbag_device *device)
+{
+	struct ratbag_test_device *d = ratbag_get_drv_data(device);
+
+	return d->svg;
+}
+
 static int
 test_fake_probe(struct ratbag_device *device)
 {
@@ -211,6 +218,7 @@ struct ratbag_driver test_driver = {
 	.probe = test_fake_probe,
 	.test_probe = test_probe,
 	.remove = test_remove,
+	.get_svg_name = test_get_svg_name,
 	.read_profile = test_read_profile,
 	.write_profile = test_write_profile,
 	.set_active_profile = test_set_active_profile,

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -145,6 +145,15 @@ struct ratbag_driver {
 	int (*commit)(struct ratbag_device *device);
 
 	/**
+	 * Callback called when the device doesn't have the udev property
+	 * RATBAG_SVG.
+	 *
+	 * The returned value must not be free by the caller, the driver
+	 * has to free it during .remove().
+	 */
+	const char *(*get_svg_name)(const struct ratbag_device *device);
+
+	/**
 	 * Callback called when a read profile is requested by the
 	 * caller of the library.
 	 *
@@ -359,7 +368,7 @@ ratbag_set_drv_data(struct ratbag_device *device, void *drv_data)
 }
 
 static inline void *
-ratbag_get_drv_data(struct ratbag_device *device)
+ratbag_get_drv_data(const struct ratbag_device *device)
 {
 	return device->drv_data;
 }

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -224,7 +224,7 @@ struct ratbag_driver {
 			 unsigned int brightness);
 
 	/* private */
-	int (*test_probe)(struct ratbag_device *device, void *data);
+	int (*test_probe)(struct ratbag_device *device, const void *data);
 
 	struct list link;
 };
@@ -503,7 +503,7 @@ ratbag_device_get_udev_property(const struct ratbag_device* device,
 bool
 ratbag_assign_driver(struct ratbag_device *device,
 		     const struct input_id *dev_id,
-		     struct ratbag_test_device *test_device);
+		     const struct ratbag_test_device *test_device);
 
 void
 ratbag_register_driver(struct ratbag *ratbag, struct ratbag_driver *driver);

--- a/src/libratbag-test.c
+++ b/src/libratbag-test.c
@@ -50,7 +50,7 @@ ratbag_register_test_drivers(struct ratbag *ratbag)
 
 LIBRATBAG_EXPORT struct ratbag_device*
 ratbag_device_new_test_device(struct ratbag *ratbag,
-			      struct ratbag_test_device *test_device)
+			      const struct ratbag_test_device *test_device)
 {
 	struct ratbag_device* device = NULL;
 #if BUILD_TESTS

--- a/src/libratbag-test.h
+++ b/src/libratbag-test.h
@@ -82,5 +82,5 @@ struct ratbag_test_device {
 };
 
 struct ratbag_device* ratbag_device_new_test_device(struct ratbag *ratbag,
-						    struct ratbag_test_device *test_device);
+						    const struct ratbag_test_device *test_device);
 

--- a/src/libratbag-test.h
+++ b/src/libratbag-test.h
@@ -75,6 +75,7 @@ struct ratbag_test_device {
 	unsigned int num_resolutions;
 	unsigned int num_buttons;
 	unsigned int num_leds;
+	const char *svg;
 	struct ratbag_test_profile profiles[RATBAG_TEST_MAX_PROFILES];
 	void (*destroyed)(struct ratbag_device *device, void *data);
 	void *destroyed_data;

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -484,7 +484,13 @@ ratbag_device_get_name(const struct ratbag_device* device)
 LIBRATBAG_EXPORT const char *
 ratbag_device_get_svg_name(const struct ratbag_device* device)
 {
-	return udev_prop_value(device->udev_device, "RATBAG_SVG");
+	const char *name;
+
+	name = udev_prop_value(device->udev_device, "RATBAG_SVG");
+	if (!name && device->driver->get_svg_name)
+		name = device->driver->get_svg_name(device);
+
+	return name;
 }
 
 const char *

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -290,7 +290,7 @@ static inline bool
 ratbag_test_driver(struct ratbag_device *device,
 		   const struct input_id *dev_id,
 		   const char *driver_name,
-		   struct ratbag_test_device *test_device)
+		   const struct ratbag_test_device *test_device)
 {
 	struct ratbag *ratbag = device->ratbag;
 	struct ratbag_driver *driver;
@@ -353,7 +353,7 @@ ratbag_driver_fallback_logitech(struct ratbag_device *device,
 bool
 ratbag_assign_driver(struct ratbag_device *device,
 		     const struct input_id *dev_id,
-		     struct ratbag_test_device *test_device)
+		     const struct ratbag_test_device *test_device)
 {
 	bool rc;
 	const char *driver_name;

--- a/tools/ratbagctl.devel.in
+++ b/tools/ratbagctl.devel.in
@@ -40,7 +40,7 @@ SCRIPT_DIR = @MESON_BUILD_ROOT@
 shutil.copy(os.path.join(SCRIPT_DIR, 'org.freedesktop.ratbag_devel1.conf'),
             '/etc/dbus-1/system.d/')
 
-ratbagd = subprocess.Popen([os.path.join(SCRIPT_DIR, "ratbagd.devel")])
+ratbagd = subprocess.Popen([os.path.join(SCRIPT_DIR, "ratbagd.devel")], shell=True)
 
 try:
     ratbagctl = subprocess.Popen(" ".join([os.path.join(SCRIPT_DIR, "ratbagctl"), *sys.argv[1:]]),

--- a/tools/ratbagctl.devel.in
+++ b/tools/ratbagctl.devel.in
@@ -29,12 +29,11 @@ import os
 import shutil
 import subprocess
 import sys
-import time
 
 if not os.geteuid() == 0:
     sys.exit('Script must be run as root')
 
-SCRIPT_DIR = @MESON_BUILD_ROOT@
+SCRIPT_DIR = '@MESON_BUILD_ROOT@'
 
 # first copy the policy for the ratbagd daemon to be allowed to run
 shutil.copy(os.path.join(SCRIPT_DIR, 'org.freedesktop.ratbag_devel1.conf'),

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -1599,6 +1599,18 @@ class RatbagParserRoot(object):
         self.parser.print_help()
 
 
+def open_ratbagd():
+    try:
+        r = Ratbagd()
+    except RatbagdDBusUnavailable:
+        print("Unable to connect to ratbagd over dbus")
+        return None
+    else:
+        if not r.devices:
+            print("No devices available.")
+        return r
+
+
 def main(argv):
     if not argv:
         argv = ["list"]
@@ -1606,14 +1618,9 @@ def main(argv):
     parser = RatbagParserRoot(parser_def)
     cmd = parser.parse(argv)
 
-    try:
-        r = Ratbagd()
-        if not r.devices:
-            print("No devices available.")
-
+    r = open_ratbagd()
+    if r is not None:
         cmd.func(r, cmd)
-    except RatbagdDBusUnavailable:
-        print("Unable to connect to ratbagd over dbus")
 
 if __name__ == "__main__":
     main(sys.argv[1:])

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -615,35 +615,129 @@ def find_device(r, args):
 def find_profile(r, args):
     d = find_device(r, args)
     try:
-        p = d.profiles[args.profile]
+        p = d.profiles[args.profile_n]
     except IndexError:
-        print("Invalid profile index {}".format(args.profile))
+        print("Invalid profile index {}".format(args.profile_n))
         sys.exit(1)
+    except AttributeError:
+        p = d.active_profile
     return p, d
 
 
 def find_resolution(r, args):
     p, d = find_profile(r, args)
     try:
-        r = p.resolutions[args.resolution]
+        r = p.resolutions[args.resolution_n]
     except IndexError:
-        print("Invalid resolution index {}".format(args.resolution))
+        print("Invalid resolution index {}".format(args.resolution_n))
         sys.exit(1)
+    except AttributeError:
+        r = p.active_resolution
     return r, p, d
 
 
 def find_button(r, args):
     p, d = find_profile(r, args)
     try:
-        b = p.buttons[args.button]
+        b = p.buttons[args.button_n]
     except IndexError:
-        print("Invalid button index {}".format(args.button))
+        print("Invalid button index {}".format(args.button_n))
         sys.exit(1)
     return b, p, d
 
 
-def show_device(r, args):
-    d = find_device(r, args)
+def find_led(r, args):
+    p, d = find_profile(r, args)
+    try:
+        l = p.leds[args.led_n]
+    except IndexError:
+        print("Invalid LED index {}".format(args.led_n))
+        sys.exit(1)
+    return l, p, d
+
+
+def print_led(d, p, l, level):
+    leds = {
+        RatbagdLed.LED_MODE_BREATHING: "breathing",
+        RatbagdLed.LED_MODE_CYCLE: "cycle",
+        RatbagdLed.LED_MODE_OFF: "off",
+        RatbagdLed.LED_MODE_ON: "on",
+    }
+    if l.mode == RatbagdLed.LED_MODE_OFF:
+        print(" " * level + "LED: {} type: {}, mode: {}".format(l.index,
+                                                                l.type,
+                                                                leds[l.mode]))
+    elif l.mode == RatbagdLed.LED_MODE_ON:
+        print(" " * level + "LED: {} type: {}, mode: {}, color: {:02x}{:02x}{:02x}".format(l.index,
+                                                                                           l.type,
+                                                                                           leds[l.mode],
+                                                                                           l.color[0],
+                                                                                           l.color[1],
+                                                                                           l.color[2]))
+    elif l.mode == RatbagdLed.LED_MODE_CYCLE:
+        print(" " * level + "LED: {} type: {}, mode: {}, rate: {}, brightness: {}".format(l.index,
+                                                                                          l.type,
+                                                                                          leds[l.mode],
+                                                                                          l.effect_rate,
+                                                                                          l.brightness))
+    elif l.mode == RatbagdLed.LED_MODE_BREATHING:
+        print(" " * level + "LED: {} type: {}, mode: {}, color: {:02x}{:02x}{:02x}, rate: {}, brightness: {}".format(l.index,
+                                                                                                                     l.type,
+                                                                                                                     leds[l.mode],
+                                                                                                                     l.color[0],
+                                                                                                                     l.color[1],
+                                                                                                                     l.color[2],
+                                                                                                                     l.effect_rate,
+                                                                                                                     l.brightness))
+
+
+def print_button(d, p, b, level):
+    header = " " * level + "Button: {} type {} is mapped to ".format(b.index,
+                                                                     b.button_type)
+
+    if b.action_type == "button":
+        print("{}'button {}'".format(header, b.button_mapping))
+    elif b.action_type == "key":
+        print("{}'{}'".format(header, b.key))
+    elif b.action_type == "special":
+        print("{}'{}'".format(header, b.special))
+    else:
+        print("{}UNKOWN".format(header))
+
+
+def print_resolution(d, p, r, level):
+    if r.resolution == (0, 0):
+        print(" " * level + "{}: <disabled>".format(r.index))
+        return
+    if RatbagdResolution.CAP_SEPARATE_XY_RESOLUTION in r.capabilities:
+        print(" " * level + "{}: {}x{}dpi @ {}Hz{}{}".format(r.index,
+                                                             r.resolution[0],
+                                                             r.resolution[1],
+                                                             r.report_rate,
+                                                             " (active)" if p.active_resolution == r else "",
+                                                             " (default)" if p.default_resolution == r else "",
+                                                             ))
+        return
+    print(" " * level + "{}: {}dpi @ {}Hz{}{}".format(r.index,
+                                                      r.resolution[0],
+                                                      r.report_rate,
+                                                      " (active)" if p.active_resolution == r else "",
+                                                      " (default)" if p.default_resolution == r else "",
+                                                      ))
+
+
+def print_profile(d, p, level):
+    print(" " * level + "Resolutions:")
+    for r in p.resolutions:
+        print_resolution(d, p, r, level + 2)
+    for b in p.buttons:
+        print_button(d, p, b, level)
+    for l in p.leds:
+        print_led(d, p, l, level)
+
+
+def print_device(d, level):
+    p = d.profiles[0]  # there should be always one
 
     caps = {RatbagdDevice.CAP_SWITCHABLE_RESOLUTION: "switchable-resolution",
             RatbagdDevice.CAP_SWITCHABLE_PROFILE: "switchable-profile",
@@ -655,48 +749,34 @@ def show_device(r, args):
             RatbagdDevice.CAP_LED: "led"}
     capabilities = [caps[c] for c in d.capabilities]
 
-    print("{} - {}".format(d.id, d.name))
-    print("               SVG: {}".format(d.svg))
-    print("      Capabilities: {}".format(", ".join(capabilities)))
-    print("Number of Profiles: {}".format(len(d.profiles)))
-    active = -1
-    for i, p in enumerate(d.profiles):
-        if p == d.active_profile:
-            active = i
-            break
-    print("    Active Profile: {}".format(active))
+    print(" " * level + "{} - {}".format(d.id, d.name))
+    print(" " * level + "               SVG: {}".format(d.get_svg('gnome')))
+    print(" " * level + "      Capabilities: {}".format(", ".join(capabilities)))
+    print(" " * level + " Number of Buttons: {}".format(len(p.buttons)))
+    print(" " * level + "    Number of Leds: {}".format(len(p.leds)))
+    print(" " * level + "Number of Profiles: {}".format(len(d.profiles)))
+    for p in d.profiles:
+        print_profile(d, p, level + 2)
+
+
+def show_device(r, args):
+    d = find_device(r, args)
+    print_device(d, 0)
 
 
 def show_profile(r, args):
     p, d = find_profile(r, args)
-
     print("Profile {} on {} ({})".format(args.profile, d.id, d.name))
-    print("    Number of Buttons: {}".format(len(p.buttons)))
-    print("Number of Resolutions: {}".format(len(p.resolutions)))
-    active, default = -1, -1
-    for i, r in enumerate(p.resolutions):
-        if p.active_resolution == r:
-            active = i
-        if p.default_resolution == r:
-            default = i
-
-    print("    Active Resolution: {}".format(active))
-    print("   Default Resolution: {}".format(default))
+    print_profile(d, p, 0)
 
 
 def show_resolution(r, args):
     r, p, d = find_resolution(r, args)
-
     print("Resolution {} on Profile {} on {} ({})".format(args.resolution,
                                                           args.profile,
                                                           d.id,
                                                           d.name))
-    print("   Report Rate: {}Hz".format(r.report_rate))
-    if RatbagdResolution.CAP_SEPARATE_XY_RESOLUTION in r.capabilities:
-        print("    Resolution: {}x{}dpi".format(*r.resolution))
-    else:
-        print("    Resolution: {}dpi".format(r.resolution[0]))
-
+    print_resolution(d, p, r, 0)
     caps = {RatbagdResolution.CAP_INDIVIDUAL_REPORT_RATE: "individual-report-rate",
             RatbagdResolution.CAP_SEPARATE_XY_RESOLUTION: "separate-xy-resolution"}
     capabilities = [caps[c] for c in r.capabilities]
@@ -705,59 +785,826 @@ def show_resolution(r, args):
 
 def show_button(r, args):
     b, p, d = find_button(r, args)
-
     print("Button {} on Profile {} on {} ({})".format(args.button,
                                                       args.profile,
                                                       d.id,
                                                       d.name))
-
-    print("           Type: {}".format(b.button_type))
-    print("    Action Type: {}".format(b.action_type))
-
-    if b.action_type == "button":
-        print(" Button Mapping: {}".format(b.button))
-    elif b.action_type == "key":
-        print("    Key Mapping: {}".format(b.key))
-    elif b.action_type == "special":
-        print("Special Mapping: {}".format(b.special))
+    print_button(d, p, b, 0)
 
 
-def make_parser():
-    parser = argparse.ArgumentParser(description="Inspect and modify configurable mice")
-    parser.add_argument("-V", "--version", action="version", version="@version@")
-    subs = parser.add_subparsers(title="COMMANDS", help=None)
+def func_led_get(r, args):
+    l, p, d = find_led(r, args)
+    print_led(d, p, l, 0)
 
-    list = subs.add_parser("list-devices", help="List available configurable mice")
-    list.set_defaults(func=list_devices)
 
-    show = subs.add_parser("show-device", help="Show device information")
-    show.add_argument("device", metavar="event0", help="The device node")
-    show.set_defaults(func=show_device)
+def func_led_set(r, args):
+    l, p, d = find_led(r, args)
+    try:
+        mode = args.mode
+    except AttributeError:
+        pass
+    else:
+        leds = {
+            "breathing": RatbagdLed.LED_MODE_BREATHING,
+            "cycle": RatbagdLed.LED_MODE_CYCLE,
+            "off": RatbagdLed.LED_MODE_OFF,
+            "on": RatbagdLed.LED_MODE_ON,
+        }
+        l.mode = leds[mode]
+    try:
+        color = args.color
+    except AttributeError:
+        pass
+    else:
+        l.color = color
+    try:
+        rate = args.rate
+    except AttributeError:
+        pass
+    else:
+        l.effect_rate = rate
+    try:
+        brightness = args.brightness
+    except AttributeError:
+        pass
+    else:
+        l.brightness = brightness
 
-    profile = subs.add_parser("show-profile", help="Show profile information")
-    profile.add_argument("device", metavar="event0", help="The device node")
-    profile.add_argument("profile", metavar="0", help="The profile index", type=int)
-    profile.set_defaults(func=show_profile)
 
-    resolution = subs.add_parser("show-resolution", help="Show resolution information")
-    resolution.add_argument("device", metavar="event0", help="The device node")
-    resolution.add_argument("profile", metavar="0", help="The profile index", type=int)
-    resolution.add_argument("resolution", metavar="0", help="The resolution index", type=int)
-    resolution.set_defaults(func=show_resolution)
+def func_led_get_all(r, args):
+    p, d = find_profile(r, args)
+    for l in p.leds:
+        print_led(d, p, l, 0)
 
-    button = subs.add_parser("show-button", help="Show button information")
-    button.add_argument("device", metavar="event0", help="The device node")
-    button.add_argument("profile", metavar="0", help="The profile index", type=int)
-    button.add_argument("button", metavar="0", help="The button index", type=int)
-    button.set_defaults(func=show_button)
 
-    return parser
+def func_button_get(r, args):
+    b, p, d = find_button(r, args)
+    print_button(b, p, b, 0)
+
+
+def func_button_action_set_button(r, args):
+    b, p, d = find_button(r, args)
+    b.button_mapping = args.target_button
+
+
+def func_button_count(r, args):
+    p, d = find_profile(r, args)
+    print(len(p.buttons))
+
+
+def func_dpi_get(r, args):
+    r, p, d = find_resolution(r, args)
+    if RatbagdResolution.CAP_SEPARATE_XY_RESOLUTION in r.capabilities:
+        print("{}x{}dpi".format(r.resolution[0], r.resolution[1]))
+    else:
+        print(r.resolution[0])
+
+
+def func_dpi_set(r, args):
+    r, p, d = find_resolution(r, args)
+    if RatbagdResolution.CAP_SEPARATE_XY_RESOLUTION in r.capabilities:
+        print(args)
+    else:
+        r.resolution = (args.dpi_n, args.dpi_n)
+
+
+def func_resolution_get(r, args):
+    r, p, d = find_resolution(r, args)
+    print_resolution(d, p, r, 0)
+
+
+def func_resolution_active_get(r, args):
+    p, d = find_profile(r, args)
+    print(p.active_resolution.index)
+
+
+def func_profile_get(r, args):
+    p, d = find_profile(r, args)
+    print_profile(d, p, 0)
+
+
+def func_profile_active_get(r, args):
+    d = find_device(r, args)
+    print(d.active_profile.index)
+
+
+def func_profile_active_set(r, args):
+    p, d = find_profile(r, args)
+    p.set_active()
+
+
+def func_dummy(r, args):
+    print("uh, oh, not implemented")
+    pr_debug(args, r, args)
+
+
+################################################################################
+# these are definitions to be reused in the dict that defines our language
+
+# key elements
+"""the type of the element (see 'types' below)"""
+of_type = 'type'
+"""the name of the element, it'll be the one matching the args on the CLI"""
+name = 'name'
+"""list of positional arguments for the given command"""
+pos_args = 'pos_args'
+"""a tag that we can refer latrer in an element of type 'link'"""
+tag = 'tag'
+"""the element pointed to in an element of type 'link'"""
+dest = 'dest'
+"""the function to associate to the switch or command"""
+func = 'func'
+"""this is a particular command that is an integer, but not an terminating argument.
+example:
+ profile active get
+ profile **2** button 3 get
+ - "profile" needs to be a switch
+ - "2" needs to be translated as a N_access, given it is a requirement to be able to call 'button'
+ """
+N_access = 'N_access'
+
+# argparse.add_argument parameters (forwarded as such)
+"""'type' of the argument"""
+arg_type = 'arg_type'
+"""'metavar' of the argument"""
+metavar = 'metavar'
+"""'help' of the argument"""
+help_str = 'help'
+"""'nargs' of the argument"""
+nargs = 'nargs'
+"""'choices' of the argument"""
+choices = 'choices'
+
+# types
+"""an option to interprete as a command (example 'list', 'info')"""
+command = 'command'
+"""an argument that is required for the given command arguments are leaf nodes
+and can not have children
+"""
+argument = 'argument'
+"""provides a list of choice of commands for instance, a switch of [A, B] means
+we can have A or B only when parsing the command line
+"""
+switch = 'switch'
+"""same as list, except we can loop inside the list for instance, a set of
+[A, B] means we can have A and B (and A, ...) one after the other, no matter
+the order
+"""
+set = 'set'
+"""a reference to any other element in the tree marked with a tag"""
+link = 'link'
+
+################################################################################
+
+
+def color(string):
+    try:
+        int_value = int(string, 16)
+    except ValueError:
+        msg = "%r is not a color in hex format" % string
+        raise argparse.ArgumentTypeError(msg)
+    r = (int_value >> 16) & 0xff
+    g = (int_value >> 8) & 0xff
+    b = (int_value >> 0) & 0xff
+    return (r, g, b)
+
+
+def u8(string):
+    int_value = int(string)
+    msg = "%r is not a single byte" % string
+    if int_value < 0 or int_value > 255:
+        raise argparse.ArgumentTypeError(msg)
+    return int_value
+
+# note: 'eventX' is assumed at the end of each command
+parser_def = [
+    {
+        of_type: command,
+        name: 'list',
+        help_str: 'List available configurable devices',
+        func: list_devices,
+    },
+    {
+        of_type: command,
+        name: 'info',
+        help_str: 'Show device information',
+        func: show_device,
+    },
+    {
+        of_type: switch,
+        name: 'profile',
+        help_str: 'Access profile information',
+        tag: 'profile',
+        switch: [
+            {
+                of_type: switch,
+                name: 'active',
+                help_str: 'access active profile information',
+                switch: [
+                    {
+                        of_type: command,
+                        name: 'get',
+                        help_str: 'Show current active profile',
+                        func: func_profile_active_get,
+                    },
+                    {
+                        of_type: command,
+                        name: 'set',
+                        help_str: 'Set current active profile',
+                        pos_args: [
+                            {
+                                of_type: argument,
+                                name: 'profile_n',
+                                metavar: 'N',
+                                help_str: 'The profile to set as current',
+                                arg_type: int,
+                            },
+                        ],
+                        func: func_profile_active_set,
+                    },
+                ],
+            },
+            {
+                of_type: command,
+                name: 'enable',
+                help_str: 'Enable a profile',
+                pos_args: [
+                    {
+                        of_type: argument,
+                        name: 'profile_n',
+                        metavar: 'N',
+                        help_str: 'The profile to enable',
+                        arg_type: int,
+                    },
+                ],
+                func: func_dummy,  # FIXME: func_profile_enable,
+            },
+            {
+                of_type: command,
+                name: 'disable',
+                help_str: 'Disable a profile',
+                pos_args: [
+                    {
+                        of_type: argument,
+                        name: 'profile_n',
+                        metavar: 'N',
+                        help_str: 'The profile to disable',
+                        arg_type: int,
+                    },
+                ],
+                func: func_dummy,  # FIXME: func_profile_disable,
+            },
+        ],
+        N_access: {
+            of_type: N_access,
+            name: 'profile_n',
+            metavar: 'N',
+            help_str: 'The profile to act on',
+            switch: [
+                {
+                    of_type: command,
+                    name: 'get',
+                    help_str: 'Show current active profile',
+                    func: func_profile_get,
+                },
+                {
+                    of_type: link,
+                    dest: 'resolution',
+                },
+                {
+                    of_type: link,
+                    dest: 'dpi',
+                },
+                {
+                    of_type: link,
+                    dest: 'button',
+                },
+                {
+                    of_type: link,
+                    dest: 'led',
+                },
+            ],
+        },
+    },
+    {
+        of_type: switch,
+        name: 'resolution',
+        help_str: 'Access resolution information',
+        tag: 'resolution',
+        switch: [
+            {
+                of_type: switch,
+                name: 'active',
+                help_str: 'access active resolution information',
+                switch: [
+                    {
+                        of_type: command,
+                        name: 'get',
+                        help_str: 'Show current active resolution',
+                        func: func_resolution_active_get,
+                    },
+                    {
+                        of_type: command,
+                        name: 'set',
+                        help_str: 'Set current active resolution',
+                        pos_args: [
+                            {
+                                of_type: argument,
+                                name: 'resolution_n',
+                                metavar: 'N',
+                                help_str: 'The resolution to set as current',
+                                arg_type: int,
+                            },
+                        ],
+                        func: func_dummy,  # FIXME: func_active_resolution_set,
+                    },
+                ],
+            },
+        ],
+        N_access: {
+            of_type: N_access,
+            name: 'resolution_n',
+            metavar: 'N',
+            help_str: 'The resolution to act on',
+            switch: [
+                {
+                    of_type: command,
+                    name: 'get',
+                    help_str: 'Show selected resolution',
+                    func: func_resolution_get,
+                },
+                {
+                    of_type: link,
+                    dest: 'dpi',
+                },
+            ],
+        },
+    },
+    {
+        of_type: switch,
+        name: 'dpi',
+        help_str: 'Access DPI information',
+        tag: 'dpi',
+        switch: [
+            {
+                of_type: command,
+                name: 'get',
+                help_str: 'Show current DPI value',
+                func: func_dpi_get,
+            },
+            {
+                of_type: command,
+                name: 'set',
+                help_str: 'Set the DPI value to N',
+                pos_args: [
+                    {
+                        of_type: argument,
+                        name: 'dpi_n',
+                        metavar: 'N',
+                        help_str: 'The resolution to set as current',
+                        arg_type: int,
+                    },
+                ],
+                func: func_dpi_set,
+            },
+        ],
+    },
+    {
+        of_type: switch,
+        name: 'button',
+        help_str: 'Access Button information',
+        tag: 'button',
+        switch: [
+            {
+                of_type: command,
+                name: 'count',
+                help_str: 'Print the number of buttons',
+                func: func_button_count,
+            },
+        ],
+        N_access: {
+            of_type: N_access,
+            name: 'button_n',
+            metavar: 'N',
+            help_str: 'The button to act on',
+            switch: [
+                {
+                    of_type: command,
+                    name: 'get',
+                    help_str: 'Show selected button',
+                    func: func_button_get,
+                },
+                {
+                    of_type: switch,
+                    name: 'action',
+                    help_str: 'Act on the selected button',
+                    switch: [
+                        {
+                            of_type: command,
+                            name: 'get',
+                            help_str: 'Print the button action',
+                            func: func_button_get,
+                        },
+                        {
+                            of_type: switch,
+                            name: 'set',
+                            help_str: 'Set an action on the selected button',
+                            switch: [
+                                {
+                                    of_type: command,
+                                    name: 'button',
+                                    help_str: 'Set the button action to button B',
+                                    pos_args: [
+                                        {
+                                            of_type: argument,
+                                            name: 'target_button',
+                                            metavar: 'B',
+                                            help_str: 'The new buton value to assign',
+                                            arg_type: int,
+                                        },
+                                    ],
+                                    func: func_button_action_set_button,
+                                },
+                                {
+                                    of_type: command,
+                                    name: 'special',
+                                    help_str: 'Set the button action to special action S',
+                                    pos_args: [
+                                        {
+                                            of_type: argument,
+                                            name: 'target_special',
+                                            metavar: 'S',
+                                            help_str: 'The new special value to assign',
+                                        },
+                                    ],
+                                    func: func_dummy,  # FIXME: func_button_action_set_special,
+                                },
+                                {
+                                    of_type: command,
+                                    name: 'macro',
+                                    help_str: 'Set the button action to the given macro',
+                                    pos_args: [
+                                        {
+                                            of_type: argument,
+                                            name: 'target_macro',
+                                            metavar: 'macro',
+                                            help_str: 'The new macro to assign',
+                                            nargs: argparse.REMAINDER,
+                                        },
+                                    ],
+                                    func: func_dummy,  # FIXME: func_button_action_set_macro,
+                                },
+                            ]
+                        },
+                    ]
+                },
+            ],
+        },
+    },
+    {
+        of_type: switch,
+        name: 'led',
+        help_str: 'Access LED information',
+        tag: 'led',
+        switch: [
+            {
+                of_type: command,
+                name: 'get',
+                help_str: 'Show current LED value',
+                func: func_led_get_all,
+            },
+        ],
+        N_access: {
+            of_type: N_access,
+            name: 'led_n',
+            metavar: 'N',
+            help_str: 'The LED to act on',
+            switch: [
+                {
+                    of_type: command,
+                    name: 'get',
+                    help_str: 'Show current LED value',
+                    func: func_led_get,
+                },
+                {
+                    of_type: set,
+                    name: 'set',
+                    help_str: 'Act on the selected LED',
+                    switch: [
+                        {
+                            of_type: command,
+                            name: 'mode',
+                            help_str: 'The mode to set as current',
+                            pos_args: [
+                                {
+                                    of_type: argument,
+                                    name: 'mode',
+                                    metavar: 'mode',
+                                    help_str: 'The mode to set as current',
+                                    choices: ['on', 'off', 'cycle', 'breathing'],
+                                },
+                            ],
+                        },
+                        {
+                            of_type: command,
+                            name: 'color',
+                            help_str: 'The color to set as current',
+                            pos_args: [
+                                {
+                                    of_type: argument,
+                                    name: 'color',
+                                    metavar: 'RRGGBB',
+                                    help_str: 'The color in hex format to set as current',
+                                    arg_type: color,
+                                },
+                            ],
+                        },
+                        {
+                            of_type: command,
+                            name: 'rate',
+                            help_str: 'The rate to set as current',
+                            pos_args: [
+                                {
+                                    of_type: argument,
+                                    name: 'rate',
+                                    metavar: 'rate',
+                                    help_str: 'The rate in Hz to set as current',
+                                    arg_type: int,
+                                },
+                            ],
+                        },
+                        {
+                            of_type: command,
+                            name: 'brightness',
+                            help_str: 'The brightness to set as current',
+                            pos_args: [
+                                {
+                                    of_type: argument,
+                                    name: 'brightness',
+                                    metavar: 'brightness',
+                                    help_str: 'The brightness to set as current',
+                                    arg_type: u8,
+                                },
+                            ],
+                        },
+                    ],
+                    func: func_led_set,
+                },
+            ],
+        },
+    },
+]
+
+
+def pr_debug(ns, *args):
+    try:
+        if ns.verbose > 2:
+            print(*args)
+    except AttributeError:
+        print(ns)
+
+
+class ParseError(Exception):
+    pass
+
+
+class RatbagParser(object):
+    tagged = {}
+
+    def __init__(self, type, name, tag=None, func=None, help=None):
+        self.type = type
+        self.name = name
+        self.tag = tag
+        if tag is not None:
+            RatbagParser.tagged[tag] = self
+        self.func = func
+        self.help = help
+
+    def repr_args(self):
+        return "name='{}', tag='{}', func='{}', help='{}'".format(self.name, self.tag, self.func, self.help)
+
+    def __repr__(self):
+        return "{}({})".format(type(self), self.repr_args())
+
+    def store_function(self, parser):
+        if self.func is not None:
+            parser.set_defaults(func=self.func)
+            if 'list' not in self.name:
+                parser.add_argument("device", metavar='eventX')
+
+    def _parse(self, parent, input_string, ns):
+        raise ParseError("please implement _parse on {}".format(type(self)))
+
+    def parse(self, parent, input_string, ns):
+        pr_debug(ns, ">>> {}: {} | {}".format(self.type, self.name, input_string))
+        self._parse(parent, input_string, ns)
+        pr_debug(ns, "<<< {}: {} | {}".format(self.type, self.name, input_string))
+
+    def _sub_parse(self, input_string, ns):
+        raise ParseError("please implement _sub_parse on {}".format(type(self)))
+
+    def sub_parse(self, input_string, ns):
+        pr_debug(ns, ">.. {}: {} | {}".format(self.type, self.name, input_string))
+        r = self._sub_parse(input_string, ns)
+        pr_debug(ns, "<.. {}: {} | {}".format(self.type, self.name, input_string))
+        return r
+
+    def print_help(self):
+        return str(type(self))
+
+    def build_cmd_args_name(self):
+        """uniquely tag the arguments of the command in the namespace"""
+        return "{}_args_{}".format(self.name)
+
+
+class RatbagParserSwitch(RatbagParser):
+    def __init__(self, type, name, switch=[], N_access=None, tag=None, func=None, help=None):
+        super(RatbagParserSwitch, self).__init__(type, name, tag, func, help)
+        self.switch = [classes[obj[of_type]](**obj) for obj in switch]
+        if N_access is not None:
+            self.N_access = RatbagParserNAccess(**N_access)
+        else:
+            self.N_access = None
+
+    def repr_args(self):
+        return """switch='{}', N_access='{}', {}""".format([repr(o) for o in self.switch], self.N_access, RatbagParser.repr_args(self))
+
+    def _parse(self, parent, input_string, ns):
+        parser = parent.add_parser(self.name, help=self.help)
+        parser.set_defaults(subparse=self.sub_parse)
+
+    def _sub_parse(self, input_string, ns):
+        if len(input_string) >= 0 and self.N_access is not None:
+            # retrieve first numbered element if any
+            try:
+                int(input_string[0])
+            except ValueError:
+                # there are arguments, but they look like commands
+                pass
+            else:
+                # we have a single int as first argument, switch to the
+                # N_access subtree of the command
+                return self.N_access.sub_parse(input_string, ns)
+
+        parser = argparse.ArgumentParser()
+
+        # create a new subparser to handle all commands
+        subs = parser.add_subparsers(title="COMMANDS", help=None)
+        for e in self.switch:
+            e.parse(subs, input_string, ns)
+
+        return parser
+
+    def __repr__(self):
+        return "switch({})".format(self.repr_args())
+
+
+class RatbagParserNAccess(RatbagParserSwitch):
+    def __init__(self, type, name, switch=[], metavar=None, tag=None, func=None, help=None):
+        super(RatbagParserNAccess, self).__init__(type, name, switch, None, tag, func, help)
+        self.metavar = metavar
+
+    def _sub_parse(self, input_string, ns):
+        parser = argparse.ArgumentParser()
+        parser.add_argument(self.name, help=self.help, type=int)
+        # create a new subparser to handle all commands
+        subs = parser.add_subparsers(title="COMMANDS", help=None)
+        for e in self.switch:
+            e.parse(subs, input_string, ns)
+        return parser
+
+    def repr_args(self):
+        return """switch='{}', metavar = '{}', {}""".format([repr(o) for o in self.switch], self.metavar, RatbagParser.repr_args(self))
+
+    def __repr__(self):
+        return "N_Access({})".format(self.repr_args())
+
+
+class RatbagParserSet(RatbagParserSwitch):
+    def __init__(self, type, name, switch=[], N_access=None, tag=None, func=None, help=None):
+        super(RatbagParserSet, self).__init__(type, name, switch, N_access, tag, func, help)
+
+    def _parse(self, parent, input_string, ns):
+        parser = parent.add_parser(self.name, help=self.help)
+        parser.set_defaults(subparse=self.sub_parse)
+
+    def _sub_parse(self, input_string, ns):
+        parser = argparse.ArgumentParser()
+        # create a new subparser to handle all commands
+        subs = parser.add_subparsers(title="COMMANDS", help=None)
+        for e in self.switch:
+            e.parse(subs, input_string, ns)
+        if len(input_string) == 3:
+            self.store_function(parser)
+        else:
+            parser.set_defaults(subparse=self.sub_parse)
+        return parser
+
+    def __repr__(self):
+        return "set({})".format(self.repr_args())
+
+
+class RatbagParserCommand(RatbagParser):
+    def __init__(self, type, name, pos_args=[], tag=None, func=None, help=None):
+        super(RatbagParserCommand, self).__init__(type, name, tag, func, help)
+        self.pos_args = [classes[obj[of_type]](**obj) for obj in pos_args]
+
+    def _parse(self, parent, input_string, ns):
+        parser = parent.add_parser(self.name, help=self.help)
+        for a in self.pos_args:
+            a.parse(parser, input_string, ns)
+        self.store_function(parser)
+
+    def __repr__(self):
+        return "command({})".format(self.repr_args())
+
+
+class RatbagParserArgument(RatbagParser):
+    def __init__(self, type, name, arg_type=None, metavar=None, nargs=None, choices=None, tag=None, func=None, help=None):
+        super(RatbagParserArgument, self).__init__(type, name, tag, func, help)
+        self.arg_type = arg_type
+        self.metavar = metavar
+        self.nargs = nargs
+        self.choices = choices
+
+    def _parse(self, parent, input_string, ns):
+        parent.add_argument(self.name, metavar=self.metavar, help=self.help, type=self.arg_type, nargs=self.nargs, choices=self.choices)
+
+
+class RatbagParserLink(RatbagParser):
+    def __init__(self, type, dest=None, tag=None, func=None, help=None):
+        super(RatbagParserLink, self).__init__(type, dest, tag, func, help)
+        self.dest = dest
+
+    def _parse(self, parent, input_string, ns):
+        try:
+            e = RatbagParser.tagged[self.dest]
+        except KeyError:
+            raise ParseError("link '{}' points to nothing".format(self.dest))
+        else:
+            e.parse(parent, input_string, ns)
+
+classes = {
+    switch: RatbagParserSwitch,
+    set: RatbagParserSet,
+    command: RatbagParserCommand,
+    argument: RatbagParserArgument,
+    link: RatbagParserLink,
+    N_access: RatbagParserNAccess,
+}
+
+
+class RatbagParserRoot(object):
+    def __init__(self, commands):
+        self.children = [classes[def_parser[of_type]](**def_parser) for def_parser in commands]
+
+    def parse(self, input_string):
+        # we do not care about case, use lower case for the input string
+        for i, string in enumerate(input_string):
+            if not string.startswith('-'):
+                input_string[i] = string.lower()
+
+        self.parser = argparse.ArgumentParser(description="Inspect and modify configurable mice")
+        self.parser.add_argument("-V", "--version", action="version", version="@version@")
+        self.parser.add_argument('--verbose', '-v', action='count', default=0)
+
+        ns, rest = self.parser.parse_known_args(input_string)
+
+        subs = self.parser.add_subparsers(title="COMMANDS", help='sub-command help')
+
+        subparser = self.parser
+        rest = input_string
+
+        for child in self.children:
+            child.parse(subs, input_string, ns)
+
+        while subparser:
+            ns, rest = subparser.parse_known_args(rest, namespace=ns)
+            if not rest:
+                break
+            pr_debug(ns, ns, rest)
+            try:
+                subparse_call = ns.subparse
+            except AttributeError:
+                break
+            else:
+                subparser = subparse_call(rest, ns)
+
+        if rest:
+            self.parser.error("extra arguments: '{}'".format(" ".join(rest)))
+
+        return ns
+
+    def print_help(self):
+        self.parser.print_help()
 
 
 def main(argv):
     if not argv:
-        argv = ["list-devices"]
-    cmd = make_parser().parse_args(argv)
+        argv = ["list"]
+
+    parser = RatbagParserRoot(parser_def)
+    cmd = parser.parse(argv)
 
     try:
         r = Ratbagd()

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -594,20 +594,23 @@ class RatbagdLed(_RatbagdDBus):
         """
         return self._dbus_call("SetBrightness", "u", brightness)
 
+
 def list_devices(r, args):
     for d in r.devices:
         print("{:10s} {:32s}".format(d.id + ":", d.name))
+
 
 def find_device(r, args):
     dev = None
     for d in r.devices:
         if d.id == args.device:
             dev = d
-            break;
+            break
     if dev is None:
         print("Unable to find device {}".format(args.device))
         sys.exit(1)
     return dev
+
 
 def find_profile(r, args):
     d = find_device(r, args)
@@ -618,6 +621,7 @@ def find_profile(r, args):
         sys.exit(1)
     return p, d
 
+
 def find_resolution(r, args):
     p, d = find_profile(r, args)
     try:
@@ -626,6 +630,7 @@ def find_resolution(r, args):
         print("Invalid resolution index {}".format(args.resolution))
         sys.exit(1)
     return r, p, d
+
 
 def find_button(r, args):
     p, d = find_profile(r, args)
@@ -636,18 +641,18 @@ def find_button(r, args):
         sys.exit(1)
     return b, p, d
 
+
 def show_device(r, args):
     d = find_device(r, args)
 
-
-    caps = { RatbagdDevice.CAP_SWITCHABLE_RESOLUTION : "switchable-resolution",
-             RatbagdDevice.CAP_SWITCHABLE_PROFILE : "switchable-profile",
-             RatbagdDevice.CAP_BUTTON_KEY : "button-keys",
-             RatbagdDevice.CAP_BUTTON_MACROS : "button-macros",
-             RatbagdDevice.CAP_DEFAULT_PROFILE : "default-profile",
-             RatbagdDevice.CAP_QUERY_CONFIGURATION : "query-configuration",
-             RatbagdDevice.CAP_DISABLE_PROFILE : "disable-profile",
-             RatbagdDevice.CAP_LED : "led" }
+    caps = {RatbagdDevice.CAP_SWITCHABLE_RESOLUTION: "switchable-resolution",
+            RatbagdDevice.CAP_SWITCHABLE_PROFILE: "switchable-profile",
+            RatbagdDevice.CAP_BUTTON_KEY: "button-keys",
+            RatbagdDevice.CAP_BUTTON_MACROS: "button-macros",
+            RatbagdDevice.CAP_DEFAULT_PROFILE: "default-profile",
+            RatbagdDevice.CAP_QUERY_CONFIGURATION: "query-configuration",
+            RatbagdDevice.CAP_DISABLE_PROFILE: "disable-profile",
+            RatbagdDevice.CAP_LED: "led"}
     capabilities = [caps[c] for c in d.capabilities]
 
     print("{} - {}".format(d.id, d.name))
@@ -660,6 +665,7 @@ def show_device(r, args):
             active = i
             break
     print("    Active Profile: {}".format(active))
+
 
 def show_profile(r, args):
     p, d = find_profile(r, args)
@@ -677,6 +683,7 @@ def show_profile(r, args):
     print("    Active Resolution: {}".format(active))
     print("   Default Resolution: {}".format(default))
 
+
 def show_resolution(r, args):
     r, p, d = find_resolution(r, args)
 
@@ -690,11 +697,11 @@ def show_resolution(r, args):
     else:
         print("    Resolution: {}dpi".format(r.resolution[0]))
 
-
-    caps = { RatbagdResolution.CAP_INDIVIDUAL_REPORT_RATE : "individual-report-rate",
-             RatbagdResolution.CAP_SEPARATE_XY_RESOLUTION : "separate-xy-resolution" }
+    caps = {RatbagdResolution.CAP_INDIVIDUAL_REPORT_RATE: "individual-report-rate",
+            RatbagdResolution.CAP_SEPARATE_XY_RESOLUTION: "separate-xy-resolution"}
     capabilities = [caps[c] for c in r.capabilities]
     print("  Capabilities: {}".format(", ".join(capabilities)))
+
 
 def show_button(r, args):
     b, p, d = find_button(r, args)
@@ -713,6 +720,7 @@ def show_button(r, args):
         print("    Key Mapping: {}".format(b.key))
     elif b.action_type == "special":
         print("Special Mapping: {}".format(b.special))
+
 
 def make_parser():
     parser = argparse.ArgumentParser(description="Inspect and modify configurable mice")
@@ -744,6 +752,7 @@ def make_parser():
     button.set_defaults(func=show_button)
 
     return parser
+
 
 def main(argv):
     if not argv:

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -2,8 +2,6 @@
 #
 # vim: set expandtab shiftwidth=4 tabstop=4:
 #
-# This file is part of ratbagd.
-#
 # Copyright 2016 Red Hat, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -25,11 +23,39 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-from gi.repository import Gio, GLib, GObject
-
 import os
 import sys
 import argparse
+
+from enum import IntEnum
+from gi.repository import Gio, GLib, GObject
+
+
+class RatbagErrorCode(IntEnum):
+    RATBAG_SUCCESS = 0
+
+    """An error occured on the device. Either the device is not a libratbag
+    device or communication with the device failed."""
+    RATBAG_ERROR_DEVICE = -1000
+
+    """Insufficient capabilities. This error occurs when a requested change is
+    beyond the device's capabilities."""
+    RATBAG_ERROR_CAPABILITY = -1001
+
+    """Invalid value or value range. The provided value or value range is
+    outside of the legal or supported range."""
+    RATBAG_ERROR_VALUE = -1002
+
+    """A low-level system error has occured, e.g. a failure to access files
+    that should be there. This error is usually unrecoverable and libratbag will
+    print a log message with details about the error."""
+    RATBAG_ERROR_SYSTEM = -1003
+
+    """Implementation bug, either in libratbag or in the caller. This error is
+    usually unrecoverable and libratbag will print a log message with details
+    about the error."""
+    RATBAG_ERROR_IMPLEMENTATION = -1004
+
 
 class RatbagdDBusUnavailable(BaseException):
     """Signals DBus is unavailable or the ratbagd daemon is not available."""
@@ -62,25 +88,31 @@ class _RatbagdDBus(GObject.GObject):
                                                  object_path,
                                                  "{}.{}".format(ratbag1, interface),
                                                  None)
-        except GLib.GError:
+        except GLib.Error:
             raise RatbagdDBusUnavailable()
 
         if self._proxy.get_name_owner() is None:
             raise RatbagdDBusUnavailable()
 
-    def dbus_property(self, property):
+    def _dbus_property(self, property):
+        # Retrieves a cached property from the bus, or None.
         p = self._proxy.get_cached_property(property)
         if p is not None:
             return p.unpack()
         return p
 
-    def dbus_call(self, method, type, *value):
+    def _dbus_call(self, method, type, *value):
+        # Calls a method synchronously on the bus, using the given method name,
+        # type signature and values. Returns the returned result, or None.
         val = GLib.Variant("({})".format(type), value)
-        res = self._proxy.call_sync(method, val,
-                                    Gio.DBusCallFlags.NO_AUTO_START, 500, None)
-        if res is not None:
-            return res.unpack()
-        return res
+        try:
+            res = self._proxy.call_sync(method, val,
+                                        Gio.DBusCallFlags.NO_AUTO_START,
+                                        500, None)
+            return res.unpack()[0]  # Result is always a tuple
+        except GLib.Error as e:
+            print(e.message, file=sys.stderr)
+            return None
 
 
 class Ratbagd(_RatbagdDBus):
@@ -102,9 +134,10 @@ class Ratbagd(_RatbagdDBus):
         _RatbagdDBus.__init__(self, "Manager", None)
         self._proxy.connect("g-signal", self._on_g_signal)
         self._devices = []
-        result = self.dbus_property("Devices")
+        result = self._dbus_property("Devices")
         if result is not None:
             self._devices = [RatbagdDevice(objpath) for objpath in result]
+        self._themes = self._dbus_property("Themes")
 
     def _on_g_signal(self, proxy, sender, signal, params):
         params = params.unpack()
@@ -117,6 +150,12 @@ class Ratbagd(_RatbagdDBus):
     def devices(self):
         """A list of RatbagdDevice objects supported by ratbagd."""
         return self._devices
+
+    @GObject.Property
+    def themes(self):
+        """A list of theme names. The theme 'default' is guaranteed to be
+        available."""
+        return self._themes
 
 
 class RatbagdDevice(_RatbagdDBus):
@@ -138,18 +177,16 @@ class RatbagdDevice(_RatbagdDBus):
     def __init__(self, object_path):
         _RatbagdDBus.__init__(self, "Device", object_path)
         self._objpath = object_path
-        self._devnode = self.dbus_property("Id")
-        self._caps = self.dbus_property("Capabilities")
-        self._name = self.dbus_property("Name")
-        self._svg = self.dbus_property("Svg")
-        self._svg_path = self.dbus_property("SvgPath")
+        self._devnode = self._dbus_property("Id")
+        self._caps = self._dbus_property("Capabilities")
+        self._name = self._dbus_property("Name")
 
         self._profiles = []
         self._active_profile = -1
-        result = self.dbus_property("Profiles")
+        result = self._dbus_property("Profiles")
         if result is not None:
             self._profiles = [RatbagdProfile(objpath) for objpath in result]
-            self._active_profile = self.dbus_property("ActiveProfile")
+            self._active_profile = self._dbus_property("ActiveProfile")
 
     @GObject.Property
     def id(self):
@@ -172,17 +209,6 @@ class RatbagdDevice(_RatbagdDBus):
         return self._name
 
     @GObject.Property
-    def svg(self):
-        """The SVG file name. This function returns the file name only, not the
-        absolute path to the file."""
-        return self._svg
-
-    @GObject.Property
-    def svg_path(self):
-        """The full, absolute path to the SVG."""
-        return self._svg_path
-
-    @GObject.Property
     def profiles(self):
         """A list of RatbagdProfile objects provided by this device."""
         return self._profiles
@@ -195,13 +221,28 @@ class RatbagdDevice(_RatbagdDBus):
             return None
         return self._profiles[self._active_profile]
 
+    def get_svg(self, theme):
+        """Gets the full path to the SVG for the given theme, or the empty
+        string if none is available.
+
+        The theme must be one of org.freedesktop.ratbag1.Manager.Themes. The
+        theme 'default' is guaranteed to be available.
+
+        @param theme The theme from which to retrieve the SVG, as str
+        """
+        return self._dbus_call("GetSvg", "s", theme)
+
     def get_profile_by_index(self, index):
         """Returns the profile found at the given index, or None if no profile
         was found.
 
         @param index The index to find the profile at, as int
         """
-        return self.dbus_call("GetProfileByIndex", "u", index)
+        return self._dbus_call("GetProfileByIndex", "u", index)
+
+    def commit(self):
+        """Commits all changes made to the device."""
+        return self._dbus_call("Commit", "")
 
     def __eq__(self, other):
         return other and self._objpath == other._objpath
@@ -219,24 +260,24 @@ class RatbagdProfile(_RatbagdDBus):
         _RatbagdDBus.__init__(self, "Profile", object_path)
         self._proxy.connect("g-signal", self._on_g_signal)
         self._objpath = object_path
-        self._index = self.dbus_property("Index")
+        self._index = self._dbus_property("Index")
         self._resolutions = []
         self._buttons = []
         self._leds = []
         self._active_resolution_index = -1
         self._default_resolution_index = -1
 
-        result = self.dbus_property("Resolutions")
+        result = self._dbus_property("Resolutions")
         if result is not None:
             self._resolutions = [RatbagdResolution(objpath) for objpath in result]
-            self._active_resolution_index = self.dbus_property("ActiveResolution")
-            self._default_resolution_index = self.dbus_property("DefaultResolution")
+            self._active_resolution_index = self._dbus_property("ActiveResolution")
+            self._default_resolution_index = self._dbus_property("DefaultResolution")
 
-        result = self.dbus_property("Buttons")
+        result = self._dbus_property("Buttons")
         if result is not None:
             self._buttons = [RatbagdButton(objpath) for objpath in result]
 
-        result = self.dbus_property("Leds")
+        result = self._dbus_property("Leds")
         if result is not None:
             self._leds = [RatbagdLed(objpath) for objpath in result]
 
@@ -286,12 +327,12 @@ class RatbagdProfile(_RatbagdDBus):
 
     def set_active(self):
         """Set this profile to be the active profile."""
-        return self.dbus_call("SetActive", "")
+        return self._dbus_call("SetActive", "")
 
     def get_resolution_by_index(self, index):
         """Returns the resolution found at the given index. This function
         returns a RatbagdResolution or None if no resolution was found."""
-        return self.dbus_call("GetResolutionByIndex", "u", index)
+        return self._dbus_call("GetResolutionByIndex", "u", index)
 
     def __eq__(self, other):
         return self._objpath == other._objpath
@@ -314,13 +355,13 @@ class RatbagdResolution(_RatbagdDBus):
         _RatbagdDBus.__init__(self, "Resolution", object_path)
         self._proxy.connect("g-signal", self._on_g_signal)
         self._objpath = object_path
-        self._index = self.dbus_property("Index")
-        self._caps = self.dbus_property("Capabilities")
-        self._xres = self.dbus_property("XResolution")
-        self._yres = self.dbus_property("YResolution")
-        self._rate = self.dbus_property("ReportRate")
-        self._max_res = self.dbus_property("Maximum")
-        self._min_res = self.dbus_property("Minimum")
+        self._index = self._dbus_property("Index")
+        self._caps = self._dbus_property("Capabilities")
+        self._xres = self._dbus_property("XResolution")
+        self._yres = self._dbus_property("YResolution")
+        self._rate = self._dbus_property("ReportRate")
+        self._max_res = self._dbus_property("Maximum")
+        self._min_res = self._dbus_property("Minimum")
 
     def _on_g_signal(self, proxy, sender, signal, params):
         params = params.unpack()
@@ -347,7 +388,7 @@ class RatbagdResolution(_RatbagdDBus):
     @GObject.Property
     def resolution(self):
         """The tuple (xres, yres) with each resolution in DPI."""
-        return (self._xres, self._yres)
+        return self._xres, self._yres
 
     @resolution.setter
     def resolution(self, res):
@@ -355,7 +396,7 @@ class RatbagdResolution(_RatbagdDBus):
 
         @param res The new resolution, as (int, int)
         """
-        return self.dbus_call("SetResolution", "uu", *res)
+        return self._dbus_call("SetResolution", "uu", *res)
 
     @GObject.Property
     def report_rate(self):
@@ -378,11 +419,11 @@ class RatbagdResolution(_RatbagdDBus):
 
         @param rate The new report rate, as int
         """
-        return self.dbus_call("SetReportRate", "u", rate)
+        return self._dbus_call("SetReportRate", "u", rate)
 
     def set_default(self):
         """Set this resolution to be the default."""
-        return self.dbus_call("SetDefault", "")
+        return self._dbus_call("SetDefault", "")
 
     def __eq__(self, other):
         return self._objpath == other._objpath
@@ -394,13 +435,13 @@ class RatbagdButton(_RatbagdDBus):
     def __init__(self, object_path):
         _RatbagdDBus.__init__(self, "Button", object_path)
         self._objpath = object_path
-        self._index = self.dbus_property("Index")
-        self._type = self.dbus_property("Type")
-        self._button = self.dbus_property("ButtonMapping")
-        self._special = self.dbus_property("SpecialMapping")
-        self._key = self.dbus_property("KeyMapping")
-        self._action = self.dbus_property("ActionType")
-        self._types = self.dbus_property("ActionTypes")
+        self._index = self._dbus_property("Index")
+        self._type = self._dbus_property("Type")
+        self._button = self._dbus_property("ButtonMapping")
+        self._special = self._dbus_property("SpecialMapping")
+        self._key = self._dbus_property("KeyMapping")
+        self._action = self._dbus_property("ActionType")
+        self._types = self._dbus_property("ActionTypes")
 
     @GObject.Property
     def index(self):
@@ -423,7 +464,7 @@ class RatbagdButton(_RatbagdDBus):
 
         @param button The button to map to, as int
         """
-        return self.dbus_call("SetButtonMapping", "u", button)
+        return self._dbus_call("SetButtonMapping", "u", button)
 
     @GObject.Property
     def special(self):
@@ -436,22 +477,22 @@ class RatbagdButton(_RatbagdDBus):
 
         @param special The special entry, as str
         """
-        return self.dbus_call("SetSpecialMapping", "s", special)
+        return self._dbus_call("SetSpecialMapping", "s", special)
 
     @GObject.Property
     def key(self):
-        """An array of integers, the first being the keycode and the other
+        """A list of integers, the first being the keycode and the other
         entries, if any, are modifiers (if mapped to key)."""
         return self._key
 
     @key.setter
-    def key(self, key, modifiers):
+    def key(self, keys):
         """Set the key mapping.
 
-        @param key The keycode, as int
-        @param modifiers Modifier keycodes, as [int]
+        @param keys A list of integers, the first being the keycode and the rest
+                    modifiers.
         """
-        return self.dbus_call("SetKeyMapping", "au", [key].append(modifiers))
+        return self._dbus_call("SetKeyMapping", "au", keys)
 
     @GObject.Property
     def action_type(self):
@@ -468,7 +509,7 @@ class RatbagdButton(_RatbagdDBus):
 
     def disable(self):
         """Disables this button."""
-        return self.dbus_call("Disable", "")
+        return self._dbus_call("Disable", "")
 
 
 class RatbagdLed(_RatbagdDBus):
@@ -482,12 +523,12 @@ class RatbagdLed(_RatbagdDBus):
     def __init__(self, object_path):
         _RatbagdDBus.__init__(self, "Led", object_path)
         self._objpath = object_path
-        self._index = self.dbus_property("Index")
-        self._mode = self.dbus_property("Mode")
-        self._type = self.dbus_property("Type")
-        self._color = self.dbus_property("Color")
-        self._effect_rate = self.dbus_property("EffectRate")
-        self._brightness = self.dbus_property("Brightness")
+        self._index = self._dbus_property("Index")
+        self._mode = self._dbus_property("Mode")
+        self._type = self._dbus_property("Type")
+        self._color = self._dbus_property("Color")
+        self._effect_rate = self._dbus_property("EffectRate")
+        self._brightness = self._dbus_property("Brightness")
 
     @GObject.Property
     def index(self):
@@ -507,7 +548,7 @@ class RatbagdLed(_RatbagdDBus):
         @param mode The new mode, as one of LED_MODE_OFF, LED_MODE_ON,
                                   LED_MODE_CYCLE and LED_MODE_BREATHING.
         """
-        return self.dbus_call("SetMode", "u", mode)
+        return self._dbus_call("SetMode", "u", mode)
 
     @GObject.Property
     def type(self):
@@ -523,9 +564,9 @@ class RatbagdLed(_RatbagdDBus):
     def color(self, color):
         """Set the led color to the given color.
 
-        @param color An RGB color, as an integer triplet.
+        @param color An RGB color, as an integer triplet with values 0-255.
         """
-        return self.dbus_call("SetColor", "(uuu)", color)
+        return self._dbus_call("SetColor", "(uuu)", color)
 
     @GObject.Property
     def effect_rate(self):
@@ -538,7 +579,7 @@ class RatbagdLed(_RatbagdDBus):
 
         @param effect_rate The new effect rate, as int
         """
-        return self.dbus_call("SetEffectRate", "u", effect_rate)
+        return self._dbus_call("SetEffectRate", "u", effect_rate)
 
     @GObject.Property
     def brightness(self):
@@ -551,7 +592,7 @@ class RatbagdLed(_RatbagdDBus):
 
         @param brightness The new brightness, as int
         """
-        return self.dbus_call("SetBrightness", "i", brightness)
+        return self._dbus_call("SetBrightness", "u", brightness)
 
 def list_devices(r, args):
     for d in r.devices:

--- a/tools/ratbagctl.test.in
+++ b/tools/ratbagctl.test.in
@@ -25,6 +25,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
+import imp
 import os
 import shutil
 import subprocess
@@ -38,7 +39,31 @@ DBUS_CONF_DIR = '/etc/dbus-1/system.d'
 DBUS_CONF_NAME = 'org.freedesktop.ratbag_devel1.conf'
 DBUS_CONF_PATH = os.path.join(DBUS_CONF_DIR, DBUS_CONF_NAME)
 
+
+def import_non_standard_path(name, path):
+    # Fast path: see if the module has already been imported.
+    try:
+        return sys.modules[name]
+    except KeyError:
+        pass
+
+    # If any of the following calls raises an exception,
+    # there's a problem we can't handle -- let the caller handle it.
+
+    with open(path, 'rb') as fp:
+        module = imp.load_module(name, fp, os.path.basename(path), ('.py', 'rb', imp.PY_SOURCE))
+
+    return module
+
+ratbagctl = import_non_standard_path(RATBAGCTL_NAME, RATBAGCTL_PATH)
+
+
 class TestRatbagCtl(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestRatbagCtl, cls).setUpClass()
+        cls.reset_test_device()
+
     @classmethod
     def run_ratbagctl(cls, params):
         ratbagctl = subprocess.Popen(" ".join([RATBAGCTL_PATH, params]),
@@ -51,6 +76,11 @@ class TestRatbagCtl(unittest.TestCase):
         return (ratbagctl.returncode,
                 stdout.decode('ascii').rstrip('\n'),
                 stderr.decode('ascii').rstrip('\n'))
+
+    @classmethod
+    def reset_test_device(cls):
+        global ratbagd
+        ratbagd._dbus_call("ResetTestDevice", "")
 
     def launch_good_test(self, params):
         returncode, stdout, stderr = self.run_ratbagctl(params)
@@ -392,13 +422,18 @@ class TestRatbgagCtlLED(TestRatbagCtl):
 
 
 def setUpModule():
-    global ratbagd_process
+    global ratbagd_process, ratbagd
     # first copy the policy for the ratbagd daemon to be allowed to run
     shutil.copy(os.path.join('@MESON_BUILD_ROOT@', DBUS_CONF_NAME), DBUS_CONF_PATH)
 
     # FIXME: kill any running ratabgd.devel
 
     ratbagd_process = subprocess.Popen([os.path.join('@MESON_BUILD_ROOT@', "ratbagd.devel")], shell=True)
+
+    os.environ['RATBAGCTL_DEVEL'] = "org.freedesktop.ratbag_devel1_@ratbagd_sha@"
+
+    ratbagd = ratbagctl.open_ratbagd()
+    assert ratbagd is not None
 
 
 def tearDownModule():

--- a/tools/ratbagctl.test.in
+++ b/tools/ratbagctl.test.in
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+#
+# vim: set expandtab shiftwidth=4 tabstop=4:
+#
+# This file is part of libratbag.
+#
+# Copyright 2017 Red Hat, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice (including the next
+# paragraph) shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+import os
+import shutil
+import subprocess
+import sys
+import unittest
+
+# various constants
+RATBAGCTL_NAME = 'ratbagctl'
+RATBAGCTL_PATH = os.path.join('@MESON_BUILD_ROOT@', RATBAGCTL_NAME)
+DBUS_CONF_DIR = '/etc/dbus-1/system.d'
+DBUS_CONF_NAME = 'org.freedesktop.ratbag_devel1.conf'
+DBUS_CONF_PATH = os.path.join(DBUS_CONF_DIR, DBUS_CONF_NAME)
+
+class TestRatbagCtl(unittest.TestCase):
+    @classmethod
+    def run_ratbagctl(cls, params):
+        ratbagctl = subprocess.Popen(" ".join([RATBAGCTL_PATH, params]),
+                                     stdout=subprocess.PIPE,
+                                     stderr=subprocess.PIPE,
+                                     shell=True,
+                                     env={"RATBAGCTL_DEVEL": "org.freedesktop.ratbag_devel1_@ratbagd_sha@"})
+
+        (stdout, stderr) = ratbagctl.communicate()
+        return (ratbagctl.returncode,
+                stdout.decode('ascii').rstrip('\n'),
+                stderr.decode('ascii').rstrip('\n'))
+
+    def launch_good_test(self, params):
+        returncode, stdout, stderr = self.run_ratbagctl(params)
+        self.assertEqual(returncode, 0)
+        return stdout
+
+    def launch_fail_test(self, params):
+        returncode, stdout, stderr = self.run_ratbagctl(params)
+        self.assertNotEqual(returncode, 0)
+        return stdout
+
+    @classmethod
+    def setProfile(cls, profile):
+        cls.run_ratbagctl("Profile active set {} test_device".format(profile))
+
+
+class TestRatbagCtlList(TestRatbagCtl):
+    def test_list(self):
+        r = self.launch_good_test("list")
+        self.assertIn('test_device', r)
+        self.launch_fail_test("list test_device")
+
+
+class TestRatbagCtlInfo(TestRatbagCtl):
+    def test_info(self):
+        self.launch_good_test("info test_device")
+        self.launch_fail_test("info test_device X")
+        self.launch_fail_test("info X")
+
+
+class TestRatbgagCtlProfile(TestRatbagCtl):
+    @classmethod
+    def setUpClass(cls):
+        super(TestRatbgagCtlProfile, cls).setUpClass()
+        cls.setProfile(0)
+
+    def test_profile_active_get(self):
+        command = "profile active get"
+        r = self.launch_good_test(command + " test_device")
+        self.assertEqual(int(r), 0)
+        self.launch_fail_test(command)
+        self.launch_fail_test(command + " X test_device")
+
+    def test_profile_active_set(self):
+        command = "profile active set"
+        r = self.launch_good_test(command + " 1 test_device")
+        self.assertEqual(r, '')
+        r = self.launch_good_test("profile active get test_device")
+        self.assertEqual(int(r), 1)
+        self.launch_fail_test(command)
+        self.launch_fail_test(command + " X test_device")
+        self.launch_fail_test(command + " 1 test_device X")
+
+    def test_profile_n(self):
+        r0 = self.launch_good_test("Profile 0 get test_device")
+        r1 = self.launch_good_test("Profile 1 get test_device")
+        self.assertNotEqual(r0, r1)
+        self.launch_fail_test("Profile 0 get")
+        self.launch_fail_test("Profile 0 test_device")
+        self.launch_fail_test("Profile 0 get test_device X")
+        self.launch_fail_test("Profile 10 get test_device")
+
+    @unittest.skip("profile doesn't show enabled/disabled")
+    def test_profile_enable(self):
+        command = "profile enable"
+        self.launch_good_test(command + " 1 test_device")
+        r = self.launch_good_test("profile 0 get test_device")
+        # FIXME: show when the profile is disabled in ratbagctl
+        self.assertNotIn('enabled', r)
+        r = self.launch_good_test("profile 1 get test_device")
+        self.assertIn('enabled', r)
+        self.launch_fail_test(command)
+        self.launch_fail_test(command + " X test_device")
+        self.launch_fail_test(command + " 1 test_device X")
+        self.launch_fail_test(command + " 10 test_device")
+
+    @unittest.skip("profile doesn't show enabled/disabled")
+    def test_profile_disable(self):
+        command = "profile disable"
+        self.launch_good_test(command + " 1 test_device")
+        r = self.launch_good_test("profile 0 get test_device")
+        # FIXME: show when the profile is disabled in ratbagctl
+        self.assertIn('enabled', r)
+        r = self.launch_good_test("profile 1 get test_device")
+        self.assertNotIn('enabled', r)
+        self.launch_fail_test(command)
+        self.launch_fail_test(command + " X test_device")
+        self.launch_fail_test(command + " 1 test_device X")
+        self.launch_fail_test(command + " 10 test_device")
+
+
+class TestRatbgagCtlResolution(TestRatbagCtl):
+    @classmethod
+    def setUpClass(cls):
+        super(TestRatbgagCtlResolution, cls).setUpClass()
+        cls.setProfile(1)
+
+    def test_resolution_active_get(self):
+        command = "Resolution active get"
+        r = self.launch_good_test(command + " test_device")
+        self.assertEqual(int(r), 2)
+        self.launch_fail_test(command + " X test_device")
+        self.launch_fail_test(command + " 10 test_device")
+        self.launch_fail_test(command + " test_device x")
+
+    @unittest.skip("Resolution active set not implemented")
+    def test_resolution_active_set(self):
+        command = "Resolution active set"
+        r = self.launch_good_test(command + " 2 test_device")
+        self.assertNotEqual(r, '')
+        r = self.launch_good_test("Resolution active get test_device")
+        self.assertEqual(int(r), 2)
+        self.launch_fail_test(command)
+        self.launch_fail_test(command + " X test_device")
+        self.launch_fail_test(command + " 1 test_device X")
+
+    def test_resolution_n_get(self):
+        r = self.launch_good_test("Resolution 1 get test_device")
+        self.assertEqual(r, "1: 1200dpi @ 2000Hz (default)")
+        self.launch_fail_test("Resolution 10 get test_device")
+        self.launch_fail_test("Resolution 1 get test_device X")
+        self.launch_fail_test("Resolution 1 get X")
+
+    def test_profile_resolution(self):
+        r = self.launch_good_test("Profile 2 Resolution 2 get test_device")
+        self.assertEqual(r, "2: 2300dpi @ 3000Hz")
+
+
+class TestRatbgagCtlDPI(TestRatbagCtl):
+    @classmethod
+    def setUpClass(cls):
+        super(TestRatbgagCtlDPI, cls).setUpClass()
+        cls.setProfile(0)
+
+    def test_dpi_get(self):
+        command = "DPI get"
+        r = self.launch_good_test(command + " test_device")
+        self.assertEqual(int(r), 200)
+        self.launch_fail_test(command)
+        self.launch_fail_test(command + " 1 test_device")
+        self.launch_fail_test(command + " test_device X")
+
+    def test_dpi_set(self):
+        command = "DPI set"
+        r = self.launch_good_test("DPI get test_device")
+        res = int(r) + 50
+        r = self.launch_good_test(command + " {} test_device".format(res))
+        self.assertEqual(r, '')
+        r = self.launch_good_test("DPI get test_device")
+        self.assertEqual(int(r), res)
+        self.launch_fail_test(command)
+        self.launch_fail_test(command + " X test_device")
+        self.launch_fail_test(command + " 100 test_device X")
+
+    def test_prefix_dpi(self):
+        r = self.launch_good_test("Profile 1 DPI get test_device")
+        self.assertEqual(int(r), 1300)
+        r = self.launch_good_test("Profile 1 Resolution 1 DPI get test_device")
+        self.assertEqual(int(r), 1200)
+        r = self.launch_good_test("Resolution 2 DPI get test_device")
+        self.assertEqual(int(r), 300)
+        self.launch_fail_test("Profile 1 Profile 1 DPI get test_device")
+        self.launch_fail_test("Profile 1 Resolution 1 Resolution 2 DPI get test_device")
+
+
+class TestRatbgagCtlButton(TestRatbagCtl):
+    @classmethod
+    def setUpClass(cls):
+        super(TestRatbgagCtlButton, cls).setUpClass()
+        cls.setProfile(0)
+
+    def test_button_count(self):
+        command = "button count"
+        r = self.launch_good_test(command + " test_device")
+        self.assertEqual(int(r), 4)
+        self.launch_fail_test(command)
+        self.launch_fail_test(command + " 1 test_device")
+        self.launch_fail_test(command + " test_device X")
+
+    def test_button_n_get(self):
+        self.setProfile(0)
+        r = self.launch_good_test("button 0 get test_device")
+        self.assertEqual(r, "Button: 0 type unknown is mapped to 'button 0'")
+        r = self.launch_good_test("button 1 get test_device")
+        # FIXME: we should probably have keys here, not int
+        self.assertEqual(r, "Button: 1 type unknown is mapped to '[4]'")
+        r = self.launch_good_test("button 2 get test_device")
+        # FIXME: special maps to UNKNOWN????
+        self.assertEqual(r, "Button: 2 type unknown is mapped to UNKOWN")
+        r = self.launch_good_test("button 3 get test_device")
+        # FIXME: macro maps to UNKNOWN????
+        self.assertEqual(r, "Button: 3 type unknown is mapped to UNKOWN")
+        self.launch_fail_test("button 1 get 10 test_device")
+        self.launch_fail_test("button 10 get test_device")
+        self.launch_fail_test("button 1 get test_device X")
+
+    def test_button_n_action_get(self):
+        self.setProfile(0)
+        r = self.launch_good_test("button 0 action get test_device")
+        self.assertEqual(r, "Button: 0 type unknown is mapped to 'button 0'")
+        self.launch_fail_test("button 1 action get 10 test_device")
+        self.launch_fail_test("button 10 action get test_device")
+        self.launch_fail_test("button 1 action get test_device X")
+
+    def test_button_n_action_set_button(self):
+        self.setProfile(2)
+        command = "button 2 action set button"
+        r = self.launch_good_test("button 2 action get test_device")
+        self.assertEqual(r, "Button: 2 type unknown is mapped to 'button 2'")
+        r = self.launch_good_test(command + " 1 test_device")
+        self.assertEqual(r, '')
+        r = self.launch_good_test("button 2 action get test_device")
+        self.assertEqual(r, "Button: 2 type unknown is mapped to 'button 1'")
+        self.launch_fail_test(command)
+        self.launch_fail_test(command + " X test_device")
+        self.launch_fail_test(command + " 100 test_device X")
+
+    @unittest.skip("Button action set special not implemented")
+    def test_button_n_action_set_special(self):
+        pass
+        # FIXME
+
+    @unittest.skip("Button action set macro not implemented")
+    def test_button_n_action_set_macro(self):
+        pass
+        # FIXME
+
+    def test_prefix_button(self):
+        r = self.launch_good_test("Profile 2 Button 3 get test_device")
+        self.assertEqual(r, "Button: 3 type unknown is mapped to 'button 3'")
+        self.launch_fail_test("Profile 2 Profile 2 Button 3 get test_device")
+        self.launch_fail_test("Profile 2 Resolution 2 Button 3 get test_device")
+
+
+class TestRatbgagCtlLED(TestRatbagCtl):
+    @classmethod
+    def setUpClass(cls):
+        super(TestRatbgagCtlLED, cls).setUpClass()
+        cls.setProfile(0)
+
+    def test_led_n_get(self):
+        self.setProfile(0)
+        r = self.launch_good_test("led 0 get test_device")
+        self.assertEqual(r, "LED: 0 type: logo, mode: off")
+        r = self.launch_good_test("led 1 get test_device")
+        self.assertEqual(r, "LED: 1 type: logo, mode: on, color: ff0000")
+        r = self.launch_good_test("led 2 get test_device")
+        self.assertEqual(r, "LED: 2 type: logo, mode: cycle, rate: 3, brightness: 40")
+        self.launch_fail_test("led 0 get 10 test_device")
+        self.launch_fail_test("led 10 get test_device")
+        self.launch_fail_test("led 0 get test_device X")
+
+    def test_led_n_set_mode(self):
+        self.setProfile(0)
+        r = self.launch_good_test("led 0 get test_device")
+        self.assertEqual(r, "LED: 0 type: logo, mode: off")
+        r = self.launch_good_test("led 0 set mode cycle test_device")
+        self.assertEqual(r, '')
+        r = self.launch_good_test("led 0 get test_device")
+        self.assertEqual(r, "LED: 0 type: logo, mode: cycle, rate: 1, brightness: 20")
+        self.launch_fail_test("led 0 set mode bicycle test_device")
+        self.launch_fail_test("led 0 set mode test_device")
+        self.launch_fail_test("led 0 set mode cycle test_device X")
+        self.launch_fail_test("led 0 set mode cycle X test_device")
+
+    def test_led_n_set_color(self):
+        self.setProfile(0)
+        r = self.launch_good_test("led 1 get test_device")
+        self.assertEqual(r, "LED: 1 type: logo, mode: on, color: ff0000")
+        r = self.launch_good_test("led 1 set color 00ff00 test_device")
+        self.assertEqual(r, '')
+        r = self.launch_good_test("led 1 get test_device")
+        self.assertEqual(r, "LED: 1 type: logo, mode: on, color: 00ff00")
+        r = self.launch_good_test("led 1 set color 0x0000ff test_device")
+        self.assertEqual(r, '')
+        r = self.launch_good_test("led 1 get test_device")
+        self.assertEqual(r, "LED: 1 type: logo, mode: on, color: 0000ff")
+        self.launch_fail_test("led 1 set color g0ff00 test_device")
+        self.launch_fail_test("led 1 set color test_device")
+        self.launch_fail_test("led 1 set color 00ff00 test_device X")
+        self.launch_fail_test("led 1 set color 00ff00 X test_device")
+
+    def test_led_n_set_rate(self):
+        self.setProfile(0)
+        r = self.launch_good_test("led 2 get test_device")
+        self.assertEqual(r, "LED: 2 type: logo, mode: cycle, rate: 3, brightness: 40")
+        r = self.launch_good_test("led 2 set rate 100 test_device")
+        self.assertEqual(r, '')
+        r = self.launch_good_test("led 2 get test_device")
+        self.assertEqual(r, "LED: 2 type: logo, mode: cycle, rate: 100, brightness: 40")
+        self.launch_fail_test("led 2 set rate this_is_not_an_int test_device")
+        self.launch_fail_test("led 2 set rate test_device")
+        self.launch_fail_test("led 2 set rate 100 test_device X")
+        self.launch_fail_test("led 2 set rate 100 X test_device")
+
+    def test_led_n_set_brightness(self):
+        self.setProfile(2)
+        r = self.launch_good_test("led 1 get test_device")
+        self.assertEqual(r, "LED: 1 type: logo, mode: cycle, rate: 3, brightness: 40")
+        r = self.launch_good_test("led 1 set brightness 100 test_device")
+        self.assertEqual(r, '')
+        r = self.launch_good_test("led 1 get test_device")
+        self.assertEqual(r, "LED: 1 type: logo, mode: cycle, rate: 3, brightness: 100")
+        self.launch_fail_test("led 1 set brightness this_is_not_an_int test_device")
+        self.launch_fail_test("led 1 set brightness test_device")
+        self.launch_fail_test("led 1 set brightness 100 test_device X")
+        self.launch_fail_test("led 1 set brightness 100 X test_device")
+        self.launch_fail_test("led 1 set brightness this_is_not_an_int test_device")
+        self.launch_fail_test("led 1 set brightness 256 test_device")
+        self.launch_fail_test("led 1 set brightness -10 test_device")
+
+    def test_led_n_set_combination(self):
+        self.setProfile(2)
+        r = self.launch_good_test("led 0 get test_device")
+        self.assertEqual(r, "LED: 0 type: logo, mode: on, color: ff0000")
+        r = self.launch_good_test("led 0 set mode cycle brightness 100 test_device")
+        r = self.launch_good_test("led 0 get test_device")
+        self.assertEqual(r, "LED: 0 type: logo, mode: cycle, rate: 1, brightness: 100")
+        r = self.launch_good_test("led 0 set mode cycle rate 100 brightness 255 test_device")
+        r = self.launch_good_test("led 0 get test_device")
+        self.assertEqual(r, "LED: 0 type: logo, mode: cycle, rate: 100, brightness: 255")
+        r = self.launch_good_test("led 0 set mode on color 00ff00 test_device")
+        r = self.launch_good_test("led 0 get test_device")
+        self.assertEqual(r, "LED: 0 type: logo, mode: on, color: 00ff00")
+        r = self.launch_good_test("led 0 set rate 100 brightness 200 mode cycle test_device")
+        r = self.launch_good_test("led 0 get test_device")
+        self.assertEqual(r, "LED: 0 type: logo, mode: cycle, rate: 100, brightness: 200")
+        r = self.launch_good_test("led 0 set rate 100 brightness 200 mode cycle brightness 100 test_device")
+        r = self.launch_good_test("led 0 get test_device")
+        self.assertEqual(r, "LED: 0 type: logo, mode: cycle, rate: 100, brightness: 100")
+        self.launch_fail_test("led 0 set brightness 10 mode bicycle test_device")
+
+    def test_prefix_led(self):
+        self.setProfile(2)
+        r = self.launch_good_test("Profile 1 Led 1 get test_device")
+        self.assertEqual(r, "LED: 1 type: logo, mode: off")
+        self.launch_fail_test("Profile 1 Profile 2 Led 1 get test_device")
+        self.launch_fail_test("Profile 1 Resolution 2 Led 1 get test_device")
+
+
+def setUpModule():
+    global ratbagd_process
+    # first copy the policy for the ratbagd daemon to be allowed to run
+    shutil.copy(os.path.join('@MESON_BUILD_ROOT@', DBUS_CONF_NAME), DBUS_CONF_PATH)
+
+    # FIXME: kill any running ratabgd.devel
+
+    ratbagd_process = subprocess.Popen([os.path.join('@MESON_BUILD_ROOT@', "ratbagd.devel")], shell=True)
+
+
+def tearDownModule():
+    global ratbagd_process
+    ratbagd_process.terminate()
+    try:
+        ratbagd_process.terminate()
+        ratbagd_process.wait(5)
+    except subprocess.TimeoutExpired:
+        ratbagd_process.kill()
+    os.unlink(DBUS_CONF_PATH)
+
+
+def main(argv):
+    if not os.geteuid() == 0:
+        sys.exit('Script must be run as root')
+
+    unittest.main()
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
Well, there are still a few FIXMEs here and there, but better sending this one out before it gets too much of a beast.

The idea is to instantiate a driver-test libratbag element, and playing with unit tests to see if we messed up the parsing of rabtagctl.

This gives a good idea if ratbagctl/ratbagd works as expected.

The current test run takes roughly 21 seconds on my machine, most of the time is spent by forking, initializing the bus, and settings the devices, etc...

I have a local version that creates only one dbus connection and directly calls the parsing/function from ratbagctl. This version runs in less than a second but fails because ratbagctl python binding doesn't listen for signals and can't update its internal state. I tried playing with the GLib.MainLoop, without success.