### PR TITLE
Make RatbagdButton properties writable

### DIFF
--- a/DBusInterface.md
+++ b/DBusInterface.md
@@ -214,9 +214,11 @@ Index of the button
 
 String describing the button type
 #### `ButtonMapping`
-- type: `u`, read-only, mutable
+- type: `u`, read-write, mutable
 
-uint of the current button mapping (if mapping to button)
+The uint of the current button mapping (if mapping to button). If written to,
+this sets the action type to "button" and the mapping to the given button.
+
 #### `SpecialMapping`
 - type: `s`, read-only, mutable
 
@@ -238,8 +240,6 @@ value
 Array of strings, possible values for ActionType
 
 ### Methods:
-#### `SetButtonMapping(u) → ()`
-Set the button mapping to the given button
 #### `SetSpecialMapping(s) → ()`
 Set the button mapping to the given special entry
 #### `SetKeyMapping(au) → ()`

--- a/DBusInterface.md
+++ b/DBusInterface.md
@@ -177,7 +177,7 @@ one resolution must be default at all times. This property is read-only, use the
 `SetDefault()` method to set a resolution as the default resolution.
 
 #### `Resolution`
-- type: `uu`, read-only, mutable
+- type: `uu`, read-write, mutable
 
 uint for the x and y resolution assigned to this entry, respectively
 

--- a/DBusInterface.md
+++ b/DBusInterface.md
@@ -227,10 +227,12 @@ this sets the action type to "special" and the mapping to the given special
 entry.
 
 #### `KeyMapping`
-- type: `au`, read-only, mutable
+- type: `au`, read-write, mutable
 
 Array of uints, first entry is the keycode, other entries, if any, are
-modifiers (if mapped to key)
+modifiers (if mapped to key). If written to, this sets the action type to "key"
+and the key mapping to the given keys.
+
 #### `ActionType`
 - type: `s`, read-only, mutable
 
@@ -243,9 +245,6 @@ value
 Array of strings, possible values for ActionType
 
 ### Methods:
-#### `SetKeyMapping(au) → ()`
-Set the key mapping, first entry is the keycode, other entries, if any, are
-modifier keycodes
 #### `Disable() → ()`
 Disable this button
 

--- a/DBusInterface.md
+++ b/DBusInterface.md
@@ -220,9 +220,12 @@ The uint of the current button mapping (if mapping to button). If written to,
 this sets the action type to "button" and the mapping to the given button.
 
 #### `SpecialMapping`
-- type: `s`, read-only, mutable
+- type: `s`, read-write, mutable
 
-String of the current special mapping (if mapped to special)
+String of the current special mapping (if mapped to special). If written to,
+this sets the action type to "special" and the mapping to the given special
+entry.
+
 #### `KeyMapping`
 - type: `au`, read-only, mutable
 
@@ -240,8 +243,6 @@ value
 Array of strings, possible values for ActionType
 
 ### Methods:
-#### `SetSpecialMapping(s) → ()`
-Set the button mapping to the given special entry
 #### `SetKeyMapping(au) → ()`
 Set the key mapping, first entry is the keycode, other entries, if any, are
 modifier keycodes

--- a/ratbagd/ratbagd-button.c
+++ b/ratbagd/ratbagd-button.c
@@ -265,7 +265,11 @@ static int ratbagd_button_get_special(sd_bus *bus,
 	return sd_bus_message_append(reply, "s", type);
 }
 
