### PR TITLE
enable/disable profiles

### DIFF
--- a/DBusInterface.md
+++ b/DBusInterface.md
@@ -108,6 +108,15 @@ org.freedesktop.ratbag1.Profile
 
 The index of this profile
 
+#### `Enabled`
+- type: `b`, read-write, mutable
+
+True if this is the profile is enabled, false otherwise.
+
+Note that a disabled profile might not have correct bindings, so it's
+a good thing to rebind everything before calling `Commit()` on the
+**org.freedesktop.ratbag1.Device**.
+
 #### `Resolutions`
 - type: `ao`, read-only, mutable
 

--- a/hwdb/70-libratbag-mouse.hwdb
+++ b/hwdb/70-libratbag-mouse.hwdb
@@ -69,31 +69,41 @@ mouse:usb:v046dpc041:name:*:
  RATBAG_HIDPP10_DPI_LIST=400;800;1600;2000
 
 # G5 2007
+# http://support.logitech.com/en_us/product/g5-laser-mouse-product/specs
 mouse:usb:v046dpc049:name:*:
  RATBAG_DRIVER=hidpp10
  RATBAG_HIDPP10_DPI_LIST=400;800;1600;2000
+ RATBAG_HIDPP10_PROFILE_COUNT=1
 
 # G7
+# http://support.logitech.com/en_us/product/g7-laser-cordless-mouse/specs
 mouse:usb:v046dpc51a:name:*:
  RATBAG_DRIVER=hidpp10
+ RATBAG_HIDPP10_PROFILE_COUNT=1
 
 # G9
+# http://support.logitech.com/en_us/product/g9-laser-mouse/specs
 mouse:usb:v046dpc048:name:*:
  RATBAG_DRIVER=hidpp10
  RATBAG_HIDPP10_DPI_LIST=0;200;400;600;800;1000;1200;1400;1600;1800;2000;2200;2400;2600;2800;3000;3200
  RATBAG_HIDPP10_PROFILE=G9
+ RATBAG_HIDPP10_PROFILE_COUNT=5
 
 # G9x [Original]
+# http://support.logitech.com/en_us/product/g9x-laser-mouse/specs
 mouse:usb:v046dpc066:name:*:
  RATBAG_DRIVER=hidpp10
  RATBAG_HIDPP10_DPI=0:5700@23.53
  RATBAG_HIDPP10_PROFILE=G500
+ RATBAG_HIDPP10_PROFILE_COUNT=5
 
 # G9x [Call of Duty MW3 Edition]
+# http://support.logitech.com/en_us/product/laser-mouse-g9x/specs
 mouse:usb:v046dpc249:name:*:
  RATBAG_DRIVER=hidpp10
  RATBAG_HIDPP10_DPI=0:5700@23.53
  RATBAG_HIDPP10_PROFILE=G500
+ RATBAG_HIDPP10_PROFILE_COUNT=5
 
 # G300
 mouse:usb:v046dpc246:name:*:
@@ -106,18 +116,22 @@ mouse:usb:v046dpc082:name:*:
  RATBAG_SVG=logitech-g403.svg
 
 # G500
+# http://support.logitech.com/en_us/product/gaming-mouse-g500/specs
 mouse:usb:v046dpc068:name:*:
  RATBAG_DRIVER=hidpp10
  RATBAG_SVG=logitech-g500.svg
  RATBAG_HIDPP10_DPI=0:5700@23.53
  RATBAG_HIDPP10_PROFILE=G500
+ RATBAG_HIDPP10_PROFILE_COUNT=1
 
 # G500s
+# http://support.logitech.com/en_us/product/g500s-laser-gaming-mouse/specs
 mouse:usb:v046dpc24e:name:*:
  RATBAG_DRIVER=hidpp10
  RATBAG_SVG=logitech-g500s.svg
  RATBAG_HIDPP10_DPI=0:8200@50
  RATBAG_HIDPP10_PROFILE=G500
+ RATBAG_HIDPP10_PROFILE_COUNT=1
 
 # G502 Proteus Core over USB
 mouse:usb:v046dpc07d:name:*:
@@ -130,33 +144,41 @@ mouse:usb:v046dpc332:name:*:
  RATBAG_SVG=logitech-g502.svg
 
 # G700 over USB
+# http://support.logitech.com/en_us/product/wireless-gaming-mouse-g700/specs
 mouse:usb:v046dpc06b:name:*:
  RATBAG_DRIVER=hidpp10
  RATBAG_SVG=logitech-g700.svg
  RATBAG_HIDPP10_DPI=0:5700@23.53
  RATBAG_HIDPP10_PROFILE=G700
