### PR TITLE
Set the parent capabilities before setting any child ones

### DIFF
--- a/src/driver-etekcity.c
+++ b/src/driver-etekcity.c
@@ -664,6 +664,7 @@ etekcity_probe(struct ratbag_device *device)
 				    ETEKCITY_BUTTON_MAX + 1,
 				    ETEKCITY_LED);
 
+	ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_BUTTON);
 	ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_BUTTON_MACROS);
 
 	active_idx = etekcity_current_profile(device);

--- a/src/driver-gskill.c
+++ b/src/driver-gskill.c
@@ -1004,6 +1004,7 @@ gskill_probe(struct ratbag_device *device)
 				    GSKILL_BUTTON_MAX, GSKILL_NUM_LED);
 
 	ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_QUERY_CONFIGURATION);
+	ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_BUTTON);
 	ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_BUTTON_KEY);
 	ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_BUTTON_MACROS);
 	ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_DISABLE_PROFILE);

--- a/src/driver-hidpp10.c
+++ b/src/driver-hidpp10.c
@@ -377,6 +377,9 @@ hidpp10drv_read_profile(struct ratbag_profile *profile, unsigned int index)
 	if (rc)
 		xres = 0xffff;
 
+	ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_RESOLUTION);
+	ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_SWITCHABLE_RESOLUTION);
+
 	for (i = 0; i < profile->resolution.num_modes; i++) {
 		unsigned int min, max;
 
@@ -475,7 +478,9 @@ hidpp10drv_fill_from_profile(struct ratbag_device *device, struct hidpp10_device
 				    profile.num_leds);
 
 	if (dev->profile_type != HIDPP10_PROFILE_UNKNOWN) {
+		ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_PROFILE);
 		ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_SWITCHABLE_PROFILE);
+		ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_BUTTON);
 		ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_BUTTON_KEY);
 		ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_BUTTON_MACROS);
 	}

--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -785,6 +785,7 @@ hidpp20drv_init_feature(struct ratbag_device *device, uint16_t feature)
 		break;
 	case HIDPP_PAGE_MOUSE_POINTER_BASIC: {
 		drv_data->capabilities |= HIDPP_CAP_RESOLUTION_2200;
+		ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_RESOLUTION);
 		break;
 	}
 	case HIDPP_PAGE_ADJUSTABLE_DPI: {
@@ -794,6 +795,7 @@ hidpp20drv_init_feature(struct ratbag_device *device, uint16_t feature)
 		rc = hidpp20drv_read_resolution_dpi_2201(device);
 		if (rc < 0)
 			return 0; /* this is not a hard failure */
+		ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_RESOLUTION);
 		ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_SWITCHABLE_RESOLUTION);
 		drv_data->capabilities |= HIDPP_CAP_SWITCHABLE_RESOLUTION_2201;
 		break;
@@ -801,6 +803,7 @@ hidpp20drv_init_feature(struct ratbag_device *device, uint16_t feature)
 	case HIDPP_PAGE_SPECIAL_KEYS_BUTTONS: {
 		log_debug(ratbag, "device has programmable keys/buttons\n");
 		drv_data->capabilities |= HIDPP_CAP_BUTTON_KEY_1b04;
+		ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_BUTTON);
 		ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_BUTTON_KEY);
 		/* we read the profile once to get the correct number of
 		 * supported buttons. */

--- a/src/driver-logitech-g300.c
+++ b/src/driver-logitech-g300.c
@@ -369,8 +369,11 @@ logitech_g300_probe(struct ratbag_device *device)
 				    LOGITECH_G300_BUTTON_MAX + 1,
 				    LOGITECH_G300_NUM_LED);
 
+	ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_RESOLUTION);
 	ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_SWITCHABLE_RESOLUTION);
+	ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_PROFILE);
 	ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_SWITCHABLE_PROFILE);
+	ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_BUTTON);
 	ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_BUTTON_KEY);
 
 	active_idx = logitech_g300_current_profile(device);

--- a/src/driver-roccat.c
+++ b/src/driver-roccat.c
@@ -800,6 +800,7 @@ roccat_probe(struct ratbag_device *device)
 				    ROCCAT_BUTTON_MAX + 1,
 				    ROCCAT_LED_MAX);
 
+	ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_BUTTON);
 	ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_BUTTON_MACROS);
 
 	active_idx = roccat_current_profile(device);

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -690,15 +690,19 @@ ratbag_device_init_profiles(struct ratbag_device *device,
 	device->num_profiles = num_profiles;
 
 	if (num_profiles > 1) {
+		ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_PROFILE);
 		ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_SWITCHABLE_PROFILE);
 
 		/* having more than one profile means we can remap the buttons
 		 * at least */
+		ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_BUTTON);
 		ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_BUTTON_KEY);
 	}
 
-	if (num_resolutions > 1)
+	if (num_resolutions > 1) {
+		ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_RESOLUTION);
 		ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_SWITCHABLE_RESOLUTION);
+	}
 
 	if (num_leds > 1)
 		ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_LED);
@@ -820,6 +824,17 @@ ratbag_device_set_capability(struct ratbag_device *device,
 {
 	if (cap == RATBAG_DEVICE_CAP_NONE || cap >= MAX_CAP)
 		abort();
+
+	if (cap != RATBAG_DEVICE_CAP_QUERY_CONFIGURATION && cap % 100) {
+		enum ratbag_device_capability parent_cap = (cap/100) * 100;
+
+		if (!long_bit_is_set(device->capabilities, parent_cap)) {
+			log_bug_libratbag(device->ratbag,
+					  "Cap %d requires setting %d\n",
+					  cap, parent_cap);
+			abort();
+		}
+	}
 
 	long_set_bit(device->capabilities, cap);
 }


### PR DESCRIPTION
Any specific capability like 'switchable resolution' requires the basic
'resolution' capabilty to be set.

Related to https://github.com/libratbag/piper/pull/35