### PR TITLE
Add support for macros in ratbagd

### DIFF
--- a/DBusInterface.md
+++ b/DBusInterface.md
@@ -219,9 +219,11 @@ org.freedesktop.ratbag1.Button
 
 Index of the button
 #### `Type`
-- type: `s`, read-only, constant
+- type: `u`, read-only, constant
 
-String describing the button type
+Enum describing the button physical type. This type is unrelated to the
+logical button mapping and serves to easily identify the button on the
+device.
 #### `ButtonMapping`
 - type: `u`, read-only, mutable
 

--- a/DBusInterface.md
+++ b/DBusInterface.md
@@ -236,15 +236,14 @@ String of the current special mapping (if mapped to special)
 Array of uints, first entry is the keycode, other entries, if any, are
 modifiers (if mapped to key)
 #### `ActionType`
-- type: `s`, read-only, mutable
+- type: `u`, read-only, mutable
 
-String describing the action type of the button ("none", "button", "key",
-"special", "macro", "unknown"). This decides which Mapping  property has a
-value
-
+An enum describing the action type of the button, see
+ratbag\_button\_get\_action\_type for the list of enums.
+This decides which Mapping  property has a value.
 #### `ActionTypes`
-- type: `as`, read-only, constant
-Array of strings, possible values for ActionType
+- type: `au`, read-only, constant
+Array of enum ratbag\_button\_action\_type, possible values for ActionType
 
 ### Methods:
 #### `SetButtonMapping(u) → ()`