+ RATBAG_HIDPP10_PROFILE_COUNT=5
 
 # G700 over wireless USB
+# http://support.logitech.com/en_us/product/wireless-gaming-mouse-g700/specs
 mouse:usb:v046dpc531:name:*:
  RATBAG_DRIVER=hidpp10
  RATBAG_HIDPP10_DPI=0:5700@23.53
  RATBAG_HIDPP10_PROFILE=G700
  RATBAG_HIDPP10_INDEX=1
+ RATBAG_HIDPP10_PROFILE_COUNT=5
 
 # G700s over USB
+# http://support.logitech.com/en_us/product/g700s-rechargable-wireless-gaming-mouse/specs
 mouse:usb:v046dpc07c:name:*:
  RATBAG_DRIVER=hidpp10
  RATBAG_SVG=logitech-g700.svg
  RATBAG_HIDPP10_DPI=0:8200@50
  RATBAG_HIDPP10_PROFILE=G700
+ RATBAG_HIDPP10_PROFILE_COUNT=5
 
 # G700s over wireless USB
+# http://support.logitech.com/en_us/product/g700s-rechargable-wireless-gaming-mouse/specs
 mouse:usb:v046dpc531:name:*:
  RATBAG_DRIVER=hidpp10
  RATBAG_SVG=logitech-g700.svg
  RATBAG_HIDPP10_DPI=0:8200@50
  RATBAG_HIDPP10_PROFILE=G700
  RATBAG_HIDPP10_INDEX=1
+ RATBAG_HIDPP10_PROFILE_COUNT=5
 
 # MX Master over unifying
 mouse:usb:v046dp4041:name:*:

--- a/ratbagd/ratbagd.c
+++ b/ratbagd/ratbagd.c
@@ -190,7 +190,7 @@ static int ratbagd_get_themes(sd_bus *bus,
  * error conditions.
  */
 static const struct ratbag_test_device ratbagd_test_device_descr = {
-	.num_profiles = 3,
+	.num_profiles = 4,
 	.num_resolutions = 3,
 	.num_buttons = 4,
 	.num_leds = 3,
@@ -282,9 +282,12 @@ static const struct ratbag_test_device ratbagd_test_device_descr = {
 					.hz = 3,
 					.brightness = 40
 				}
+			},
+			.active = false,
+			.dflt = false,
 		},
-		.active = false,
-		.dflt = false,
+		{
+			.disabled = true,
 		},
 	},
 	.destroyed = NULL,

--- a/src/driver-hidpp10.c
+++ b/src/driver-hidpp10.c
@@ -393,8 +393,11 @@ hidpp10drv_read_profile(struct ratbag_profile *profile, unsigned int index)
 		    res->dpi_x == xres &&
 		    res->dpi_y == yres)
 			res->is_active = true;
-		if (i == p.default_dpi_mode)
+		if (i == p.default_dpi_mode) {
 			res->is_default = true;
+			if (!profile->is_active)
+				res->is_active = true;
+		}
 
 		min = hidpp10_dpi_table_get_min_dpi(hidpp10);
 		max = hidpp10_dpi_table_get_max_dpi(hidpp10);

--- a/src/hidpp10.h
+++ b/src/hidpp10.h
@@ -59,15 +59,19 @@ struct hidpp10_device  {
 	unsigned index;
 	uint8_t dpi_count;
 	struct hidpp10_dpi_mapping *dpi_table;
-	struct hidpp10_directory  *profile_directory; /* must be null terminated */
 	enum hidpp10_profile_type profile_type;
 	struct hidpp10_profile *profiles;
 	unsigned int profile_count;
 };
 
 struct hidpp10_device*
-hidpp10_device_new(const struct hidpp_device *base, int idx,
-		   enum hidpp10_profile_type type);
+hidpp10_device_new(const struct hidpp_device *base,
+		   int idx,
+		   enum hidpp10_profile_type type,
+		   unsigned int profile_count);
+
+int
+hidpp10_device_read_profiles(struct hidpp10_device *dev);
 
 void
 hidpp10_device_destroy(struct hidpp10_device *dev);
