### PR TITLE
DBus interface revamp

### DIFF
--- a/DBusInterface.md
+++ b/DBusInterface.md
@@ -176,19 +176,16 @@ Resolutions can only be set to default, but never to not default - at least
 one resolution must be default at all times. This property is read-only, use the
 `SetDefault()` method to set a resolution as the default resolution.
 
-#### `XResolution`
-- type: `u`, read-only, mutable
+#### `Resolution`
+- type: `uu`, read-only, mutable
 
-uint for the x resolution assigned to this entry
+uint for the x and y resolution assigned to this entry, respectively
 
-#### `YResolution`
-- type: `u`, read-only, mutable
-
-uint for the y resolution assigned to this entry
 #### `ReportRate`
-- type: `u`, read-only, mutable
+- type: `u`, read-write, mutable
 
 uint for the report rate in Hz assigned to this entry
+
 #### `Maximum`
 - type: `u`, read-only, constant
 
@@ -200,11 +197,6 @@ uint for the minimum possible resolution
 
 ### Methods:
 
-#### `SetResolution(u, u) → ()`
-x/y resolution to assign
-
-#### `SetReportRate(uint) → ()`
-uint for the report rate to assign
 #### `SetDefault() → () `
 
 Set this resolution to be the default

--- a/DBusInterface.md
+++ b/DBusInterface.md
@@ -84,12 +84,6 @@ profiles.
 Provides the list of profile paths for all profiles on this device, see
 **org.freedesktop.ratbag1.Profile**.
 
-### Methods
-
-#### `GetProfileByIndex(u) → (o)`
-
-Returns the object path for the profile with the given index
-
 #### `Commit() → ()`
 
 Commits the changes to the device. Changes to the device are batched; they

--- a/DBusInterface.md
+++ b/DBusInterface.md
@@ -258,7 +258,7 @@ org.freedesktop.ratbag1.Led
 Index of the LED
 
 #### `Mode`
-- type: `u`, read-only, mutable
+- type: `u`, read-write, mutable
 
 uint mapping to the mode enum from libratbag
 
@@ -268,28 +268,18 @@ uint mapping to the mode enum from libratbag
 String describing the LED type
 
 #### `Color`
-- type: `(uuu)`, read-only, mutable
+- type: `(uuu)`, read-write, mutable
 uint triplet (RGB) of the LED's color
 
 #### `EffectRate`
-- type: `u`, read-only, mutable
+- type: `u`, read-write, mutable
 
 The effect rate in Hz, possible values are in the range 100 - 20000
 
 #### `Brightness`
-- type: `u`, read-only, mutable
+- type: `u`, read-write, mutable
 
 The brightness of the LED, possible values are in the range 0 - 255
-
-### Methods:
-#### `SetMode(u) → ()`
-Set the mode to the given mode enum value from libratbag
-#### `SetColor((uuu)) → ()`
-Set the color to the given uint triplet (RGB)
-#### `SetEffectRate(u) → ()`
-Set the effect rate in Hz, possible values are in the range 100 - 20000
-#### `SetBrightness(i) → ()`
-Set the brightness, possible values are in the range 0 - 255
 
 For easier debugging, objects paths are constructed from the device. e.g.
 `/org/freedesktop/ratbag/button/event5/p0/b10` is the button interface for

--- a/DBusInterface.md
+++ b/DBusInterface.md
@@ -84,11 +84,6 @@ profiles.
 Provides the list of profile paths for all profiles on this device, see
 **org.freedesktop.ratbag1.Profile**.
 
-#### `ActiveProfile`
-- type: `u`, read-only, mutable
-
-The index of the currently active profile in `Profiles`.
-
 ### Methods
 
 #### `GetProfileByIndex(u) → (o)`
@@ -140,28 +135,19 @@ Provides the object paths of all buttons in this profile, see
 Provides the object paths of all LEDs in this profile, see
 **org.freedesktop.ratbag1.Led**
 
-#### `ActiveResolution`
-- type: `u`, read-only, mutable
+### `IsActive`
+- type: `b`, read-only, mutable
 
-Index of the currently active resolution in `Resolutions`
+True if this is the currently active profile, false otherwise.
 
-#### `DefaultResolution`
-- type: `u`, read-only, mutable
-
-Index of the default resolution in `Resolutions`
+Profiles can only be set to active, but never to not active - at least one
+profile must be active at all times. This property is read-only, use the
+`SetActive()` method to activate a profile.
 
 ### Methods
 
 #### `SetActive() → ()`
 Set this profile to be the active profile
-
-#### `GetResolutionByIndex(u) → (o)`
-Returns the object path for the given index
-
-### Signals
-
-#### `ActiveProfileChanged(u)`
-Active profile changed, carries index of the new active profile
 
 org.freedesktop.ratbag1.Resolution
 ==================================

--- a/DBusInterface.md
+++ b/DBusInterface.md
@@ -75,11 +75,6 @@ capabilities.
 
 The device's SVG file name, without path.
 
-#### `SvgPath`
-- type: `s`, read-only, constant
-
-The device's SVG file name including the absolute path.
-
 #### `Profiles`
 - type: `ao`, read-only, mutable
 

--- a/DBusInterface.md
+++ b/DBusInterface.md
@@ -155,6 +155,27 @@ Index of the resolution
 - type: `au`, read-only, constant
 
 Array of uints with the capabilities enum from libratbag
+
+#### `IsActive`
+- type: `b`, read-only, mutable
+
+True if this is the currently active resolution, false otherwise.
+
+Resolutions can only be set to active, but never to not active - at least
+one resoultion must be active at all times. This property is read-only, use the
+`SetActive()` method to set a resolution as the active resolution.
+
+#### `IsDefault`
+- type: `b`, read-only, mutable
+
+True if this is the currently default resolution, false otherwise. If the
+device does not have the default resolution capability, this property is
+always false.
+
+Resolutions can only be set to default, but never to not default - at least
+one resolution must be default at all times. This property is read-only, use the
+`SetDefault()` method to set a resolution as the default resolution.
+
 #### `XResolution`
 - type: `u`, read-only, mutable
 
@@ -187,13 +208,6 @@ uint for the report rate to assign
 #### `SetDefault() → () `
 
 Set this resolution to be the default
-
-### Signals:
-
-#### `ActiveResolutionChanged(u)`
-Active resolution changed, carries index of the new active resolution
-#### `DefaultResolutionChanged(u)`
-Default resolution changed, carries index of the new default resolution
 
 org.freedesktop.ratbag1.Button
 ==============================

--- a/DBusInterface.md
+++ b/DBusInterface.md
@@ -43,29 +43,6 @@ specific theme.
 
 This list is static for the lifetime of ratbagd.
 
-### Signals
-
-#### `DeviceNew(o)`
-Notifies the client that a new device is available. The new device's
-object path is provided as argument in the signal.
-
-This signal is auxilary to the
-`org.freedesktop.DBus.Properties.PropertyChanged` signal for the `Devices`
-property.
-
-#### `DeviceRemoved(o)`
-
-Notifies the client that a device has been removed. The device's old
-object path is provided as argument in the signal.
-
-When this signal is received, all references to this device have been
-dropped by ratbagd. Further attempts at querying or modifying this
-device will fail.
-
-This signal is auxilary to the
-`org.freedesktop.DBus.Properties.PropertyChanged` signal for the `Devices`
-property.
-
 org.freedesktop.ratbag1.Device
 ==============================
 

