### PR TITLE
circleci: use fedora-latest, not rawhide

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -121,7 +121,7 @@ workflows:
   version: 2
   compile_and_test:
     jobs:
-      - fedora_rawhide
+      # - fedora_rawhide
       - scan_build
       - ubuntu_17_04
-      #- fedora_latest
+      - fedora_latest


### PR DESCRIPTION
Otherwise we get build errors when rawhide is broken, like today. Not worth
chasing that moving target.

