### PR TITLE
RatbagdLed: emit DefaultResolutionChanged on the resolution's object path

### DIFF
--- a/ratbagd/ratbagd-resolution.c
+++ b/ratbagd/ratbagd-resolution.c
@@ -112,9 +112,11 @@ static int ratbagd_resolution_set_default(sd_bus_message *m,
 	int r;
 
 	r = ratbag_resolution_set_default(resolution->lib_resolution);
+	if (r < 0)
+		return r;
 
 	(void) sd_bus_emit_signal(sd_bus_message_get_bus(m),
-				  RATBAGD_OBJ_ROOT,
+				  resolution->path,
 				  RATBAGD_NAME_ROOT ".Resolution",
 				  "DefaultResolutionChanged",
 				  "u",


### PR DESCRIPTION
See https://github.com/libratbag/piper/pull/36#issuecomment-315065722

The only issue now is that the signal is only emitted on the resolution that has just been set the default. At the very least it should also be emitted on the resolution that *was* the default, but I don't think this is currently possible so we'll have to go with emitting it on all resolutions. What's the best way to go about this?

(We should probably do this for other signals too.)