--- a/DBusInterface.md
+++ b/DBusInterface.md
@@ -11,93 +11,327 @@ Interfaces:
 -  org.freedesktop.ratbag1.Button
 -  org.freedesktop.ratbag1.Led
 
-The **org.freedesktop.ratbag1.Manager** interface provides:
-- Properties:
-  - Devices -> array of object paths with interface Device
-  - Themes -> array of strings with theme names. The theme 'default' is
-              guaranteed to be available.
-- Signals:
-  - DeviceNew -> new device available, carries object path
-  - DeviceRemoved -> device removed, carries object path
+For a list of dbus types as used below, see https://dbus.freedesktop.org/doc/dbus-specification.html
 
-The **org.freedesktop.ratbag1.Device** interface provides:
-- Properties:
-  - Id -> unique ID of this device
-  - Capabilities -> array of uints with the capabilities enum from libratbag
-  - Description -> device name
-  - Svg -> device SVG name (file only)
-  - SvgPath -> device SVG name (full absolute path)
-  - Profiles -> array of object paths with interface Profile
-  - ActiveProfile -> index of the currently active profile in Profiles
-- Methods:
-  - GetProfileByIndex(uint) -> returns the object path for the given index
-  - Commit() -> commit the changes to the device
-  - GetSvg(string) -> returns the full path to the SVG for the given theme
-       or an empty string if none is available.  The theme must be one of
-       org.freedesktop.ratbag1.Manager.Themes. The theme 'default' is
-       guaranteed to be available. ratbagd may return the path to a
-       file that doesn't exist. This is the case if the device has SVGs
-       available but not for the given theme.
+Properties marked as 'constant' do not change for the lifetime of the
+object. Properties marked as 'mutable' may change, and a
+`org.freedesktop.DBus.Properties.PropertyChanged` signal is sent for those
+unless otherwise specified.
 
-The **org.freedesktop.ratbag1.Profile** interface provides:
-- Properties:
-  - Index -> index of the profile
-  - Resolutions -> array of object paths with interface Resolution
-  - Buttons -> array of object paths with interface Button
-  - Leds -> array of object paths with interface Led
-  - ActiveResolution -> index of the currently active resolution in Resolutions
-  - DefaultResolution -> index of the default resolution in Resolutions
-- Methods:
-  - SetActive(void) -> set this profile to be the active profile
-  - GetResolutionByIndex(uint) -> returns the object path for the given index
-- Signals:
-  - ActiveProfileChanged -> active profile changed, carries index of the new active profile
+org.freedesktop.ratbag1.Manager
+===============================
 
-The **org.freedesktop.ratbag1.Resolution** interface provides:
-- Properties:
-  - Index -> index of the resolution
-  - Capabilities -> array of uints with the capabilities enum from libratbag
-  - XResolution -> uint for the x resolution assigned to this entry
-  - YResolution -> uint for the y resolution assigned to this entry
-  - ReportRate -> uint for the report rate in Hz assigned to this entry
-  - Maximum -> uint for the maximum possible resolution
-  - Minimum -> uint for the minimum possible resolution
-- Methods:
-  - SetResolution(uint, uint) -> x/y resolution to assign
-  - SetReportRate(uint) -> uint for the report rate to assign
-  - SetDefault -> set this resolution to be the default
-- Signals:
-  - ActiveResolutionChanged -> active resolution changed, carries index of the new active resolution
-  - DefaultResolutionChanged -> default resolution changed, carries index of the new default resolution
+The **org.freedesktop.ratbag1.Manager** interface is the entry point to
+interact with ratbagd.
 
-The **org.freedesktop.ratbag1.Button** interface provides:
-- Properties:
-  - Index -> index of the button
-  - Type -> string describing the button type
-  - ButtonMapping -> uint of the current button mapping (if mapping to button)
-  - SpecialMapping -> string of the current special mapping (if mapped to special)
-  - KeyMapping -> array of uints, first entry is the keycode, other entries, if any, are modifiers (if mapped to key)
-  - ActionType -> string describing the action type of the button ("none", "button", "key", "special", "macro", "unknown"). This decides which \*Mapping  property has a value
-  - ActionTypes -> array of strings, possible values for ActionType
-- Methods:
-  - SetButtonMapping(uint) -> set the button mapping to the given button
-  - SetSpecialMapping(string) -> set the button mapping to the given special entry
-  - SetKeyMapping(uint[]) -> set the key mapping, first entry is the keycode, other entries, if any, are modifier keycodes
-  - Disable(void) -> disable this button
+### Properties
 