--- a/ratbagd/ratbagd-button.c
+++ b/ratbagd/ratbagd-button.c
@@ -53,90 +53,11 @@ static int ratbagd_button_get_type(sd_bus *bus,
 				   sd_bus_error *error)
 {
 	struct ratbagd_button *button = userdata;
-	const char *type = NULL;
 	enum ratbag_button_type t;
 
 	t = ratbag_button_get_type(button->lib_button);
 
-	switch(t) {
-		default:
-			log_error("Unknown button type %d\n", t);
-			/* fallthrough */
-		case RATBAG_BUTTON_TYPE_UNKNOWN:
-			type = "unknown";
-			break;
-		case RATBAG_BUTTON_TYPE_LEFT:
-			type = "left";
-			break;
-		case RATBAG_BUTTON_TYPE_MIDDLE:
-			type = "middle";
-			break;
-		case RATBAG_BUTTON_TYPE_RIGHT:
-			type = "right";
-			break;
-		case RATBAG_BUTTON_TYPE_THUMB:
-			type = "thumb";
-			break;
-		case RATBAG_BUTTON_TYPE_THUMB2:
-			type = "thumb2";
-			break;
-		case RATBAG_BUTTON_TYPE_THUMB3:
-			type = "thumb3";
-			break;
-		case RATBAG_BUTTON_TYPE_THUMB4:
-			type = "thumb4";
-			break;
-		case RATBAG_BUTTON_TYPE_WHEEL_LEFT:
-			type = "wheel-left";
-			break;
-		case RATBAG_BUTTON_TYPE_WHEEL_RIGHT:
-			type = "wheel-right";
-			break;
-		case RATBAG_BUTTON_TYPE_WHEEL_CLICK:
-			type = "wheel-click";
-			break;
-		case RATBAG_BUTTON_TYPE_WHEEL_UP:
-			type = "wheel-up";
-			break;
-		case RATBAG_BUTTON_TYPE_WHEEL_DOWN:
-			type = "wheel-down";
-			break;
-		case RATBAG_BUTTON_TYPE_WHEEL_RATCHET_MODE_SHIFT:
-			type = "wheel-ratchet_mode_shift";
-			break;
-		case RATBAG_BUTTON_TYPE_EXTRA:
-			type = "extra";
-			break;
-		case RATBAG_BUTTON_TYPE_SIDE:
-			type = "side";
-			break;
-		case RATBAG_BUTTON_TYPE_PINKIE:
-			type = "pinkie";
-			break;
-		case RATBAG_BUTTON_TYPE_PINKIE2:
-			type = "pinkie2";
-			break;
-		case RATBAG_BUTTON_TYPE_RESOLUTION_CYCLE_UP:
-			type = "resolution-cycle-up";
-			break;
-		case RATBAG_BUTTON_TYPE_RESOLUTION_UP:
-			type = "resolution-up";
-			break;
-		case RATBAG_BUTTON_TYPE_RESOLUTION_DOWN:
-			type = "resolution-down";
-			break;
-		case RATBAG_BUTTON_TYPE_PROFILE_CYCLE_UP:
-			type = "profile-cycle-up";
-			break;
-		case RATBAG_BUTTON_TYPE_PROFILE_UP:
-			type = "profile-up";
-			break;
-		case RATBAG_BUTTON_TYPE_PROFILE_DOWN:
-			type = "profile-down";
-			break;
-	}
-
-	return sd_bus_message_append(reply, "s", type);
+	return sd_bus_message_append(reply, "u", t);
 }
 
 static int ratbagd_button_get_button(sd_bus *bus,
@@ -557,7 +478,7 @@ static int ratbagd_button_disable(sd_bus_message *m,
 const sd_bus_vtable ratbagd_button_vtable[] = {
 	SD_BUS_VTABLE_START(0),
 	SD_BUS_PROPERTY("Index", "u", NULL, offsetof(struct ratbagd_button, index), SD_BUS_VTABLE_PROPERTY_CONST),
-	SD_BUS_PROPERTY("Type", "s", ratbagd_button_get_type, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+	SD_BUS_PROPERTY("Type", "u", ratbagd_button_get_type, 0, SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_PROPERTY("ButtonMapping", "u", ratbagd_button_get_button, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_PROPERTY("SpecialMapping", "s", ratbagd_button_get_special, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_PROPERTY("KeyMapping", "au", ratbagd_button_get_key, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),

--- a/ratbagd/ratbagd.c
+++ b/ratbagd/ratbagd.c
@@ -206,7 +206,16 @@ static const struct ratbag_test_device ratbagd_test_device_descr = {
 				  .key = KEY_3 },
 				{ .type = RATBAG_BUTTON_ACTION_TYPE_SPECIAL,
 				  .special = RATBAG_BUTTON_ACTION_SPECIAL_PROFILE_CYCLE_UP },
-				{ .type = RATBAG_BUTTON_ACTION_TYPE_MACRO },
+				{ .type = RATBAG_BUTTON_ACTION_TYPE_MACRO,
+				  .macro = {
+					  { .type = RATBAG_MACRO_EVENT_KEY_PRESSED,
+					    .value = KEY_B },
+					  { .type = RATBAG_MACRO_EVENT_KEY_RELEASED,
+					    .value = KEY_B },
+					  { .type = RATBAG_MACRO_EVENT_WAIT,
+					    .value = 300 },
+				  },
+				}
 			},
 			.resolutions = {
 				{ .xres = 100, .yres = 200, .hz = 1000 },
@@ -260,7 +269,15 @@ static const struct ratbag_test_device ratbagd_test_device_descr = {
 				{ .type = RATBAG_BUTTON_ACTION_TYPE_SPECIAL,
 				  .special = RATBAG_BUTTON_ACTION_SPECIAL_PROFILE_CYCLE_UP },
 				{ .type = RATBAG_BUTTON_ACTION_TYPE_MACRO,
-				  .button = 1 },
+				  .macro = {
+					  { .type = RATBAG_MACRO_EVENT_KEY_PRESSED,
+					    .value = KEY_A },
+					  { .type = RATBAG_MACRO_EVENT_KEY_RELEASED,
+					    .value = KEY_A },
+					  { .type = RATBAG_MACRO_EVENT_WAIT,
+					    .value = 150 },
+				  }
+				},
 				{ .type = RATBAG_BUTTON_ACTION_TYPE_BUTTON,
 				  .button = 2 },
 				{ .type = RATBAG_BUTTON_ACTION_TYPE_BUTTON,

--- a/ratbagd/ratbagd.c
+++ b/ratbagd/ratbagd.c
@@ -25,6 +25,8 @@
 
 #include "config.h"
 
+#include <linux/input-event-codes.h>
+
 #include <assert.h>
 #include <errno.h>
 #include <libratbag.h>
@@ -201,7 +203,7 @@ static const struct ratbag_test_device ratbagd_test_device_descr = {
 				{ .type = RATBAG_BUTTON_ACTION_TYPE_BUTTON,
 				  .button = 0 },
 				{ .type = RATBAG_BUTTON_ACTION_TYPE_KEY,
-				  .key = 4 },
+				  .key = KEY_3 },
 				{ .type = RATBAG_BUTTON_ACTION_TYPE_SPECIAL,
 				  .special = RATBAG_BUTTON_ACTION_SPECIAL_PROFILE_CYCLE_UP },
 				{ .type = RATBAG_BUTTON_ACTION_TYPE_MACRO },

--- a/ratbagd/ratbagd.c
+++ b/ratbagd/ratbagd.c
@@ -200,13 +200,13 @@ static const struct ratbag_test_device ratbagd_test_device_descr = {
 	.profiles = {
 		{
 			.buttons = {
-				{ .type = RATBAG_BUTTON_ACTION_TYPE_BUTTON,
+				{ .action_type = RATBAG_BUTTON_ACTION_TYPE_BUTTON,
 				  .button = 0 },
-				{ .type = RATBAG_BUTTON_ACTION_TYPE_KEY,
+				{ .action_type = RATBAG_BUTTON_ACTION_TYPE_KEY,
 				  .key = KEY_3 },
-				{ .type = RATBAG_BUTTON_ACTION_TYPE_SPECIAL,
+				{ .action_type = RATBAG_BUTTON_ACTION_TYPE_SPECIAL,
 				  .special = RATBAG_BUTTON_ACTION_SPECIAL_PROFILE_CYCLE_UP },
-				{ .type = RATBAG_BUTTON_ACTION_TYPE_MACRO,
+				{ .action_type = RATBAG_BUTTON_ACTION_TYPE_MACRO,
 				  .macro = {
 					  { .type = RATBAG_MACRO_EVENT_KEY_PRESSED,
 					    .value = KEY_B },
@@ -247,13 +247,13 @@ static const struct ratbag_test_device ratbagd_test_device_descr = {
 		},
 		{
 			.buttons = {
-				{ .type = RATBAG_BUTTON_ACTION_TYPE_KEY,
+				{ .action_type = RATBAG_BUTTON_ACTION_TYPE_KEY,
 				  .key = 4 },
-				{ .type = RATBAG_BUTTON_ACTION_TYPE_KEY,
+				{ .action_type = RATBAG_BUTTON_ACTION_TYPE_KEY,
 				  .key = 5 },
-				{ .type = RATBAG_BUTTON_ACTION_TYPE_KEY,
+				{ .action_type = RATBAG_BUTTON_ACTION_TYPE_KEY,
 				  .key = 6 },
-				{ .type = RATBAG_BUTTON_ACTION_TYPE_KEY,
+				{ .action_type = RATBAG_BUTTON_ACTION_TYPE_KEY,
 				  .key = 7 },
 			},
 			.resolutions = {
@@ -266,9 +266,9 @@ static const struct ratbag_test_device ratbagd_test_device_descr = {
 		},
 		{
 			.buttons = {
-				{ .type = RATBAG_BUTTON_ACTION_TYPE_SPECIAL,
+				{ .action_type = RATBAG_BUTTON_ACTION_TYPE_SPECIAL,
 				  .special = RATBAG_BUTTON_ACTION_SPECIAL_PROFILE_CYCLE_UP },
-				{ .type = RATBAG_BUTTON_ACTION_TYPE_MACRO,
+				{ .action_type = RATBAG_BUTTON_ACTION_TYPE_MACRO,
 				  .macro = {
 					  { .type = RATBAG_MACRO_EVENT_KEY_PRESSED,
 					    .value = KEY_A },
@@ -278,9 +278,9 @@ static const struct ratbag_test_device ratbagd_test_device_descr = {
 					    .value = 150 },
 				  }
 				},
-				{ .type = RATBAG_BUTTON_ACTION_TYPE_BUTTON,
+				{ .action_type = RATBAG_BUTTON_ACTION_TYPE_BUTTON,
 				  .button = 2 },
-				{ .type = RATBAG_BUTTON_ACTION_TYPE_BUTTON,
+				{ .action_type = RATBAG_BUTTON_ACTION_TYPE_BUTTON,
 				  .button = 3 },
 			},
 			.resolutions = {

--- a/ratbagd/ratbagd.c
+++ b/ratbagd/ratbagd.c
@@ -200,11 +200,14 @@ static const struct ratbag_test_device ratbagd_test_device_descr = {
 	.profiles = {
 		{
 			.buttons = {
-				{ .action_type = RATBAG_BUTTON_ACTION_TYPE_BUTTON,
+				{ .button_type = RATBAG_BUTTON_TYPE_LEFT,
+				  .action_type = RATBAG_BUTTON_ACTION_TYPE_BUTTON,
 				  .button = 0 },
-				{ .action_type = RATBAG_BUTTON_ACTION_TYPE_KEY,
+				{ .button_type = RATBAG_BUTTON_TYPE_MIDDLE,
+				  .action_type = RATBAG_BUTTON_ACTION_TYPE_KEY,
 				  .key = KEY_3 },
-				{ .action_type = RATBAG_BUTTON_ACTION_TYPE_SPECIAL,
+				{ .button_type = RATBAG_BUTTON_TYPE_RIGHT,
+				  .action_type = RATBAG_BUTTON_ACTION_TYPE_SPECIAL,
 				  .special = RATBAG_BUTTON_ACTION_SPECIAL_PROFILE_CYCLE_UP },
 				{ .action_type = RATBAG_BUTTON_ACTION_TYPE_MACRO,
 				  .macro = {

--- a/src/driver-test.c
+++ b/src/driver-test.c
@@ -100,6 +100,7 @@ test_read_button(struct ratbag_button *button)
 	struct ratbag_button_macro *m;
 	const char data[] = "TEST";
 	const char *c;
+	int idx;
 
 	switch (p->buttons[button->index].type) {
 	case RATBAG_BUTTON_ACTION_TYPE_BUTTON:
@@ -114,15 +115,18 @@ test_read_button(struct ratbag_button *button)
 		button->action.type = RATBAG_BUTTON_ACTION_TYPE_MACRO;
 		m = ratbag_button_macro_new("test macro");
 
+		idx = 0;
 		ARRAY_FOR_EACH(data, c) {
 			char str[6];
+			if (*c == '\0')
+				break;
 			snprintf_safe(str, 6, "KEY_%c", *c);
 			ratbag_button_macro_set_event(m,
-						      0,
+						      idx++,
 						      RATBAG_MACRO_EVENT_KEY_PRESSED,
 						      libevdev_event_code_from_name(EV_KEY, str));
 			ratbag_button_macro_set_event(m,
-						      0,
+						      idx++,
 						      RATBAG_MACRO_EVENT_KEY_RELEASED,
 						      libevdev_event_code_from_name(EV_KEY, str));
 		}

--- a/src/driver-test.c
+++ b/src/driver-test.c
@@ -102,7 +102,7 @@ test_read_button(struct ratbag_button *button)
 	struct ratbag_test_macro_event *e;
 	int idx;
 
-	switch (b->type) {
+	switch (b->action_type) {
 	case RATBAG_BUTTON_ACTION_TYPE_BUTTON:
 		button->action.type = RATBAG_BUTTON_ACTION_TYPE_BUTTON;
 		button->action.action.button = p->buttons[button->index].button;

--- a/src/driver-test.c
+++ b/src/driver-test.c
@@ -102,6 +102,9 @@ test_read_button(struct ratbag_button *button)
 	struct ratbag_test_macro_event *e;
 	int idx;
 
+	/* Only take the button types from the first profile */
+	button->type = d->profiles[0].buttons[button->index].button_type;
+
 	switch (b->action_type) {
 	case RATBAG_BUTTON_ACTION_TYPE_BUTTON:
 		button->action.type = RATBAG_BUTTON_ACTION_TYPE_BUTTON;

--- a/src/driver-test.c
+++ b/src/driver-test.c
@@ -97,12 +97,12 @@ test_read_button(struct ratbag_button *button)
 	struct ratbag_device *device = button->profile->device;
 	struct ratbag_test_device *d = ratbag_get_drv_data(device);
 	struct ratbag_test_profile *p = &d->profiles[button->profile->index];
+	struct ratbag_test_button *b = &p->buttons[button->index];
 	struct ratbag_button_macro *m;
-	const char data[] = "TEST";
-	const char *c;
+	struct ratbag_test_macro_event *e;
 	int idx;
 
-	switch (p->buttons[button->index].type) {
+	switch (b->type) {
 	case RATBAG_BUTTON_ACTION_TYPE_BUTTON:
 		button->action.type = RATBAG_BUTTON_ACTION_TYPE_BUTTON;
 		button->action.action.button = p->buttons[button->index].button;
@@ -116,19 +116,10 @@ test_read_button(struct ratbag_button *button)
 		m = ratbag_button_macro_new("test macro");
 
 		idx = 0;
-		ARRAY_FOR_EACH(data, c) {
-			char str[6];
-			if (*c == '\0')
+		ARRAY_FOR_EACH(b->macro, e) {
+			if (e->type == RATBAG_MACRO_EVENT_NONE)
 				break;
-			snprintf_safe(str, 6, "KEY_%c", *c);
-			ratbag_button_macro_set_event(m,
-						      idx++,
-						      RATBAG_MACRO_EVENT_KEY_PRESSED,
-						      libevdev_event_code_from_name(EV_KEY, str));
-			ratbag_button_macro_set_event(m,
-						      idx++,
-						      RATBAG_MACRO_EVENT_KEY_RELEASED,
-						      libevdev_event_code_from_name(EV_KEY, str));
+			ratbag_button_macro_set_event(m, idx++, e->type, e->value);
 		}
 		ratbag_button_copy_macro(button, m);
 		ratbag_button_macro_unref(m);

--- a/src/libratbag-test.h
+++ b/src/libratbag-test.h
@@ -37,6 +37,7 @@ struct ratbag_test_macro_event {
 };
 
 struct ratbag_test_button {
+	enum ratbag_button_type button_type;
 	enum ratbag_button_action_type action_type;
 	union {
 		int button;

--- a/src/libratbag-test.h
+++ b/src/libratbag-test.h
@@ -37,7 +37,7 @@ struct ratbag_test_macro_event {
 };
 
 struct ratbag_test_button {
-	enum ratbag_button_action_type type;
+	enum ratbag_button_action_type action_type;
 	union {
 		int button;
 		int key;

--- a/src/libratbag-test.h
+++ b/src/libratbag-test.h
@@ -31,12 +31,18 @@
 #define RATBAG_TEST_MAX_RESOLUTIONS 8
 #define RATBAG_TEST_MAX_LEDS 8
 
+struct ratbag_test_macro_event {
+	enum ratbag_macro_event_type type;
+	unsigned int value;
+};
+
 struct ratbag_test_button {
 	enum ratbag_button_action_type type;
 	union {
 		int button;
 		int key;
 		enum ratbag_button_action_special special;
+		struct ratbag_test_macro_event macro[24];
 	};
 };
 

--- a/src/libratbag.h
+++ b/src/libratbag.h
@@ -1235,10 +1235,6 @@ ratbag_button_get_type(struct ratbag_button *button);
  */
 enum ratbag_button_action_type {
 	/**
-	 * Button action is unknown
-	 */
-	RATBAG_BUTTON_ACTION_TYPE_UNKNOWN = -1,
-	/**
 	 * Button is disabled
 	 */
 	RATBAG_BUTTON_ACTION_TYPE_NONE = 0,
@@ -1259,6 +1255,10 @@ enum ratbag_button_action_type {
 	 * Button sends a user-defined key or button sequence
 	 */
 	RATBAG_BUTTON_ACTION_TYPE_MACRO,
+	/**
+	 * Button action is unknown
+	 */
+	RATBAG_BUTTON_ACTION_TYPE_UNKNOWN = 1000,
 };
 
 /**

--- a/test/test-device.c
+++ b/test/test-device.c
@@ -681,7 +681,7 @@ START_TEST(device_buttons)
 	struct ratbag_test_device td = sane_device;
 	td.num_buttons = 10;
 
-	td.profiles[0].buttons[8].type = RATBAG_BUTTON_ACTION_TYPE_MACRO;
+	td.profiles[0].buttons[8].action_type = RATBAG_BUTTON_ACTION_TYPE_MACRO;
 
 	td.destroyed_data = &device_freed_count;
 

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -143,17 +143,28 @@ def print_button(d, p, b, level):
     elif b.action_type == RatbagdButton.ACTION_TYPE_KEY:
         bmap = ""
         for m in b.key:
-            try:
-                code = evdev.ecodes.KEY[m]
-            except KeyError:
-                code = m
-
+            code = evdev.ecodes.KEY.get(m, m)
             bmap = bmap +  "{}".format(code)
+
         print("{}'{}'".format(header, bmap))
     elif b.action_type == RatbagdButton.ACTION_TYPE_SPECIAL:
         print("{}'{}'".format(header, b.special))
     elif b.action_type == RatbagdButton.ACTION_TYPE_MACRO:
-        print("{}macro".format(header))
+        bmap = ""
+        for t, v in b.macro:
+            bt = 'unknown'
+            if t == RatbagdButton.MACRO_KEY_PRESS:
+                bt = '+'
+                bv =  evdev.ecodes.KEY.get(v, v)
+            elif t == RatbagdButton.MACRO_KEY_RELEASE:
+                bt = '-'
+                bv =  evdev.ecodes.KEY.get(v, v)
+            elif t == RatbagdButton.MACRO_WAIT:
+                bt = 't'
+                bv = v
+            bmap = bmap + "{}{} ".format(bt, bv)
+
+        print("{}macro '{}'".format(header, bmap[:-1]))
     elif b.action_type == RatbagdButton.ACTION_TYPE_NONE:
         print("{}none".format(header))
     else:
@@ -304,6 +315,44 @@ def func_button_get(r, args):
 def func_button_action_set_button(r, args):
     b, p, d = find_button(r, args)
     b.mapping = args.target_button
+    d.commit()
+
+def func_button_action_set_macro(r, args):
+    b, p, d = find_button(r, args)
+    macro_keys = args.target_macro
+    macro = []
+    for s in macro_keys:
+        is_press = True
+        is_release = True
+        is_timeout = False
+
+        s = s.upper()
+        if s[0] == 'T':
+            is_timeout = True
+            is_press = False
+            is_release = False
+        elif s[0] == '+':
+            is_release = False
+            s = s[1:]
+        elif s[0] == '-':
+            is_press = False
+            s = s[1:]
+
+        if is_timeout:
+            t = int(s[1:])
+            macro.append((RatbagdButton.MACRO_WAIT, t))
+        else:
+            if not s.startswith("KEY_") and not s.startswith("BTN_"):
+                msg = "Don't know how to convert {}".format(s)
+                raise argparse.ArgumentTypeError(msg)
+
+            code = evdev.ecodes.ecodes[s]
+            if is_press:
+                macro.append((RatbagdButton.MACRO_KEY_PRESS, code))
+            if is_release:
+                macro.append((RatbagdButton.MACRO_KEY_RELEASE, code))
+
+    b.macro = macro
     d.commit()
 
 
@@ -780,7 +829,7 @@ parser_def = [
                                             nargs: argparse.REMAINDER,
                                         },
                                     ],
-                                    func: func_dummy,  # FIXME: func_button_action_set_macro,
+                                    func: func_button_action_set_macro,
                                 },
                             ]
                         },

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -144,7 +144,7 @@ def print_button(d, p, b, level):
     elif b.action_type == "special":
         print("{}'{}'".format(header, b.special))
     else:
-        print("{}UNKOWN".format(header))
+        print("{}UNKNOWN".format(header))
 
 
 def print_resolution(d, p, r, level):

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -135,8 +135,36 @@ def print_led(d, p, l, level):
 
 
 def print_button(d, p, b, level):
+    types =  {
+        RatbagdButton.TYPE_UNKNOWN : "unknown",
+        RatbagdButton.TYPE_LEFT : "left",
+        RatbagdButton.TYPE_MIDDLE : "middle",
+        RatbagdButton.TYPE_RIGHT : "right",
+        RatbagdButton.TYPE_THUMB : "thumb",
+        RatbagdButton.TYPE_THUMB2 : "thumb2",
+        RatbagdButton.TYPE_THUMB3 : "thumb3",
+        RatbagdButton.TYPE_THUMB4 : "thumb4",
+        RatbagdButton.TYPE_WHEEL_LEFT : "wheel-left",
+        RatbagdButton.TYPE_WHEEL_RIGHT : "wheel-right",
+        RatbagdButton.TYPE_WHEEL_CLICK : "wheel-click",
+        RatbagdButton.TYPE_WHEEL_UP : "wheel-up",
+        RatbagdButton.TYPE_WHEEL_DOWN : "wheel-down",
+        RatbagdButton.TYPE_WHEEL_RATCHET_MODE_SHIFT : "wheel-ratchet-mode-shift",
+        RatbagdButton.TYPE_EXTRA : "extra",
+        RatbagdButton.TYPE_SIDE : "side",
+        RatbagdButton.TYPE_PINKIE : "pinkie",
+        RatbagdButton.TYPE_PINKIE2 : "pinkie2",
+        RatbagdButton.TYPE_RESOLUTION_CYCLE_UP : "resolution-cycle-up",
+        RatbagdButton.TYPE_RESOLUTION_UP : "resolution-up",
+        RatbagdButton.TYPE_RESOLUTION_DOWN : "resolution-down",
+        RatbagdButton.TYPE_PROFILE_CYCLE_UP : "profile-cycle-up",
+        RatbagdButton.TYPE_PROFILE_UP : "profile-up",
+        RatbagdButton.TYPE_PROFILE_DOWN : "profile-down",
+    }
+
+    t = types[b.type]
     header = " " * level + "Button: {} type {} is mapped to ".format(b.index,
-                                                                     b.type)
+                                                                     t)
 
     if b.action_type == RatbagdButton.ACTION_TYPE_BUTTON:
         print("{}'button {}'".format(header, b.mapping))

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -137,12 +137,16 @@ def print_button(d, p, b, level):
     header = " " * level + "Button: {} type {} is mapped to ".format(b.index,
                                                                      b.type)
 
-    if b.action_type == "button":
+    if b.action_type == RatbagdButton.ACTION_TYPE_BUTTON:
         print("{}'button {}'".format(header, b.mapping))
-    elif b.action_type == "key":
+    elif b.action_type == RatbagdButton.ACTION_TYPE_KEY:
         print("{}'{}'".format(header, b.key))
-    elif b.action_type == "special":
+    elif b.action_type == RatbagdButton.ACTION_TYPE_SPECIAL:
         print("{}'{}'".format(header, b.special))
+    elif b.action_type == RatbagdButton.ACTION_TYPE_MACRO:
+        print("{}macro".format(header))
+    elif b.action_type == RatbagdButton.ACTION_TYPE_NONE:
+        print("{}none".format(header))
     else:
         print("{}UNKNOWN".format(header))
 

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -23,6 +23,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
+import evdev
 import sys
 import argparse
 
@@ -140,7 +141,15 @@ def print_button(d, p, b, level):
     if b.action_type == RatbagdButton.ACTION_TYPE_BUTTON:
         print("{}'button {}'".format(header, b.mapping))
     elif b.action_type == RatbagdButton.ACTION_TYPE_KEY:
-        print("{}'{}'".format(header, b.key))
+        bmap = ""
+        for m in b.key:
+            try:
+                code = evdev.ecodes.KEY[m]
+            except KeyError:
+                code = m
+
+            bmap = bmap +  "{}".format(code)
+        print("{}'{}'".format(header, bmap))
     elif b.action_type == RatbagdButton.ACTION_TYPE_SPECIAL:
         print("{}'{}'".format(header, b.special))
     elif b.action_type == RatbagdButton.ACTION_TYPE_MACRO:

--- a/tools/ratbagctl.test.in
+++ b/tools/ratbagctl.test.in
@@ -358,7 +358,7 @@ class TestRatbgagCtlButton(TestRatbagCtl):
         # FIXME: special maps to UNKNOWN????
         self.assertEqual(r, "Button: 2 type unknown is mapped to UNKNOWN")
         r = self.launch_good_test("button 3 get test_device")
-        self.assertEqual(r, "Button: 3 type unknown is mapped to macro")
+        self.assertEqual(r, "Button: 3 type unknown is mapped to macro '+KEY_B -KEY_B t300'")
         self.launch_fail_test("button 1 get 10 test_device")
         self.launch_fail_test("button 10 get test_device")
         self.launch_fail_test("button 1 get test_device X")
@@ -389,10 +389,14 @@ class TestRatbgagCtlButton(TestRatbagCtl):
         pass
         # FIXME
 
-    @unittest.skip("Button action set macro not implemented")
     def test_button_n_action_set_macro(self):
-        pass
-        # FIXME
+        command = "button 2 action set macro "
+        self.launch_good_test(command + 'KEY_B KEY_A KEY_C test_device')
+        r = self.launch_good_test("button 2 get test_device")
+        self.assertEqual(r, "Button: 2 type unknown is mapped to macro '+KEY_B -KEY_B +KEY_A -KEY_A +KEY_C -KEY_C'")
+        self.launch_good_test(command + 't100 t200 test_device')
+        r = self.launch_good_test("button 2 get test_device")
+        self.assertEqual(r, "Button: 2 type unknown is mapped to macro 't100 t200'")
 
     def test_prefix_button(self):
         r = self.launch_good_test("Profile 2 Button 3 get test_device")

--- a/tools/ratbagctl.test.in
+++ b/tools/ratbagctl.test.in
@@ -357,10 +357,10 @@ class TestRatbgagCtlButton(TestRatbagCtl):
         self.assertEqual(r, "Button: 1 type unknown is mapped to '[4]'")
         r = self.launch_good_test("button 2 get test_device")
         # FIXME: special maps to UNKNOWN????
-        self.assertEqual(r, "Button: 2 type unknown is mapped to UNKOWN")
+        self.assertEqual(r, "Button: 2 type unknown is mapped to UNKNOWN")
         r = self.launch_good_test("button 3 get test_device")
         # FIXME: macro maps to UNKNOWN????
-        self.assertEqual(r, "Button: 3 type unknown is mapped to UNKOWN")
+        self.assertEqual(r, "Button: 3 type unknown is mapped to UNKNOWN")
         self.launch_fail_test("button 1 get 10 test_device")
         self.launch_fail_test("button 10 get test_device")
         self.launch_fail_test("button 1 get test_device X")

--- a/tools/ratbagctl.test.in
+++ b/tools/ratbagctl.test.in
@@ -353,8 +353,7 @@ class TestRatbgagCtlButton(TestRatbagCtl):
         r = self.launch_good_test("button 0 get test_device")
         self.assertEqual(r, "Button: 0 type unknown is mapped to 'button 0'")
         r = self.launch_good_test("button 1 get test_device")
-        # FIXME: we should probably have keys here, not int
-        self.assertEqual(r, "Button: 1 type unknown is mapped to '[4]'")
+        self.assertEqual(r, "Button: 1 type unknown is mapped to 'KEY_3'")
         r = self.launch_good_test("button 2 get test_device")
         # FIXME: special maps to UNKNOWN????
         self.assertEqual(r, "Button: 2 type unknown is mapped to UNKNOWN")

--- a/tools/ratbagctl.test.in
+++ b/tools/ratbagctl.test.in
@@ -351,12 +351,12 @@ class TestRatbgagCtlButton(TestRatbagCtl):
     def test_button_n_get(self):
         self.setProfile(0)
         r = self.launch_good_test("button 0 get test_device")
-        self.assertEqual(r, "Button: 0 type unknown is mapped to 'button 0'")
+        self.assertEqual(r, "Button: 0 type left is mapped to 'button 0'")
         r = self.launch_good_test("button 1 get test_device")
-        self.assertEqual(r, "Button: 1 type unknown is mapped to 'KEY_3'")
+        self.assertEqual(r, "Button: 1 type middle is mapped to 'KEY_3'")
         r = self.launch_good_test("button 2 get test_device")
         # FIXME: special maps to UNKNOWN????
-        self.assertEqual(r, "Button: 2 type unknown is mapped to UNKNOWN")
+        self.assertEqual(r, "Button: 2 type right is mapped to UNKNOWN")
         r = self.launch_good_test("button 3 get test_device")
         self.assertEqual(r, "Button: 3 type unknown is mapped to macro '+KEY_B -KEY_B t300'")
         self.launch_fail_test("button 1 get 10 test_device")
@@ -366,7 +366,7 @@ class TestRatbgagCtlButton(TestRatbagCtl):
     def test_button_n_action_get(self):
         self.setProfile(0)
         r = self.launch_good_test("button 0 action get test_device")
-        self.assertEqual(r, "Button: 0 type unknown is mapped to 'button 0'")
+        self.assertEqual(r, "Button: 0 type left is mapped to 'button 0'")
         self.launch_fail_test("button 1 action get 10 test_device")
         self.launch_fail_test("button 10 action get test_device")
         self.launch_fail_test("button 1 action get test_device X")
@@ -375,11 +375,11 @@ class TestRatbgagCtlButton(TestRatbagCtl):
         self.setProfile(2)
         command = "button 2 action set button"
         r = self.launch_good_test("button 2 action get test_device")
-        self.assertEqual(r, "Button: 2 type unknown is mapped to 'button 2'")
+        self.assertEqual(r, "Button: 2 type right is mapped to 'button 2'")
         r = self.launch_good_test(command + " 1 test_device")
         self.assertEqual(r, '')
         r = self.launch_good_test("button 2 action get test_device")
-        self.assertEqual(r, "Button: 2 type unknown is mapped to 'button 1'")
+        self.assertEqual(r, "Button: 2 type right is mapped to 'button 1'")
         self.launch_fail_test(command)
         self.launch_fail_test(command + " X test_device")
         self.launch_fail_test(command + " 100 test_device X")
@@ -393,10 +393,10 @@ class TestRatbgagCtlButton(TestRatbagCtl):
         command = "button 2 action set macro "
         self.launch_good_test(command + 'KEY_B KEY_A KEY_C test_device')
         r = self.launch_good_test("button 2 get test_device")
-        self.assertEqual(r, "Button: 2 type unknown is mapped to macro '+KEY_B -KEY_B +KEY_A -KEY_A +KEY_C -KEY_C'")
+        self.assertEqual(r, "Button: 2 type right is mapped to macro '+KEY_B -KEY_B +KEY_A -KEY_A +KEY_C -KEY_C'")
         self.launch_good_test(command + 't100 t200 test_device')
         r = self.launch_good_test("button 2 get test_device")
-        self.assertEqual(r, "Button: 2 type unknown is mapped to macro 't100 t200'")
+        self.assertEqual(r, "Button: 2 type right is mapped to macro 't100 t200'")
 
     def test_prefix_button(self):
         r = self.launch_good_test("Profile 2 Button 3 get test_device")

--- a/tools/ratbagctl.test.in
+++ b/tools/ratbagctl.test.in
@@ -359,8 +359,7 @@ class TestRatbgagCtlButton(TestRatbagCtl):
         # FIXME: special maps to UNKNOWN????
         self.assertEqual(r, "Button: 2 type unknown is mapped to UNKNOWN")
         r = self.launch_good_test("button 3 get test_device")
-        # FIXME: macro maps to UNKNOWN????
-        self.assertEqual(r, "Button: 3 type unknown is mapped to UNKNOWN")
+        self.assertEqual(r, "Button: 3 type unknown is mapped to macro")
         self.launch_fail_test("button 1 get 10 test_device")
         self.launch_fail_test("button 10 get test_device")
         self.launch_fail_test("button 1 get test_device X")

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -150,7 +150,7 @@ class _RatbagdDBus(GObject.GObject):
             return p.unpack()
         return p
 
-    def _set_dbus_property(self, property, type, value):
+    def _set_dbus_property(self, property, type, value, readwrite=True):
         # Sets a cached property on the bus.
 
         # Take our real value and wrap it into a variant. To call
@@ -158,10 +158,11 @@ class _RatbagdDBus(GObject.GObject):
         # into a (ssv), where v is our value's variant.
         # args to .Set are "interface name", "function name",  value-variant
         val = GLib.Variant("{}".format(type), value)
-        pval = GLib.Variant("(ssv)".format(type), (self._interface, property, val))
-        self._proxy.call_sync("org.freedesktop.DBus.Properties.Set",
-                              pval, Gio.DBusCallFlags.NO_AUTO_START,
-                              500, None)
+        if readwrite:
+            pval = GLib.Variant("(ssv)".format(type), (self._interface, property, val))
+            self._proxy.call_sync("org.freedesktop.DBus.Properties.Set",
+                                  pval, Gio.DBusCallFlags.NO_AUTO_START,
+                                  500, None)
 
         # This is our local copy, so we don't have to wait for the async
         # update
@@ -438,6 +439,10 @@ class RatbagdButton(_RatbagdDBus):
     ACTION_TYPE_KEY = 3
     ACTION_TYPE_MACRO = 4
 
+    MACRO_KEY_PRESS = 1
+    MACRO_KEY_RELEASE = 2
+    MACRO_WAIT = 3
+
     def __init__(self, object_path):
         _RatbagdDBus.__init__(self, "Button", object_path)
 
@@ -464,6 +469,25 @@ class RatbagdButton(_RatbagdDBus):
         """
         ret = self._dbus_call("SetButtonMapping", "u", button)
         self._set_dbus_property("ButtonMapping", "u", button)
+        return ret
+
+    @GObject.Property
+    def macro(self):
+        """A list of (type, keycode) tuples that form the currently set macro,
+        where type is either RatbagdButton.KEY_PRESS or RatbagdButton.KEY_RELEASE
+        and the keycode is as specified in linux/input.h."""
+        return self._get_dbus_property("Macro")
+
+    @macro.setter
+    def macro(self, macro):
+        """Set the macro to the given macro. Note that the type must be one of
+        RatbagdButton.KEY_PRESS or RatbagdButton.KEY_RELEASE and the keycodes
+        must be as specified in linux/input.h.
+
+        @param macro A list of (type, keycode) tuples to form the new macro.
+        """
+        ret = self._dbus_call("SetMacro", "a(uu)", macro)
+        self._set_dbus_property("Macro", "a(uu)", macro, readwrite=False)
         return ret
 
     @GObject.Property

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -443,6 +443,32 @@ class RatbagdButton(_RatbagdDBus):
     MACRO_KEY_RELEASE = 2
     MACRO_WAIT = 3
 
+    TYPE_UNKNOWN = 0
+    TYPE_LEFT = 1
+    TYPE_MIDDLE = 2
+    TYPE_RIGHT= 3
+    TYPE_THUMB = 4
+    TYPE_THUMB2 = 5
+    TYPE_THUMB3 = 6
+    TYPE_THUMB4 = 7
+    TYPE_WHEEL_LEFT = 8
+    TYPE_WHEEL_RIGHT = 9
+    TYPE_WHEEL_CLICK = 10
+    TYPE_WHEEL_UP = 11
+    TYPE_WHEEL_DOWN = 12
+    TYPE_WHEEL_RATCHET_MODE_SHIFT = 13
+    TYPE_EXTRA = 14
+    TYPE_SIDE = 15
+    TYPE_PINKIE = 16
+    TYPE_PINKIE2 = 17
+    TYPE_RESOLUTION_CYCLE_UP = 18
+    TYPE_RESOLUTION_UP = 19
+    TYPE_RESOLUTION_DOWN = 20
+    TYPE_PROFILE_CYCLE_UP = 21
+    TYPE_PROFILE_UP = 22
+    TYPE_PROFILE_DOWN = 23
+
+
     def __init__(self, object_path):
         _RatbagdDBus.__init__(self, "Button", object_path)
 
@@ -453,7 +479,7 @@ class RatbagdButton(_RatbagdDBus):
 
     @GObject.Property
     def type(self):
-        """A string describing this button's type."""
+        """An enum describing this button's type."""
         return self._get_dbus_property("Type")
 
     @GObject.Property

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -432,6 +432,12 @@ class RatbagdResolution(_RatbagdDBus):
 class RatbagdButton(_RatbagdDBus):
     """Represents a ratbagd button."""
 
+    ACTION_TYPE_NONE = 0
+    ACTION_TYPE_BUTTON = 1
+    ACTION_TYPE_SPECIAL = 2
+    ACTION_TYPE_KEY = 3
+    ACTION_TYPE_MACRO = 4
+
     def __init__(self, object_path):
         _RatbagdDBus.__init__(self, "Button", object_path)
 
@@ -494,8 +500,9 @@ class RatbagdButton(_RatbagdDBus):
 
     @GObject.Property
     def action_type(self):
-        """A string describing the action type of the button. One of "none",
-        "button", "key", "special", "macro" or "unknown". This decides which
+        """An enum describing the action type of the button. One of
+        ACTION_TYPE_NONE, ACTION_TYPE_BUTTON, ACTION_TYPE_SPECIAL,
+        ACTION_TYPE_KEY, ACTION_TYPE_MACRO. This decides which
         *Mapping property has a value.
         """
         return self._get_dbus_property("ActionType")


### PR DESCRIPTION
Disclaimer: I just finished this and I'm running out of time before leaving. The test suite passes, but there may be bugs left, sorry.

Main item here is support for macros in ratbagd. I'm not 100% sure whether that'll be the final API, but the approach here is an array of tuples of `(type, value)` for each element in the macro. Macro names are picked by ratbagd. There's the theoretical case of exposing macros as separate objects on dbus but I don't think that's worth doing. DBus would allow for `SetMacro(s, a(uu))` where we can set the string as well, may be worth doing, maybe not.

Meanwhile, this will be at least useful, if it works ;)

This pull also removes the remaining string button properties and changes them to enums. The LED type is still left and should be fixed too.
