### PR TITLE
RatbagdProfile: emit ActiveProfileChanged signal on the device

### DIFF
--- a/DBusInterface.md
+++ b/DBusInterface.md
@@ -69,7 +69,6 @@ The capabilities supported by this device. see `enum
 ratbag_device_capability` in libratbag.h for the list of permissible
 capabilities.
 
-
 #### `Svg`
 - type: `s`, read-only, constant
 
@@ -84,6 +83,8 @@ profiles.
 Provides the list of profile paths for all profiles on this device, see
 **org.freedesktop.ratbag1.Profile**.
 
+### Methods
+
 #### `Commit() → ()`
 
 Commits the changes to the device. Changes to the device are batched; they
@@ -97,6 +98,13 @@ none is available.  The theme must be one of
 guaranteed to be available. ratbagd may return the path to a file that
 doesn't exist. This is the case if the device has SVGs available but not for
 the given theme.
+
+### Signals
+
+#### `ActiveProfileChanged(u)`
+
+Emitted when the active profile is changed, with the index of the new active
+profile.
 
 org.freedesktop.ratbag1.Profile
 ===============================

--- a/ratbagd/ratbagd-profile.c
+++ b/ratbagd/ratbagd-profile.c
@@ -298,6 +298,13 @@ static int ratbagd_profile_set_active(sd_bus_message *m,
 					profile->device,
 					ratbagd_profile_active_signal_cb);
 
+	(void) sd_bus_emit_signal(sd_bus_message_get_bus(m),
+				  ratbagd_device_get_path(profile->device),
+				  RATBAGD_NAME_ROOT ".Device",
+				  "ActiveProfileChanged",
+				  "u",
+				  profile->index);
+
         return sd_bus_reply_method_return(m, "u",
                                           ratbag_profile_set_active(profile->lib_profile));
 }


### PR DESCRIPTION
This allows Piper to listen for profile changes using a clean approach based on this one signal.