### PR TITLE
Emit PropertyChanged signals for AcitonType when setting button mappings

### DIFF
--- a/DBusInterface.md
+++ b/DBusInterface.md
@@ -240,6 +240,11 @@ Enum describing the current special mapping (if mapped to special)
 
 Array of uints, first entry is the keycode, other entries, if any, are
 modifiers (if mapped to key)
+#### `Macro`
+-type: `a(uu)`, read-only, mutable
+
+Array of (type, keycode), where type may be one of
+`RATBAG_MACRO_EVENT_KEY_PRESSED` or `RATBAG_MACRO_EVENT_KEY_RELEASED`.
 #### `ActionType`
 - type: `u`, read-only, mutable
 
@@ -259,6 +264,9 @@ Set the button mapping to the given special entry
 #### `SetKeyMapping(au) → ()`
 Set the key mapping, first entry is the keycode, other entries, if any, are
 modifier keycodes
+#### `SetMacro(a(uu)) → ()`
+Set the macro, as an array of (type, key) where type may be one of
+`RATBAG_MACRO_EVENT_KEY_PRESSED` or `RATBAG_MACRO_EVENT_KEY_RELEASED`.
 #### `Disable() → ()`
 Disable this button
 

--- a/ratbagd/ratbagd-button.c
+++ b/ratbagd/ratbagd-button.c
@@ -367,6 +367,15 @@ static int ratbagd_button_set_macro(sd_bus_message *m,
 	if (r < 0)
 		return r;
 
+	if (r == 0) {
+		sd_bus *bus = sd_bus_message_get_bus(m);
+		sd_bus_emit_properties_changed(bus,
+					       button->path,
+					       RATBAGD_NAME_ROOT ".Button",
+					       "Macro",
+					       NULL);
+	}
+
 	return sd_bus_reply_method_return(m, "u", r);
 }
 

--- a/ratbagd/ratbagd-button.c
+++ b/ratbagd/ratbagd-button.c
@@ -222,6 +222,15 @@ static int ratbagd_button_set_key(sd_bus_message *m,
 
 	r = ratbag_button_set_key(button->lib_button, key, modifiers, nmodifiers);
 
+	if (r == 0) {
+		sd_bus *bus = sd_bus_message_get_bus(m);
+		sd_bus_emit_properties_changed(bus,
+					       button->path,
+					       RATBAGD_NAME_ROOT ".Button",
+					       "KeyMapping",
+					       NULL);
+	}
+
 	return sd_bus_reply_method_return(m, "u", r);
 }
 

--- a/ratbagd/ratbagd-button.c
+++ b/ratbagd/ratbagd-button.c
@@ -100,6 +100,12 @@ static int ratbagd_button_set_button(sd_bus_message *m,
 					       RATBAGD_NAME_ROOT ".Button",
 					       "ButtonMapping",
 					       NULL);
+
+		sd_bus_emit_properties_changed(bus,
+					       button->path,
+					       RATBAGD_NAME_ROOT ".Button",
+					       "ActionType",
+					       NULL);
 	}
 
 	return sd_bus_reply_method_return(m, "u", r);
@@ -141,6 +147,12 @@ static int ratbagd_button_set_special(sd_bus_message *m,
 					       button->path,
 					       RATBAGD_NAME_ROOT ".Button",
 					       "SpecialMapping",
+					       NULL);
+
+		sd_bus_emit_properties_changed(bus,
+					       button->path,
+					       RATBAGD_NAME_ROOT ".Button",
+					       "ActionType",
 					       NULL);
 	}
 
@@ -228,6 +240,12 @@ static int ratbagd_button_set_key(sd_bus_message *m,
 					       button->path,
 					       RATBAGD_NAME_ROOT ".Button",
 					       "KeyMapping",
+					       NULL);
+
+		sd_bus_emit_properties_changed(bus,
+					       button->path,
+					       RATBAGD_NAME_ROOT ".Button",
+					       "ActionType",
 					       NULL);
 	}
 
@@ -373,6 +391,12 @@ static int ratbagd_button_set_macro(sd_bus_message *m,
 					       button->path,
 					       RATBAGD_NAME_ROOT ".Button",
 					       "Macro",
+					       NULL);
+
+		sd_bus_emit_properties_changed(bus,
+					       button->path,
+					       RATBAGD_NAME_ROOT ".Button",
+					       "ActionType",
 					       NULL);
 	}
 


### PR DESCRIPTION
Internally, setting mappings changes the action type but this isn't reflected on DBus because ratbagd doesn't emit the PropertyChanged signal for them.