-The **org.freedesktop.ratbag1.Led** interface provides:
-- Properties:
-  - Index -> index of the LED
-  - Mode -> uint mapping to the mode enum from libratbag
-  - Type -> string describing the LED type
-  - Color -> uint triplet (RGB) of the LED's color
-  - EffectRate -> the effect rate in Hz, possible values are in the range 100 - 20000
-  - Brightness -> the brightness of the LED, possible values are in the range 0 - 255
-- Methods:
-  - SetMode(uint) -> set the mode to the given mode enum value from libratbag
-  - SetColor((uuu)) -> set the color to the given uint triplet (RGB)
-  - SetEffectRate(uint) -> set the effect rate in Hz, possible values are in the range 100 - 20000
-  - SetBrightness(int) -> set the brightness, possible values are in the range 0 - 255
+#### `Devices`
+- type `ao`, read-only, mutable
+
+Provides the object paths of all current devices, see **org.freedesktop.ratbag1.Device**
+
+#### `Themes`
+- type `as`, read-only, constant
+
+Provides the list of available theme names. This list is guaranteed to have
+one theme available ('default'). Other themes are implementation defined.
+A theme listed here is only a guarantee that the theme is known to libratbag
+and that SVGs *may* exist, it is not a guarantee that the SVG for any
+specific device exists. In other words, a device may not have an SVG for a
+specific theme.
+
+This list is static for the lifetime of ratbagd.
+
+### Signals
+
+#### `DeviceNew(o)`
+Notifies the client that a new device is available. The new device's
+object path is provided as argument in the signal.
+
+This signal is auxilary to the
+`org.freedesktop.DBus.Properties.PropertyChanged` signal for the `Devices`
+property.
+
+#### `DeviceRemoved(o)`
+
+Notifies the client that a device has been removed. The device's old
+object path is provided as argument in the signal.
+
+When this signal is received, all references to this device have been
+dropped by ratbagd. Further attempts at querying or modifying this
+device will fail.
+
+This signal is auxilary to the
+`org.freedesktop.DBus.Properties.PropertyChanged` signal for the `Devices`
+property.
+
+org.freedesktop.ratbag1.Device
+==============================
+
+The **org.freedesktop.ratbag1.Device** interface describes a single device
+known to ratbagd.
+
+### Properties
+
+#### `Id`
+- type: `s`, read-only, constant
+
+An ID describing this device. This ID should not be used for presentation to
+the user.
+
+#### `Description`
+- type: `s`, read-only, constant
+
+The device's name, suitable for presentation to the user.
+
+#### `Capabilities`
+- type: `au`, read-only, constant
+
+The capabilities supported by this device. see `enum
+ratbag_device_capability` in libratbag.h for the list of permissible
+capabilities.
+
+
+#### `Svg`
+- type: `s`, read-only, constant
+
+The device's SVG file name, without path.
+
+#### `SvgPath`
+- type: `s`, read-only, constant
+
+The device's SVG file name including the absolute path.
+
+#### `Profiles`
+- type: `ao`, read-only, mutable
+
+This property is mutable if the device supports adding and removing
+profiles.
+
+Provides the list of profile paths for all profiles on this device, see
+**org.freedesktop.ratbag1.Profile**.
+
+#### `ActiveProfile`
+- type: `u`, read-only, mutable
+
+The index of the currently active profile in `Profiles`.
+
+### Methods
+
+#### `GetProfileByIndex(u) → (o)`
+
+Returns the object path for the profile with the given index
+
+#### `Commit() → ()`
+
+Commits the changes to the device. Changes to the device are batched; they
+are not written to the hardware until `Commit()` is invoked.
+
+#### `GetSvg(s) → (s)`
+
+Returns the full path to the SVG for the given theme or an empty string if
+none is available.  The theme must be one of
+**org.freedesktop.ratbag1.Manager.Themes**. The theme 'default' is
+guaranteed to be available. ratbagd may return the path to a file that
+doesn't exist. This is the case if the device has SVGs available but not for
+the given theme.
+
+org.freedesktop.ratbag1.Profile
+===============================
+
+### Properties
+
+#### `Index`
+- type: `u`, read-only, constant
+
+The index of this profile
+
+#### `Resolutions`
+- type: `ao`, read-only, mutable
+
+This property is mutable if the device supports adding and removing
+resolutions.
+
+Provides the object paths of all resolutions in this profile, see
+**org.freedesktop.ratbag1.Resolution**
+
+#### `Buttons`
+- type: `ao`, read-only, constant
+
+Provides the object paths of all buttons in this profile, see
+**org.freedesktop.ratbag1.Button**
+
+#### `Leds`
+- type: `ao`, read-only, constant
+
+Provides the object paths of all LEDs in this profile, see
+**org.freedesktop.ratbag1.Led**
+
+#### `ActiveResolution`
+- type: `u`, read-only, mutable
+
+Index of the currently active resolution in `Resolutions`
+
+#### `DefaultResolution`
+- type: `u`, read-only, mutable
+
+Index of the default resolution in `Resolutions`
+
+### Methods
+
+#### `SetActive() → ()`
+Set this profile to be the active profile
+
+#### `GetResolutionByIndex(u) → (o)`
+Returns the object path for the given index
+
+### Signals
+
+#### `ActiveProfileChanged(u)`
+Active profile changed, carries index of the new active profile
+
+org.freedesktop.ratbag1.Resolution
+==================================
+
+### Properties:
+#### `Index`
+- type: `u`, read-only, constant
+
+Index of the resolution
+#### `Capabilities`
+- type: `au`, read-only, constant
+
+Array of uints with the capabilities enum from libratbag
+#### `XResolution`
+- type: `u`, read-only, mutable
+
+uint for the x resolution assigned to this entry
+
+#### `YResolution`
+- type: `u`, read-only, mutable
+
+uint for the y resolution assigned to this entry
+#### `ReportRate`
+- type: `u`, read-only, mutable
+
+uint for the report rate in Hz assigned to this entry
+#### `Maximum`
+- type: `u`, read-only, constant
+
+uint for the maximum possible resolution
+#### `Minimum`
+- type: `u`, read-only, constant
+
+uint for the minimum possible resolution
+
+### Methods:
+
+#### `SetResolution(u, u) → ()`
+x/y resolution to assign
+
+#### `SetReportRate(uint) → ()`
+uint for the report rate to assign
+#### `SetDefault() → () `
+
+Set this resolution to be the default
+
+### Signals:
+
+#### `ActiveResolutionChanged(u)`
+Active resolution changed, carries index of the new active resolution
+#### `DefaultResolutionChanged(u)`
+Default resolution changed, carries index of the new default resolution
+
+org.freedesktop.ratbag1.Button
+==============================
+
+### Properties:
+#### `Index`
+- type: `u`, read-only, constant
+
+Index of the button
+#### `Type`
+- type: `s`, read-only, constant
+
+String describing the button type
+#### `ButtonMapping`
+- type: `u`, read-only, mutable
+
+uint of the current button mapping (if mapping to button)
+#### `SpecialMapping`
+- type: `s`, read-only, mutable
+
+String of the current special mapping (if mapped to special)
+#### `KeyMapping`
+- type: `au`, read-only, mutable
+
+Array of uints, first entry is the keycode, other entries, if any, are
+modifiers (if mapped to key)
+#### `ActionType`
+- type: `s`, read-only, mutable
+
+String describing the action type of the button ("none", "button", "key",
+"special", "macro", "unknown"). This decides which Mapping  property has a
+value
+
+#### `ActionTypes`
+- type: `as`, read-only, constant
+Array of strings, possible values for ActionType
+
+### Methods:
+#### `SetButtonMapping(u) → ()`
+Set the button mapping to the given button
+#### `SetSpecialMapping(s) → ()`
+Set the button mapping to the given special entry
+#### `SetKeyMapping(au) → ()`
+Set the key mapping, first entry is the keycode, other entries, if any, are
+modifier keycodes
+#### `Disable() → ()`
+Disable this button
+
+org.freedesktop.ratbag1.Led
+===========================
+
+### Properties:
+#### `Index`
+- type: `u`, read-only, constant
+
+Index of the LED
+
+#### `Mode`
+- type: `u`, read-only, mutable
+
+uint mapping to the mode enum from libratbag
+
+#### `Type`
+- type: `s`, read-only, mutable
+
+String describing the LED type
+
+#### `Color`
+- type: `(uuu)`, read-only, mutable
+uint triplet (RGB) of the LED's color
+
+#### `EffectRate`
+- type: `u`, read-only, mutable
+
+The effect rate in Hz, possible values are in the range 100 - 20000
+
+#### `Brightness`
+- type: `u`, read-only, mutable
+
+The brightness of the LED, possible values are in the range 0 - 255
+
+### Methods:
+#### `SetMode(u) → ()`
+Set the mode to the given mode enum value from libratbag
+#### `SetColor((uuu)) → ()`
+Set the color to the given uint triplet (RGB)
+#### `SetEffectRate(u) → ()`
+Set the effect rate in Hz, possible values are in the range 100 - 20000
+#### `SetBrightness(i) → ()`
+Set the brightness, possible values are in the range 0 - 255
 
 For easier debugging, objects paths are constructed from the device. e.g.
 `/org/freedesktop/ratbag/button/event5/p0/b10` is the button interface for