-static int ratbagd_button_set_special(sd_bus_message *m,
+static int ratbagd_button_set_special(sd_bus *bus,
+				      const char *path,
+				      const char *interface,
+				      const char *property,
+				      sd_bus_message *m,
 				      void *userdata,
 				      sd_bus_error *error)
 {
@@ -326,7 +330,7 @@ static int ratbagd_button_set_special(sd_bus_message *m,
 					       NULL);
 	}
 
-	return sd_bus_reply_method_return(m, "u", r);
+	return r;
 }
 
 static int ratbagd_button_get_key(sd_bus *bus,
@@ -508,12 +512,14 @@ const sd_bus_vtable ratbagd_button_vtable[] = {
 				 ratbagd_button_get_button,
 				 ratbagd_button_set_button, 0,
 				 SD_BUS_VTABLE_UNPRIVILEGED|SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
-	SD_BUS_PROPERTY("SpecialMapping", "s", ratbagd_button_get_special, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
+	SD_BUS_WRITABLE_PROPERTY("SpecialMapping", "s",
+				 ratbagd_button_get_special,
+				 ratbagd_button_set_special, 0,
+				 SD_BUS_VTABLE_UNPRIVILEGED|SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_PROPERTY("KeyMapping", "au", ratbagd_button_get_key, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_PROPERTY("ActionType", "s", ratbagd_button_get_action_type, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_PROPERTY("ActionTypes", "as", ratbagd_button_get_action_types, 0, SD_BUS_VTABLE_PROPERTY_CONST),
 
-	SD_BUS_METHOD("SetSpecialMapping", "s", "u", ratbagd_button_set_special, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("SetKeyMapping", "au", "u", ratbagd_button_set_key, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("Disable", "", "u", ratbagd_button_disable, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_VTABLE_END,

--- a/ratbagd/ratbagd-button.c
+++ b/ratbagd/ratbagd-button.c
@@ -155,7 +155,11 @@ static int ratbagd_button_get_button(sd_bus *bus,
 	return sd_bus_message_append(reply, "u", b);
 }
 
-static int ratbagd_button_set_button(sd_bus_message *m,
+static int ratbagd_button_set_button(sd_bus *bus,
+				     const char *path,
+				     const char *interface,
+				     const char *property,
+				     sd_bus_message *m,
 				     void *userdata,
 				     sd_bus_error *error)
 {
@@ -181,7 +185,7 @@ static int ratbagd_button_set_button(sd_bus_message *m,
 					       NULL);
 	}
 
-	return sd_bus_reply_method_return(m, "u", r);
+	return r;
 }
 
 static int ratbagd_button_get_special(sd_bus *bus,
@@ -500,13 +504,15 @@ const sd_bus_vtable ratbagd_button_vtable[] = {
 	SD_BUS_VTABLE_START(0),
 	SD_BUS_PROPERTY("Index", "u", NULL, offsetof(struct ratbagd_button, index), SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_PROPERTY("Type", "s", ratbagd_button_get_type, 0, SD_BUS_VTABLE_PROPERTY_CONST),
-	SD_BUS_PROPERTY("ButtonMapping", "u", ratbagd_button_get_button, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
+	SD_BUS_WRITABLE_PROPERTY("ButtonMapping", "u",
+				 ratbagd_button_get_button,
+				 ratbagd_button_set_button, 0,
+				 SD_BUS_VTABLE_UNPRIVILEGED|SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_PROPERTY("SpecialMapping", "s", ratbagd_button_get_special, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_PROPERTY("KeyMapping", "au", ratbagd_button_get_key, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_PROPERTY("ActionType", "s", ratbagd_button_get_action_type, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_PROPERTY("ActionTypes", "as", ratbagd_button_get_action_types, 0, SD_BUS_VTABLE_PROPERTY_CONST),
 
-	SD_BUS_METHOD("SetButtonMapping", "u", "u", ratbagd_button_set_button, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("SetSpecialMapping", "s", "u", ratbagd_button_set_special, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("SetKeyMapping", "au", "u", ratbagd_button_set_key, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("Disable", "", "u", ratbagd_button_disable, SD_BUS_VTABLE_UNPRIVILEGED),

--- a/ratbagd/ratbagd-button.c
+++ b/ratbagd/ratbagd-button.c
@@ -376,7 +376,11 @@ static int ratbagd_button_get_key(sd_bus *bus,
 	return sd_bus_message_close_container(reply);
 }
 
-static int ratbagd_button_set_key(sd_bus_message *m,
+static int ratbagd_button_set_key(sd_bus *bus,
+				  const char *path,
+				  const char *interface,
+				  const char *property,
+				  sd_bus_message *m,
 				  void *userdata,
 				  sd_bus_error *error)
 {
@@ -408,7 +412,7 @@ static int ratbagd_button_set_key(sd_bus_message *m,
 
 	r = ratbag_button_set_key(button->lib_button, key, modifiers, nmodifiers);
 
-	return sd_bus_reply_method_return(m, "u", r);
+	return r;
 }
 
 static int ratbagd_button_get_action_type(sd_bus *bus,
@@ -516,11 +520,13 @@ const sd_bus_vtable ratbagd_button_vtable[] = {
 				 ratbagd_button_get_special,
 				 ratbagd_button_set_special, 0,
 				 SD_BUS_VTABLE_UNPRIVILEGED|SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
-	SD_BUS_PROPERTY("KeyMapping", "au", ratbagd_button_get_key, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
+	SD_BUS_WRITABLE_PROPERTY("KeyMapping", "au",
+				 ratbagd_button_get_key,
+				 ratbagd_button_set_key, 0,
+				 SD_BUS_VTABLE_UNPRIVILEGED|SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_PROPERTY("ActionType", "s", ratbagd_button_get_action_type, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_PROPERTY("ActionTypes", "as", ratbagd_button_get_action_types, 0, SD_BUS_VTABLE_PROPERTY_CONST),
 
-	SD_BUS_METHOD("SetKeyMapping", "au", "u", ratbagd_button_set_key, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("Disable", "", "u", ratbagd_button_disable, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_VTABLE_END,
 };

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -444,9 +444,7 @@ class RatbagdButton(_RatbagdDBus):
 
         @param button The button to map to, as int
         """
-        ret = self._dbus_call("SetButtonMapping", "u", button)
-        self._set_dbus_property("ButtonMapping", "u", button)
-        return ret
+        return self._set_dbus_property("ButtonMapping", "u", button)
 
     @GObject.Property
     def special(self):

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -472,9 +472,7 @@ class RatbagdButton(_RatbagdDBus):
         @param keys A list of integers, the first being the keycode and the rest
                     modifiers.
         """
-        ret = self._dbus_call("SetKeyMapping", "au", keys)
-        self._set_dbus_property("KeyMapping", "au", keys)
-        return ret
+        return self._set_dbus_property("KeyMapping", "au", keys)
 
     @GObject.Property
     def action_type(self):

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -457,9 +457,7 @@ class RatbagdButton(_RatbagdDBus):
 
         @param special The special entry, as str
         """
-        ret = self._dbus_call("SetSpecialMapping", "s", special)
-        self._set_dbus_property("SpecialMapping", "s", special)
-        return ret
+        return self._set_dbus_property("SpecialMapping", "s", special)
 
     @GObject.Property
     def key(self):


### PR DESCRIPTION
@whot wanted to wait until the conversion to enums was done[¹](https://github.com/libratbag/libratbag/pull/242#issue-244965513):

> Note that his is not complete but I'm about to head out for GUADEC, so better to get this in now. The bits missing are changing the Button interface from using strings to using the libratbag enums and the LED type string to an enum too.

I needed this quickly to be able to test some things in https://github.com/libratbag/piper/pull/47, and AFAIK changing to enums is just as easy now as it was before making these properties writable. Feel free to close this and cherry-pick these commits or use them in another way if I'm wrong :)