@@ -463,6 +467,8 @@ union hidpp10_macro_data {
 _Static_assert(sizeof(union hidpp10_macro_data) == 5, "Invalid size");
 
 struct hidpp10_profile {
+	uint8_t page;
+	uint8_t offset;
 	struct {
 		uint16_t xres;
 		uint16_t yres;
@@ -512,6 +518,7 @@ struct hidpp10_profile {
 	size_t num_leds;
 
 	unsigned int initialized;
+	bool enabled;
 };
 
 struct hidpp10_directory {
@@ -521,22 +528,17 @@ struct hidpp10_directory {
 } __attribute__((packed));
 
 int
-hidpp10_get_profile_directory(struct hidpp10_device *dev,
-			      struct hidpp10_directory *out,
-			      size_t nelems);
+hidpp10_get_current_profile(struct hidpp10_device *dev, uint8_t *current_profile);
 
 int
-hidpp10_get_current_profile(struct hidpp10_device *dev, int8_t *current_profile);
+hidpp10_set_current_profile(struct hidpp10_device *dev, uint16_t current_profile);
 
 int
-hidpp10_set_current_profile(struct hidpp10_device *dev, int16_t current_profile);
-
-int
-hidpp10_get_profile(struct hidpp10_device *dev, int8_t number,
+hidpp10_get_profile(struct hidpp10_device *dev, uint8_t number,
 		    struct hidpp10_profile *profile);
 
 int
-hidpp10_set_profile(struct hidpp10_device *dev, int8_t number,
+hidpp10_set_profile(struct hidpp10_device *dev, uint8_t number,
 		    struct hidpp10_profile *profile);
 
 enum ratbag_button_action_special

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -1634,7 +1634,7 @@ hidpp20_onboard_profiles_allocate(struct hidpp20_device *device,
 	}
 
 	for (i = 0; i < profiles->num_profiles; i++) {
-		uint8_t *d = data + offset + 4 * i;
+		uint8_t *d = data + 4 * i;
 
 		if (d[0] == 0xFF && d[1] == 0xFF)
 			break;
@@ -1727,18 +1727,14 @@ hidpp20_onboard_profiles_find_and_read_profile(struct hidpp20_device *device,
 }
 
 static int
-hidpp20_onboard_profiles_enable_profile(struct hidpp20_device *device,
-					unsigned int index,
-					struct hidpp20_profiles *profiles_list)
+hidpp20_onboard_profiles_set_enable_profile(struct hidpp20_device *device,
+					    unsigned int index,
+					    struct hidpp20_profiles *profiles_list)
 {
 	unsigned int i, buffer_index = 0;
 	uint8_t data[HIDPP20_PROFILE_SIZE] = {0};
 
-	if (profiles_list->profiles[index].enabled)
-		return 0;
-
 	profiles_list->profiles[index].index = index + 1;
-	profiles_list->profiles[index].enabled = 0x01;
 
 	for (i = 0; i < profiles_list->num_profiles; i++) {
 		data[buffer_index++] = 0x00;
@@ -2036,7 +2032,7 @@ int hidpp20_onboard_profiles_write(struct hidpp20_device *device,
 	if (rc < 0)
 		return rc;
 
-	rc = hidpp20_onboard_profiles_enable_profile(device, index, profiles_list);
+	rc = hidpp20_onboard_profiles_set_enable_profile(device, index, profiles_list);
 	if (rc < 0)
 		return rc;
 

--- a/src/liblur.c
+++ b/src/liblur.c
@@ -146,7 +146,7 @@ hidpp10_init(int fd)
 	hidpp_device_init(&base, fd);
 
 	return hidpp10_device_new(&base, HIDPP_RECEIVER_IDX,
-				  HIDPP10_PROFILE_UNKNOWN);
+				  HIDPP10_PROFILE_UNKNOWN, 1);
 }
 
 _EXPORT_ int
@@ -201,8 +201,7 @@ lur_receiver_enumerate(struct lur_receiver *lur,
 		uint32_t serial;
 		bool is_new_device = true;
 
-		d = hidpp10_device_new(&base, i,
-				  HIDPP10_PROFILE_UNKNOWN);
+		d = hidpp10_device_new(&base, i, HIDPP10_PROFILE_UNKNOWN, 1);
 		if (!d)
 			continue;
 

--- a/src/libratbag-test.h
+++ b/src/libratbag-test.h
@@ -68,6 +68,7 @@ struct ratbag_test_profile {
 	struct ratbag_test_led leds[RATBAG_TEST_MAX_LEDS];
 	bool active;
 	bool dflt;
+	bool disabled;
 };
 
 struct ratbag_test_device {

--- a/tools/hidpp10-dump-page.c
+++ b/tools/hidpp10-dump-page.c
@@ -98,7 +98,7 @@ main(int argc, char **argv)
 		error(1, errno, "Failed to open path %s", path);
 
 	hidpp_device_init(&base, fd);
-	dev = hidpp10_device_new(&base, HIDPP_WIRED_DEVICE_IDX, HIDPP10_PROFILE_UNKNOWN);
+	dev = hidpp10_device_new(&base, HIDPP_WIRED_DEVICE_IDX, HIDPP10_PROFILE_UNKNOWN, 5);
 
 	if (argc == 2)
 		rc = dump_all_pages(dev);

--- a/tools/ratbag-command.c
+++ b/tools/ratbag-command.c
@@ -106,8 +106,8 @@ usage(void)
 	       "Profile Commands:\n"
 	       "  profile active get            Print the currently active profile\n"
 	       "  profile active set N          Set profile N as to the  active profile\n"
-	       "  profile enable N              Enable profile N\n"
-	       "  profile disable N             Disable profile N\n"
+	       "  profile N enable              Enable profile N\n"
+	       "  profile N disable             Disable profile N\n"
 	       "  profile N {COMMAND}           Use profile N for COMMAND\n"
 	       "\n"
 	       "Resolution Commands\n"
@@ -441,6 +441,9 @@ ratbag_cmd_info(const struct ratbag_cmd *cmd,
 		printf("  Profile %d (%s)%s\n", i,
 		       ratbag_profile_is_enabled(profile) ? "enabled" : "disabled",
 		       ratbag_profile_is_active(profile) ? " (active)" : "");
+		if (!ratbag_profile_is_enabled(profile))
+			continue;
+
 		printf("    Resolutions:\n");
 
 		res = ratbag_profile_get_resolution(profile, 0);

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -270,6 +270,7 @@ def func_led_set(r, args):
         pass
     else:
         l.brightness = brightness
+    d.commit()
 
 
 def func_led_get_all(r, args):
@@ -286,6 +287,7 @@ def func_button_get(r, args):
 def func_button_action_set_button(r, args):
     b, p, d = find_button(r, args)
     b.mapping = args.target_button
+    d.commit()
 
 
 def func_button_count(r, args):
@@ -307,6 +309,7 @@ def func_dpi_set(r, args):
         print(args)
     else:
         r.resolution = (args.dpi_n, args.dpi_n)
+    d.commit()
 
 
 def func_report_rate_get(r, args):
@@ -352,6 +355,7 @@ def func_profile_active_get(r, args):
 def func_profile_active_set(r, args):
     p, d = find_profile(r, args)
     p.set_active()
+    d.commit()
 
 
 def func_dummy(r, args):

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -165,13 +165,15 @@ def print_resolution(d, p, r, level):
 
 
 def print_profile(d, p, level):
-    print(" " * level + "Resolutions:")
-    for r in p.resolutions:
-        print_resolution(d, p, r, level + 2)
-    for b in p.buttons:
-        print_button(d, p, b, level)
-    for l in p.leds:
-        print_led(d, p, l, level)
+    print(" " * (level - 2) + "Profile {}:{}".format(p.index, " <disabled>" if not p.enabled else ""))
+    if p.enabled:
+        print(" " * level + "Resolutions:")
+        for r in p.resolutions:
+            print_resolution(d, p, r, level + 2)
+        for b in p.buttons:
+            print_button(d, p, b, level)
+        for l in p.leds:
+            print_led(d, p, l, level)
 
 
 def print_device(d, level):
@@ -358,6 +360,18 @@ def func_profile_active_set(r, args):
     d.commit()
 
 
+def func_profile_enable(r, args):
+    p, d = find_profile(r, args)
+    p.enabled = True
+    d.commit()
+
+
+def func_profile_disable(r, args):
+    p, d = find_profile(r, args)
+    p.enabled = False
+    d.commit()
+
+
 def func_dummy(r, args):
     print("uh, oh, not implemented")
     pr_debug(args, r, args)
@@ -489,36 +503,6 @@ parser_def = [
                     },
                 ],
             },
-            {
-                of_type: command,
-                name: 'enable',
-                help_str: 'Enable a profile',
-                pos_args: [
-                    {
-                        of_type: argument,
-                        name: 'profile_n',
-                        metavar: 'N',
-                        help_str: 'The profile to enable',
-                        arg_type: int,
-                    },
-                ],
-                func: func_dummy,  # FIXME: func_profile_enable,
-            },
-            {
-                of_type: command,
-                name: 'disable',
-                help_str: 'Disable a profile',
-                pos_args: [
-                    {
-                        of_type: argument,
-                        name: 'profile_n',
-                        metavar: 'N',
-                        help_str: 'The profile to disable',
-                        arg_type: int,
-                    },
-                ],
-                func: func_dummy,  # FIXME: func_profile_disable,
-            },
         ],
         N_access: {
             of_type: N_access,
@@ -531,6 +515,18 @@ parser_def = [
                     name: 'get',
                     help_str: 'Show current active profile',
                     func: func_profile_get,
+                },
+                {
+                    of_type: command,
+                    name: 'enable',
+                    help_str: 'Enable a profile',
+                    func: func_profile_enable,
+                },
+                {
+                    of_type: command,
+                    name: 'disable',
+                    help_str: 'Disable a profile',
+                    func: func_profile_disable,
                 },
                 {
                     of_type: link,

--- a/tools/ratbagctl.test.in
+++ b/tools/ratbagctl.test.in
@@ -174,33 +174,29 @@ class TestRatbgagCtlProfile(TestRatbagCtl):
         self.launch_fail_test("Profile 0 get test_device X")
         self.launch_fail_test("Profile 10 get test_device")
 
-    @unittest.skip("profile doesn't show enabled/disabled")
     def test_profile_enable(self):
-        command = "profile enable"
-        self.launch_good_test(command + " 1 test_device")
         r = self.launch_good_test("profile 0 get test_device")
-        # FIXME: show when the profile is disabled in ratbagctl
-        self.assertNotIn('enabled', r)
-        r = self.launch_good_test("profile 1 get test_device")
-        self.assertIn('enabled', r)
-        self.launch_fail_test(command)
-        self.launch_fail_test(command + " X test_device")
-        self.launch_fail_test(command + " 1 test_device X")
-        self.launch_fail_test(command + " 10 test_device")
+        self.assertNotIn('disabled', r)
+        r = self.launch_good_test("profile 3 get test_device")
+        self.assertIn('disabled', r)
+        self.launch_good_test("profile 3 enable test_device")
+        r = self.launch_good_test("profile 3 get test_device")
+        self.assertNotIn('Profile 3: <disabled>', r)
+        self.launch_fail_test("profile enable")
+        self.launch_fail_test("profile X enable test_device")
+        self.launch_fail_test("profile 1 enable test_device X")
+        self.launch_fail_test("profile 10 enable test_device")
 
-    @unittest.skip("profile doesn't show enabled/disabled")
     def test_profile_disable(self):
-        command = "profile disable"
-        self.launch_good_test(command + " 1 test_device")
-        r = self.launch_good_test("profile 0 get test_device")
-        # FIXME: show when the profile is disabled in ratbagctl
-        self.assertIn('enabled', r)
-        r = self.launch_good_test("profile 1 get test_device")
-        self.assertNotIn('enabled', r)
-        self.launch_fail_test(command)
-        self.launch_fail_test(command + " X test_device")
-        self.launch_fail_test(command + " 1 test_device X")
-        self.launch_fail_test(command + " 10 test_device")
+        r = self.launch_good_test("profile 2 get test_device")
+        self.assertNotIn('disabled', r)
+        self.launch_good_test("profile 2 disable test_device")
+        r = self.launch_good_test("profile 2 get test_device")
+        self.assertEqual('Profile 2: <disabled>', r)
+        self.launch_fail_test("profile disable")
+        self.launch_fail_test("profile X disable test_device")
+        self.launch_fail_test("profile 1 disable test_device X")
+        self.launch_fail_test("profile 10 disable test_device")
 
 
 class TestRatbgagCtlResolution(TestRatbagCtl):

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -300,6 +300,18 @@ class RatbagdProfile(_RatbagdDBus):
         return self._get_dbus_property("Index")
 
     @GObject.Property
+    def enabled(self):
+        """tells if the profile is enabled."""
+        return self._get_dbus_property("Enabled")
+
+    @enabled.setter
+    def enabled(self, enabled):
+        """Enable/Disable this profile.
+
+        @param enabled The new state, as boolean"""
+        return self._set_dbus_property("Enabled", "b", enabled)
+
+    @GObject.Property
     def resolutions(self):
         """A list of RatbagdResolution objects with this profile's resolutions.
         """


### PR DESCRIPTION
enable and disable profiles in ratbagd, ratbagctl and ratbag-command.

The hidpp10 implementation was not done with that in mind, which explains the large commits for them.
The result is now less communications with the HID++ 1.0 devices as we are caching the data inside libratbag.