### PR TITLE
ratbagd: change the led path to .../event4/p0/l0

### DIFF
--- a/ratbagd/ratbagd-led.c
+++ b/ratbagd/ratbagd-led.c
@@ -279,7 +279,7 @@ int ratbagd_led_new(struct ratbagd_led **out,
 	led->index = index;
 
 	sprintf(profile_buffer, "p%u", ratbagd_profile_get_index(profile));
-	sprintf(led_buffer, "b%u", index);
+	sprintf(led_buffer, "l%u", index);
 	r = sd_bus_path_encode_many(&led->path,
 				    RATBAGD_OBJ_ROOT "/led/%/%/%",
 				    ratbagd_device_get_name(device),

--- a/ratbagd/ratbagd-profile.c
+++ b/ratbagd/ratbagd-profile.c
@@ -285,7 +285,7 @@ static int ratbagd_profile_find_led(sd_bus *bus,
 	int r;
 
 	r = sd_bus_path_decode_many(path,
-				    RATBAGD_OBJ_ROOT "/led/%/p%/b%",
+				    RATBAGD_OBJ_ROOT "/led/%/p%/l%",
 				    NULL,
 				    NULL,
 				    &name);


### PR DESCRIPTION
Was using 'b0' as enumerator, copy-paste error from the button code. Switch to
'l0' to make it easier to differentiate in d-feet or other dbus viewers.

