### PR TITLE
ratbagd: fix ratbagd_device_new() error path

### DIFF
--- a/ratbagd/ratbagd-device.c
+++ b/ratbagd/ratbagd-device.c
@@ -385,7 +385,8 @@ int ratbagd_device_new(struct ratbagd_device **out,
 
 	device->ctx = ctx;
 	rbnode_init(&device->node);
-	device->lib_device = ratbag_device_ref(lib_device);
+	/* note: we steal the reference here */
+	device->lib_device = lib_device;
 
 	device->name = strdup(name);
 	if (!device->name)

--- a/ratbagd/ratbagd.c
+++ b/ratbagd/ratbagd.c
@@ -313,11 +313,8 @@ static int ratbagd_reset_test_device(sd_bus_message *m,
 	device = ratbag_device_new_test_device(ctx->lib_ctx, &ratbagd_test_device_descr);
 
 	r = ratbagd_device_new(&ratbagd_test_device, ctx, "test_device", device);
-
-	/* the ratbagd_device takes its own reference, drop ours */
-	ratbag_device_unref(device);
-
 	if (r < 0) {
+		ratbag_device_unref(device);
 		log_error("Cannot track test device\n");
 		return r;
 	}
@@ -407,11 +404,8 @@ static void ratbagd_process_device(struct ratbagd *ctx,
 			return; /* unsupported device */
 
 		r = ratbagd_device_new(&device, ctx, name, lib_device);
-
-		/* the ratbagd_device takes its own reference, drop ours */
-		ratbag_device_unref(lib_device);
-
 		if (r < 0) {
+			ratbag_device_unref(lib_device);
 			log_error("Cannot track device '%s'\n", name);
 			return;
 		}


### PR DESCRIPTION
ratbagd_device_new() increments the ref count on the ratbag device, but forgets to unref it in case of an error.
Instead of doing that, just steal the reference (i.e. do nothing), and let the caller unref the device only when an error occurs.