--- a/ratbagd/ratbagd-device.c
+++ b/ratbagd/ratbagd-device.c
@@ -214,32 +214,6 @@ static int ratbagd_device_get_profiles(sd_bus *bus,
 	return sd_bus_message_close_container(reply);
 }
 
-static int ratbagd_device_get_active_profile(sd_bus *bus,
-					     const char *path,
-					     const char *interface,
-					     const char *property,
-					     sd_bus_message *reply,
-					     void *userdata,
-					     sd_bus_error *error)
-{
-	struct ratbagd_device *device = userdata;
-	struct ratbagd_profile *profile;
-	unsigned int i;
-
-	for (i = 0; i < device->n_profiles; ++i) {
-		profile = device->profiles[i];
-		if (!profile)
-			continue;
-		if (!ratbagd_profile_is_active(profile))
-			continue;
-
-		return sd_bus_message_append(reply, "u", i);
-	}
-
-	log_error("Unable to find active profile for %s\n", device->name);
-	return sd_bus_message_append(reply, "u", 0);
-}
-
 static int ratbagd_device_get_profile_by_index(sd_bus_message *m,
 					       void *userdata,
 					       sd_bus_error *error)
@@ -324,7 +298,6 @@ const sd_bus_vtable ratbagd_device_vtable[] = {
 	SD_BUS_PROPERTY("Name", "s", ratbagd_device_get_device_name, 0, SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_PROPERTY("Svg", "s", ratbagd_device_get_svg, 0, SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_PROPERTY("Profiles", "ao", ratbagd_device_get_profiles, 0, SD_BUS_VTABLE_PROPERTY_CONST),
-	SD_BUS_PROPERTY("ActiveProfile", "u", ratbagd_device_get_active_profile, 0, 0),
 	SD_BUS_METHOD("GetProfileByIndex", "u", "o", ratbagd_device_get_profile_by_index, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("GetSvg", "s", "s", ratbagd_device_get_theme_svg, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("Commit", "", "u", ratbagd_device_commit, SD_BUS_VTABLE_UNPRIVILEGED),
@@ -581,4 +554,17 @@ struct ratbagd_device *ratbagd_device_next(struct ratbagd_device *device)
 
 	node = rbnode_next(&device->node);
 	return node ? ratbagd_device_from_node(node) : NULL;
+}
+
+int ratbagd_for_each_profile_signal(sd_bus *bus,
+				    struct ratbagd_device *device,
+				    int (*func)(sd_bus *bus,
+						struct ratbagd_profile *profile))
+{
+	int rc = 0;
+
+	for (size_t i = 0; rc == 0 && i < device->n_profiles; i++)
+		rc = func(bus, device->profiles[i]);
+
+	return rc;
 }

--- a/ratbagd/ratbagd-device.c
+++ b/ratbagd/ratbagd-device.c
@@ -154,31 +154,6 @@ static int ratbagd_device_get_svg(sd_bus *bus,
 	return sd_bus_message_append(reply, "s", svg);
 }
 
-static int ratbagd_device_get_svg_path(sd_bus *bus,
-				       const char *path,
-				       const char *interface,
-				       const char *property,
-				       sd_bus_message *reply,
-				       void *userdata,
-				       sd_bus_error *error)
-{
-	struct ratbagd_device *device = userdata;
-	char svg_path[PATH_MAX] = {0};
-	const char *svg;
-
-	svg = ratbag_device_get_svg_name(device->lib_device);
-	if (!svg) {
-		log_error("Unable to fetch SVG for %s\n",
-			  ratbagd_device_get_name(device));
-		goto out;
-	}
-
-	sprintf(svg_path, "%s/%s", LIBRATBAG_DATA_DIR, svg);
-
-out:
-	return sd_bus_message_append(reply, "s", svg_path);
-}
-
 static int ratbagd_device_get_theme_svg(sd_bus_message *m,
 					void *userdata,
 					sd_bus_error *error)
@@ -348,7 +323,6 @@ const sd_bus_vtable ratbagd_device_vtable[] = {
 	SD_BUS_PROPERTY("Capabilities", "au", ratbagd_device_get_capabilities, 0, SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_PROPERTY("Name", "s", ratbagd_device_get_device_name, 0, SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_PROPERTY("Svg", "s", ratbagd_device_get_svg, 0, SD_BUS_VTABLE_PROPERTY_CONST),
-	SD_BUS_PROPERTY("SvgPath", "s", ratbagd_device_get_svg_path, 0, SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_PROPERTY("Profiles", "ao", ratbagd_device_get_profiles, 0, SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_PROPERTY("ActiveProfile", "u", ratbagd_device_get_active_profile, 0, 0),
 	SD_BUS_METHOD("GetProfileByIndex", "u", "o", ratbagd_device_get_profile_by_index, SD_BUS_VTABLE_UNPRIVILEGED),

--- a/ratbagd/ratbagd-device.c
+++ b/ratbagd/ratbagd-device.c
@@ -214,27 +214,6 @@ static int ratbagd_device_get_profiles(sd_bus *bus,
 	return sd_bus_message_close_container(reply);
 }
 
-static int ratbagd_device_get_profile_by_index(sd_bus_message *m,
-					       void *userdata,
-					       sd_bus_error *error)
-{
-	struct ratbagd_device *device = userdata;
-	struct ratbagd_profile *profile;
-	unsigned int index;
-	int r;
-
-	r = sd_bus_message_read(m, "u", &index);
-	if (r < 0)
-		return r;
-
-	if (index >= device->n_profiles || !device->profiles[index])
-		return -ENXIO;
-
-	profile = device->profiles[index];
-	return sd_bus_reply_method_return(m, "o",
-					  ratbagd_profile_get_path(profile));
-}
-
 static int ratbagd_device_commit(sd_bus_message *m,
 				 void *userdata,
 				 sd_bus_error *error)
@@ -298,7 +277,6 @@ const sd_bus_vtable ratbagd_device_vtable[] = {
 	SD_BUS_PROPERTY("Name", "s", ratbagd_device_get_device_name, 0, SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_PROPERTY("Svg", "s", ratbagd_device_get_svg, 0, SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_PROPERTY("Profiles", "ao", ratbagd_device_get_profiles, 0, SD_BUS_VTABLE_PROPERTY_CONST),
-	SD_BUS_METHOD("GetProfileByIndex", "u", "o", ratbagd_device_get_profile_by_index, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("GetSvg", "s", "s", ratbagd_device_get_theme_svg, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("Commit", "", "u", ratbagd_device_commit, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_VTABLE_END,

--- a/ratbagd/ratbagd-led.c
+++ b/ratbagd/ratbagd-led.c
@@ -54,7 +54,11 @@ static int ratbagd_led_get_mode(sd_bus *bus,
 	return sd_bus_message_append(reply, "u", mode);
 }
 
-static int ratbagd_led_set_mode(sd_bus_message *m,
+static int ratbagd_led_set_mode(sd_bus *bus,
+				const char *path,
+				const char *interface,
+				const char *property,
+				sd_bus_message *m,
 				void *userdata,
 				sd_bus_error *error)
 {
@@ -77,7 +81,7 @@ static int ratbagd_led_set_mode(sd_bus_message *m,
 					       NULL);
 	}
 
-	return sd_bus_reply_method_return(m, "u", r);
+	return r;
 }
 
 static int ratbagd_led_get_type(sd_bus *bus,
@@ -127,7 +131,11 @@ static int ratbagd_led_get_color(sd_bus *bus,
 	return sd_bus_message_append(reply, "(uuu)", c.red, c.green, c.blue);
 }
 
-static int ratbagd_led_set_color(sd_bus_message *m,
+static int ratbagd_led_set_color(sd_bus *bus,
+				 const char *path,
+				 const char *interface,
+				 const char *property,
+				 sd_bus_message *m,
 				 void *userdata,
 				 sd_bus_error *error)
 {
@@ -153,7 +161,7 @@ static int ratbagd_led_set_color(sd_bus_message *m,
 					       NULL);
 	}
 
-	return sd_bus_reply_method_return(m, "u", r);
+	return r;
 }
 
 static int ratbagd_led_get_effect_rate(sd_bus *bus,
@@ -168,10 +176,14 @@ static int ratbagd_led_get_effect_rate(sd_bus *bus,
 	int rate;
 
 	rate = ratbag_led_get_effect_rate(led->lib_led);
-	return sd_bus_message_append(reply, "i", rate);
+	return sd_bus_message_append(reply, "u", rate);
 }
 
-static int ratbagd_led_set_effect_rate(sd_bus_message *m,
+static int ratbagd_led_set_effect_rate(sd_bus *bus,
+				       const char *path,
+				       const char *interface,
+				       const char *property,
+				       sd_bus_message *m,
 				       void *userdata,
 				       sd_bus_error *error)
 {
@@ -197,7 +209,7 @@ static int ratbagd_led_set_effect_rate(sd_bus_message *m,
 					       NULL);
 	}
 
-	return sd_bus_reply_method_return(m, "u", r);
+	return r;
 }
 
 static int ratbagd_led_get_brightness(sd_bus *bus,
@@ -215,7 +227,11 @@ static int ratbagd_led_get_brightness(sd_bus *bus,
 	return sd_bus_message_append(reply, "u", brightness);
 }
 
-static int ratbagd_led_set_brightness(sd_bus_message *m,
+static int ratbagd_led_set_brightness(sd_bus *bus,
+				      const char *path,
+				      const char *interface,
+				      const char *property,
+				      sd_bus_message *m,
 				      void *userdata,
 				      sd_bus_error *error)
 {
@@ -241,22 +257,26 @@ static int ratbagd_led_set_brightness(sd_bus_message *m,
 					       NULL);
 	}
 
-	return sd_bus_reply_method_return(m, "u", r);
+	return r;
 }
 
 const sd_bus_vtable ratbagd_led_vtable[] = {
 	SD_BUS_VTABLE_START(0),
 	SD_BUS_PROPERTY("Index", "u", NULL, offsetof(struct ratbagd_led, index), SD_BUS_VTABLE_PROPERTY_CONST),
-	SD_BUS_PROPERTY("Mode", "u", ratbagd_led_get_mode, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
+	SD_BUS_WRITABLE_PROPERTY("Mode", "u",
+				 ratbagd_led_get_mode,
+				 ratbagd_led_set_mode, 0,
+				 SD_BUS_VTABLE_UNPRIVILEGED|SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_PROPERTY("Type", "s", ratbagd_led_get_type, 0, SD_BUS_VTABLE_PROPERTY_CONST),
-	SD_BUS_PROPERTY("Color", "(uuu)", ratbagd_led_get_color, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
-	SD_BUS_PROPERTY("EffectRate", "i", ratbagd_led_get_effect_rate, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
-	SD_BUS_PROPERTY("Brightness", "u", ratbagd_led_get_brightness, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
-
-	SD_BUS_METHOD("SetMode", "u", "u", ratbagd_led_set_mode, SD_BUS_VTABLE_UNPRIVILEGED),
-	SD_BUS_METHOD("SetColor", "(uuu)", "u", ratbagd_led_set_color, SD_BUS_VTABLE_UNPRIVILEGED),
-	SD_BUS_METHOD("SetEffectRate", "u", "u", ratbagd_led_set_effect_rate, SD_BUS_VTABLE_UNPRIVILEGED),
-	SD_BUS_METHOD("SetBrightness", "u", "u", ratbagd_led_set_brightness, SD_BUS_VTABLE_UNPRIVILEGED),
+	SD_BUS_WRITABLE_PROPERTY("Color", "(uuu)",
+				 ratbagd_led_get_color, ratbagd_led_set_color, 0,
+				 SD_BUS_VTABLE_UNPRIVILEGED|SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
+	SD_BUS_WRITABLE_PROPERTY("EffectRate", "u",
+				 ratbagd_led_get_effect_rate, ratbagd_led_set_effect_rate, 0,
+				 SD_BUS_VTABLE_UNPRIVILEGED|SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
+	SD_BUS_WRITABLE_PROPERTY("Brightness", "u",
+				 ratbagd_led_get_brightness, ratbagd_led_set_brightness, 0,
+				 SD_BUS_VTABLE_UNPRIVILEGED|SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_VTABLE_END,
 };
 

--- a/ratbagd/ratbagd-profile.c
+++ b/ratbagd/ratbagd-profile.c
@@ -302,27 +302,6 @@ static int ratbagd_profile_set_active(sd_bus_message *m,
                                           ratbag_profile_set_active(profile->lib_profile));
 }
 
-static int ratbagd_profile_get_resolution_by_index(sd_bus_message *m,
-						   void *userdata,
-						   sd_bus_error *error)
-{
-	struct ratbagd_profile *profile = userdata;
-	struct ratbagd_resolution *resolution;
-	unsigned int index = 0;
-	int r;
-
-	r = sd_bus_message_read(m, "u", &index);
-	if (r < 0)
-		return r;
-
-	if (index >= profile->n_resolutions || !profile->resolutions[index])
-		return 0;
-
-	resolution = profile->resolutions[index];
-	return sd_bus_reply_method_return(m, "o",
-					  ratbagd_resolution_get_path(resolution));
-}
-
 const sd_bus_vtable ratbagd_profile_vtable[] = {
 	SD_BUS_VTABLE_START(0),
 	SD_BUS_PROPERTY("Index", "u", NULL, offsetof(struct ratbagd_profile, index), SD_BUS_VTABLE_PROPERTY_CONST),
@@ -331,7 +310,6 @@ const sd_bus_vtable ratbagd_profile_vtable[] = {
 	SD_BUS_PROPERTY("Leds", "ao", ratbagd_profile_get_leds, 0, 0),
 	SD_BUS_PROPERTY("IsActive", "b", ratbagd_profile_is_active, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_METHOD("SetActive", "", "u", ratbagd_profile_set_active, SD_BUS_VTABLE_UNPRIVILEGED),
-	SD_BUS_METHOD("GetResolutionByIndex", "u", "o", ratbagd_profile_get_resolution_by_index, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_VTABLE_END,
 };
 

--- a/ratbagd/ratbagd.c
+++ b/ratbagd/ratbagd.c
@@ -309,6 +309,12 @@ static int ratbagd_reset_test_device(sd_bus_message *m,
 					  ratbagd_device_get_path(ratbagd_test_device));
 		ratbagd_device_unlink(ratbagd_test_device);
 		ratbagd_device_free(ratbagd_test_device);
+
+		(void) sd_bus_emit_properties_changed(ctx->bus,
+						      RATBAGD_OBJ_ROOT,
+						      RATBAGD_NAME_ROOT ".Manager",
+						      "Devices",
+						      NULL);
 	}
 
 	device = ratbag_device_new_test_device(ctx->lib_ctx, &ratbagd_test_device_descr);
@@ -332,6 +338,11 @@ static int ratbagd_reset_test_device(sd_bus_message *m,
 					  "o",
 					  ratbagd_device_get_path(ratbagd_test_device));
 		sd_bus_reply_method_return(m, "u", r);
+		(void) sd_bus_emit_properties_changed(ctx->bus,
+						      RATBAGD_OBJ_ROOT,
+						      RATBAGD_NAME_ROOT ".Manager",
+						      "Devices",
+						      NULL);
 	}
 
 	return 0;
@@ -350,7 +361,7 @@ static inline void ratbagd_init_test_device(struct ratbagd *ctx) {}
 
 static const sd_bus_vtable ratbagd_vtable[] = {
 	SD_BUS_VTABLE_START(0),
-	SD_BUS_PROPERTY("Devices", "ao", ratbagd_get_devices, 0, 0),
+	SD_BUS_PROPERTY("Devices", "ao", ratbagd_get_devices, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_PROPERTY("Themes", "as", ratbagd_get_themes, 0, 0),
 	SD_BUS_SIGNAL("DeviceNew", "o", 0),
 	SD_BUS_SIGNAL("DeviceRemoved", "o", 0),
@@ -386,6 +397,11 @@ static void ratbagd_process_device(struct ratbagd *ctx,
 	if (streq_ptr("remove", udev_device_get_action(udevice))) {
 		/* device was removed, unlink it and destroy our context */
 		if (device) {
+			(void) sd_bus_emit_properties_changed(ctx->bus,
+							      RATBAGD_OBJ_ROOT,
+							      RATBAGD_NAME_ROOT ".Manager",
+							      "Devices",
+							      NULL);
 			(void) sd_bus_emit_signal(ctx->bus,
 						  RATBAGD_OBJ_ROOT,
 						  RATBAGD_NAME_ROOT ".Manager",
@@ -418,6 +434,11 @@ static void ratbagd_process_device(struct ratbagd *ctx,
 		}
 
 		ratbagd_device_link(device);
+		(void) sd_bus_emit_properties_changed(ctx->bus,
+						      RATBAGD_OBJ_ROOT,
+						      RATBAGD_NAME_ROOT ".Manager",
+						      "Devices",
+						      NULL);
 		(void) sd_bus_emit_signal(ctx->bus,
 					  RATBAGD_OBJ_ROOT,
 					  RATBAGD_NAME_ROOT ".Manager",

--- a/ratbagd/ratbagd.c
+++ b/ratbagd/ratbagd.c
@@ -301,12 +301,6 @@ static int ratbagd_reset_test_device(sd_bus_message *m,
 	int r;
 
 	if (ratbagd_test_device) {
-		(void) sd_bus_emit_signal(ctx->bus,
-					  RATBAGD_OBJ_ROOT,
-					  RATBAGD_NAME_ROOT ".Manager",
-					  "DeviceRemoved",
-					  "o",
-					  ratbagd_device_get_path(ratbagd_test_device));
 		ratbagd_device_unlink(ratbagd_test_device);
 		ratbagd_device_free(ratbagd_test_device);
 
@@ -331,12 +325,6 @@ static int ratbagd_reset_test_device(sd_bus_message *m,
 
 	ratbagd_device_link(ratbagd_test_device);
 	if (m) {
-		(void) sd_bus_emit_signal(ctx->bus,
-					  RATBAGD_OBJ_ROOT,
-					  RATBAGD_NAME_ROOT ".Manager",
-					  "DeviceNew",
-					  "o",
-					  ratbagd_device_get_path(ratbagd_test_device));
 		sd_bus_reply_method_return(m, "u", r);
 		(void) sd_bus_emit_properties_changed(ctx->bus,
 						      RATBAGD_OBJ_ROOT,
@@ -363,8 +351,6 @@ static const sd_bus_vtable ratbagd_vtable[] = {
 	SD_BUS_VTABLE_START(0),
 	SD_BUS_PROPERTY("Devices", "ao", ratbagd_get_devices, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_PROPERTY("Themes", "as", ratbagd_get_themes, 0, 0),
-	SD_BUS_SIGNAL("DeviceNew", "o", 0),
-	SD_BUS_SIGNAL("DeviceRemoved", "o", 0),
 #ifdef RATBAG_DEVELOPER_EDITION
 	SD_BUS_METHOD("ResetTestDevice", "", "u", ratbagd_reset_test_device, SD_BUS_VTABLE_UNPRIVILEGED),
 #endif /* RATBAG_DEVELOPER_EDITION */
@@ -402,12 +388,6 @@ static void ratbagd_process_device(struct ratbagd *ctx,
 							      RATBAGD_NAME_ROOT ".Manager",
 							      "Devices",
 							      NULL);
-			(void) sd_bus_emit_signal(ctx->bus,
-						  RATBAGD_OBJ_ROOT,
-						  RATBAGD_NAME_ROOT ".Manager",
-						  "DeviceRemoved",
-						  "o",
-						  ratbagd_device_get_path(device));
 			ratbagd_device_unlink(device);
 			ratbagd_device_free(device);
 		}
@@ -439,12 +419,6 @@ static void ratbagd_process_device(struct ratbagd *ctx,
 						      RATBAGD_NAME_ROOT ".Manager",
 						      "Devices",
 						      NULL);
-		(void) sd_bus_emit_signal(ctx->bus,
-					  RATBAGD_OBJ_ROOT,
-					  RATBAGD_NAME_ROOT ".Manager",
-					  "DeviceNew",
-					  "o",
-					  ratbagd_device_get_path(device));
 	}
 }
 

--- a/ratbagd/ratbagd.h
+++ b/ratbagd/ratbagd.h
@@ -85,7 +85,10 @@ int ratbagd_for_each_profile_signal(sd_bus *bus,
 				    struct ratbagd_device *device,
 				    int (*func)(sd_bus *bus,
 						struct ratbagd_profile *profile));
-
+int ratbagd_for_each_resolution_signal(sd_bus *bus,
+				       struct ratbagd_profile *profile,
+				       int (*func)(sd_bus *bus,
+						   struct ratbagd_resolution *resolution));
 
 DEFINE_TRIVIAL_CLEANUP_FUNC(struct ratbagd_profile *, ratbagd_profile_free);
 
@@ -101,8 +104,6 @@ int ratbagd_resolution_new(struct ratbagd_resolution **out,
 			   unsigned int index);
 struct ratbagd_resolution *ratbagd_resolution_free(struct ratbagd_resolution *resolution);
 const char *ratbagd_resolution_get_path(struct ratbagd_resolution *resolution);
-bool ratbagd_resolution_is_active(struct ratbagd_resolution *resolution);
-bool ratbagd_resolution_is_default(struct ratbagd_resolution *resolution);
 
 DEFINE_TRIVIAL_CLEANUP_FUNC(struct ratbagd_resolution *, ratbagd_resolution_free);
 

--- a/ratbagd/ratbagd.h
+++ b/ratbagd/ratbagd.h
@@ -69,7 +69,6 @@ int ratbagd_profile_new(struct ratbagd_profile **out,
 			unsigned int index);
 struct ratbagd_profile *ratbagd_profile_free(struct ratbagd_profile *profile);
 const char *ratbagd_profile_get_path(struct ratbagd_profile *profile);
-bool ratbagd_profile_is_active(struct ratbagd_profile *profile);
 bool ratbagd_profile_is_default(struct ratbagd_profile *profile);
 unsigned int ratbagd_profile_get_index(struct ratbagd_profile *profile);
 int ratbagd_profile_register_resolutions(struct sd_bus *bus,
@@ -81,6 +80,12 @@ int ratbagd_profile_register_buttons(struct sd_bus *bus,
 int ratbagd_profile_register_leds(struct sd_bus *bus,
 				  struct ratbagd_device *device,
 				  struct ratbagd_profile *profile);
+
+int ratbagd_for_each_profile_signal(sd_bus *bus,
+				    struct ratbagd_device *device,
+				    int (*func)(sd_bus *bus,
+						struct ratbagd_profile *profile));
+
 
 DEFINE_TRIVIAL_CLEANUP_FUNC(struct ratbagd_profile *, ratbagd_profile_free);
 

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -70,7 +70,11 @@ def find_resolution(r, args):
         print("Invalid resolution index {}".format(args.resolution_n))
         sys.exit(1)
     except AttributeError:
-        r = p.active_resolution
+        for r in p.resolutions:
+            if r.is_active:
+                break
+        else:
+            r = None
     return r, p, d
 
 
@@ -155,8 +159,8 @@ def print_resolution(d, p, r, level):
     print(" " * level + "{}: {}dpi @ {}Hz{}{}".format(r.index,
                                                       dpi,
                                                       r.report_rate,
-                                                      " (active)" if p.active_resolution == r else "",
-                                                      " (default)" if p.default_resolution == r else "",
+                                                      " (active)" if r.is_active else "",
+                                                      " (default)" if r.is_default else "",
                                                       ))
 
 
@@ -322,7 +326,12 @@ def func_resolution_get(r, args):
 
 def func_resolution_active_get(r, args):
     p, d = find_profile(r, args)
-    print(p.active_resolution.index)
+    for r in p.resolutions:
+        if r.is_active:
+            break
+    else:
+        r = None
+    print(r.index)
 
 
 def func_profile_get(r, args):

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -54,7 +54,11 @@ def find_profile(r, args):
         print("Invalid profile index {}".format(args.profile_n))
         sys.exit(1)
     except AttributeError:
-        p = d.active_profile
+        for p in d.profiles:
+            if p.is_active:
+                break
+        else:
+            p = None
     return p, d
 
 
@@ -328,7 +332,12 @@ def func_profile_get(r, args):
 
 def func_profile_active_get(r, args):
     d = find_device(r, args)
-    print(d.active_profile.index)
+    for p in d.profiles:
+        if p.is_active:
+            break
+    else:
+        p = None
+    print(p.index)
 
 
 def func_profile_active_set(r, args):

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -292,14 +292,6 @@ class RatbagdDevice(_RatbagdDBus):
         """
         return self._dbus_call("GetSvg", "s", theme)
 
-    def get_profile_by_index(self, index):
-        """Returns the profile found at the given index, or None if no profile
-        was found.
-
-        @param index The index to find the profile at, as int
-        """
-        return self._dbus_call("GetProfileByIndex", "u", index)
-
     def commit(self):
         """Commits all changes made to the device."""
         return self._dbus_call("Commit", "")

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -214,23 +214,8 @@ class Ratbagd(_RatbagdDBus):
     Throws RatbagdDBusUnavailable when the DBus service is not available.
     """
 
-    __gsignals__ = {
-        "device-added":
-            (GObject.SIGNAL_RUN_LAST, GObject.TYPE_NONE, [str]),
-        "device-removed":
-            (GObject.SIGNAL_RUN_LAST, GObject.TYPE_NONE, [str]),
-    }
-
     def __init__(self):
         _RatbagdDBus.__init__(self, "Manager", None)
-        self._proxy.connect("g-signal", self._on_g_signal)
-
-    def _on_g_signal(self, proxy, sender, signal, params):
-        params = params.unpack()
-        if signal == "DeviceNew":
-            self.emit("device-added", params[0])
-        elif signal == "DeviceRemoved":
-            self.emit("device-removed", params[0])
 
     @GObject.Property
     def devices(self):

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -159,18 +159,9 @@ class _RatbagdDBus(GObject.GObject):
         # args to .Set are "interface name", "function name",  value-variant
         val = GLib.Variant("{}".format(type), value)
         pval = GLib.Variant("(ssv)".format(type), (self._interface, property, val))
-        try:
-            self._proxy.call_sync("org.freedesktop.DBus.Properties.Set",
-                                  pval, Gio.DBusCallFlags.NO_AUTO_START,
-                                  500, None)
-        except GLib.Error as e:
-            # FIXME: Temporary fix until the DBus API revamp is complete:
-            # Silently ignore DBus unknown property warnings so the bits we
-            # already have updated are testable. In the future when all
-            # properties are switched from SetFoo to just a writable
-            # property Foo, remove this error
-            if "org.freedesktop.DBus.Error.UnknownProperty" not in e.message:
-                raise
+        self._proxy.call_sync("org.freedesktop.DBus.Properties.Set",
+                              pval, Gio.DBusCallFlags.NO_AUTO_START,
+                              500, None)
 
         # This is our local copy, so we don't have to wait for the async
         # update

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -375,7 +375,7 @@ class RatbagdResolution(_RatbagdDBus):
     @GObject.Property
     def resolution(self):
         """The tuple (xres, yres) with each resolution in DPI."""
-        return self._get_dbus_property("XResolution"), self._get_dbus_property("YResolution")
+        return self._get_dbus_property("Resolution")
 
     @resolution.setter
     def resolution(self, res):
@@ -383,8 +383,7 @@ class RatbagdResolution(_RatbagdDBus):
 
         @param res The new resolution, as (int, int)
         """
-        ret = self._dbus_call("SetResolution", "uu", *res)
-        self._set_dbus_property("Resolution", "(uu)", res)
+        ret = self._set_dbus_property("Resolution", "(uu)", res)
         return ret
 
     @GObject.Property
@@ -408,9 +407,7 @@ class RatbagdResolution(_RatbagdDBus):
 
         @param rate The new report rate, as int
         """
-        ret = self._dbus_call("SetReportRate", "u", rate)
-        self._set_dbus_property("ReportRate", "u", rate)
-        return ret
+        return self._set_dbus_property("ReportRate", "u", rate)
 
     @GObject.Property
     def is_active(self):

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -281,14 +281,6 @@ class RatbagdDevice(_RatbagdDBus):
             profiles = [RatbagdProfile(objpath) for objpath in result]
         return profiles
 
-    @GObject.Property
-    def active_profile(self):
-        """The currently active profile. This function returns a RatbagdProfile
-        or None if no active profile was found."""
-        profiles = self.profiles
-        active_index = self._get_dbus_property("ActiveProfile")
-        return profiles[active_index] if len(profiles) > active_index else None
-
     def get_svg(self, theme):
         """Gets the full path to the SVG for the given theme, or the empty
         string if none is available.
@@ -316,19 +308,8 @@ class RatbagdDevice(_RatbagdDBus):
 class RatbagdProfile(_RatbagdDBus):
     """Represents a ratbagd profile."""
 
-    __gsignals__ = {
-        "active-profile-changed":
-            (GObject.SIGNAL_RUN_LAST, GObject.TYPE_NONE, [int]),
-    }
-
     def __init__(self, object_path):
         _RatbagdDBus.__init__(self, "Profile", object_path)
-        self._proxy.connect("g-signal", self._on_g_signal)
-
-    def _on_g_signal(self, proxy, sender, signal, params):
-        params = params.unpack()
-        if signal == "ActiveProfileChanged":
-            self.emit("active-profile-changed", params[0])
 
     @GObject.Property
     def index(self):
@@ -380,6 +361,11 @@ class RatbagdProfile(_RatbagdDBus):
         resolutions = self.resolutions
         default_index = self._get_dbus_property("DefaultResolution")
         return resolutions[default_index] if len(resolutions) > default_index else None
+
+    @GObject.Property
+    def is_active(self):
+        """Returns True if the profile is currenly active, false otherwise."""
+        return self._get_dbus_property("IsActive")
 
     def set_active(self):
         """Set this profile to be the active profile."""

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -339,22 +339,6 @@ class RatbagdProfile(_RatbagdDBus):
         return leds
 
     @GObject.Property
-    def active_resolution(self):
-        """The currently active resolution. This function returns a
-        RatbagdResolution object or None."""
-        resolutions = self.resolutions
-        active_index = self._get_dbus_property("ActiveResolution")
-        return resolutions[active_index] if len(resolutions) > active_index else None
-
-    @GObject.Property
-    def default_resolution(self):
-        """The default resolution. This function returns a RatbagdResolution
-        object or None."""
-        resolutions = self.resolutions
-        default_index = self._get_dbus_property("DefaultResolution")
-        return resolutions[default_index] if len(resolutions) > default_index else None
-
-    @GObject.Property
     def is_active(self):
         """Returns True if the profile is currenly active, false otherwise."""
         return self._get_dbus_property("IsActive")
@@ -375,23 +359,8 @@ class RatbagdResolution(_RatbagdDBus):
     CAP_INDIVIDUAL_REPORT_RATE = 1
     CAP_SEPARATE_XY_RESOLUTION = 2
 
-    __gsignals__ = {
-        "active-resolution-changed":
-            (GObject.SIGNAL_RUN_LAST, GObject.TYPE_NONE, [int]),
-        "default-resolution-changed":
-            (GObject.SIGNAL_RUN_LAST, GObject.TYPE_NONE, [int]),
-    }
-
     def __init__(self, object_path):
         _RatbagdDBus.__init__(self, "Resolution", object_path)
-        self._proxy.connect("g-signal", self._on_g_signal)
-
-    def _on_g_signal(self, proxy, sender, signal, params):
-        params = params.unpack()
-        if signal == "ActiveResolutionChanged":
-            self.emit("active-resolution-changed", params[0])
-        elif signal == "DefaultResolutionChanged":
-            self.emit("default-resolution-changed", params[0])
 
     @GObject.Property
     def index(self):
@@ -447,6 +416,18 @@ class RatbagdResolution(_RatbagdDBus):
         ret = self._dbus_call("SetReportRate", "u", rate)
         self._set_dbus_property("ReportRate", "u", rate)
         return ret
+
+    @GObject.Property
+    def is_active(self):
+        """True if this is the currently active resolution, False
+        otherwise"""
+        return self._get_dbus_property("IsActive")
+
+    @GObject.Property
+    def is_default(self):
+        """True if this is the currently default resolution, False
+        otherwise"""
+        return self._get_dbus_property("IsDefault")
 
     def set_default(self):
         """Set this resolution to be the default."""

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -347,11 +347,6 @@ class RatbagdProfile(_RatbagdDBus):
         """Set this profile to be the active profile."""
         return self._dbus_call("SetActive", "")
 
-    def get_resolution_by_index(self, index):
-        """Returns the resolution found at the given index. This function
-        returns a RatbagdResolution or None if no resolution was found."""
-        return self._dbus_call("GetResolutionByIndex", "u", index)
-
 
 class RatbagdResolution(_RatbagdDBus):
     """Represents a ratbagd resolution."""

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -536,9 +536,7 @@ class RatbagdLed(_RatbagdDBus):
         @param mode The new mode, as one of MODE_OFF, MODE_ON, MODE_CYCLE and
                     MODE_BREATHING.
         """
-        ret = self._dbus_call("SetMode", "u", mode)
-        self._set_dbus_property("Mode", "u", mode)
-        return ret
+        return self._set_dbus_property("Mode", "u", mode)
 
     @GObject.Property
     def type(self):
@@ -556,9 +554,7 @@ class RatbagdLed(_RatbagdDBus):
 
         @param color An RGB color, as an integer triplet with values 0-255.
         """
-        ret = self._dbus_call("SetColor", "(uuu)", color)
-        self._set_dbus_property("Color", "(uuu)", color)
-        return ret
+        return self._set_dbus_property("Color", "(uuu)", color)
 
     @GObject.Property
     def effect_rate(self):
@@ -571,9 +567,7 @@ class RatbagdLed(_RatbagdDBus):
 
         @param effect_rate The new effect rate, as int
         """
-        ret = self._dbus_call("SetEffectRate", "u", effect_rate)
-        self._set_dbus_property("EffectRate", "u", effect_rate)
-        return ret
+        return self._set_dbus_property("EffectRate", "u", effect_rate)
 
     @GObject.Property
     def brightness(self):
@@ -586,6 +580,4 @@ class RatbagdLed(_RatbagdDBus):
 
         @param brightness The new brightness, as int
         """
-        ret = self._dbus_call("SetBrightness", "u", brightness)
-        self._set_dbus_property("Brightness", "u", brightness)
-        return ret
+        return self._set_dbus_property("Brightness", "u", brightness)


### PR DESCRIPTION
This is on top of #241 and should only be merged when that one is merged.

When I started tidying up the DBusInterface.md document I noticed a fair few inconsistencies with the API. A few basically superfluous calls and some imbalanced property handling (having a 'foo' readonly property but a SetFoo() method - instead we can just make the property read-write).

Note that his is not complete but I'm about to head out for GUADEC, so better to get this in now. The bits missing are changing the Button interface from using strings to using the libratbag enums and the LED type string to an enum too.

ratbagd.py will need to be synced to piper after merging this but no client changes are needed, this is all handled within the bindings.