### PR TITLE
profiles name support

### DIFF
--- a/ratbagd/ratbagd.c
+++ b/ratbagd/ratbagd.c
@@ -266,6 +266,7 @@ static const struct ratbag_test_device ratbagd_test_device_descr = {
 			},
 			.active = false,
 			.dflt = true,
+			.caps = { RATBAG_PROFILE_CAP_WRITABLE_NAME },
 		},
 		{
 			.buttons = {

--- a/src/driver-test.c
+++ b/src/driver-test.c
@@ -70,6 +70,10 @@ test_read_profile(struct ratbag_profile *profile, unsigned int index)
 
 	profile->is_active = p->active;
 	profile->is_enabled = !p->disabled;
+
+	for (i = 0; i < ARRAY_LENGTH(p->caps) && p->caps[i]; i++) {
+		ratbag_profile_set_cap(profile, p->caps[i]);
+	}
 }
 
 static int

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -261,6 +261,7 @@ struct ratbag_led {
 struct ratbag_profile {
 	int refcount;
 	void *userdata;
+	char *name;
 
 	struct list link;
 	unsigned index;

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -277,6 +277,7 @@ struct ratbag_profile {
 	bool is_active;		/**< profile is the currently active one */
 	bool is_enabled;
 	bool dirty;       /**< profile changed since last commit */
+	unsigned long capabilities[NLONGS(MAX_CAP)];
 };
 
 #define BUTTON_ACTION_NONE \
@@ -395,6 +396,15 @@ static inline void *
 ratbag_profile_get_drv_data(struct ratbag_profile *profile)
 {
 	return profile->drv_data;
+}
+
+static inline void
+ratbag_profile_set_cap(struct ratbag_profile *profile,
+		       enum ratbag_profile_capability cap)
+{
+	assert(cap <= MAX_CAP);
+
+	long_set_bit(profile->capabilities, cap);
 }
 
 static inline int

--- a/src/libratbag-test.h
+++ b/src/libratbag-test.h
@@ -76,6 +76,7 @@ struct ratbag_test_profile {
 	bool active;
 	bool dflt;
 	bool disabled;
+	uint32_t caps[10];
 };
 
 struct ratbag_test_device {

--- a/src/libratbag-util.h
+++ b/src/libratbag-util.h
@@ -118,6 +118,24 @@ snprintf_safe(char *buf, size_t n, const char *fmt, ...)
 #define sprintf_safe(buf, fmt, ...) \
 	snprintf_safe(buf, ARRAY_LENGTH(buf), fmt, __VA_ARGS__)
 
+__attribute__((format(printf, 1, 2)))
+static inline void *
+asprintf_safe(const char *fmt, ...)
+{
+	va_list args;
+	int rc;
+	char *result;
+
+	va_start(args, fmt);
+	rc = vasprintf(&result, fmt, args);
+	va_end(args);
+
+	if (rc < 0)
+		abort();
+
+	return result;
+}
+
 static inline void
 msleep(unsigned int ms)
 {

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -634,6 +634,16 @@ ratbag_profile_init_leds(struct ratbag_profile *profile, unsigned int count)
 	return 0;
 }
 
+LIBRATBAG_EXPORT int
+ratbag_profile_has_capability(const struct ratbag_profile *profile,
+			      enum ratbag_profile_capability cap)
+{
+	if (cap == RATBAG_PROFILE_CAP_NONE || cap >= MAX_CAP)
+		abort();
+
+	return long_bit_is_set(profile->capabilities, cap);
+}
+
 static struct ratbag_profile *
 ratbag_create_profile(struct ratbag_device *device,
 		      unsigned int index,

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -663,6 +663,7 @@ ratbag_create_profile(struct ratbag_device *device,
 						   sizeof(*profile->resolution.modes));
 	profile->resolution.num_modes = num_resolutions;
 	profile->is_enabled = true;
+	profile->name = asprintf_safe("Profile %d", index + 1);
 
 	list_insert(&device->profiles, &profile->link);
 	list_init(&profile->buttons);
@@ -742,6 +743,9 @@ ratbag_profile_destroy(struct ratbag_profile *profile)
 		ratbag_led_destroy(led);
 
 	free(profile->resolution.modes);
+
+	if (profile->name)
+		free(profile->name);
 
 	list_remove(&profile->link);
 	free(profile);
@@ -1530,6 +1534,31 @@ ratbag_profile_get_led(struct ratbag_profile *profile,
 			  index, profile->index);
 
 	return NULL;
+}
+
+LIBRATBAG_EXPORT const char *
+ratbag_profile_get_name(struct ratbag_profile *profile)
+{
+	return profile->name;
+}
+
+LIBRATBAG_EXPORT int
+ratbag_profile_set_name(struct ratbag_profile *profile,
+			const char *name)
+{
+	char *name_copy;
+
+	if (!ratbag_profile_has_capability(profile,
+					   RATBAG_PROFILE_CAP_WRITABLE_NAME))
+		return RATBAG_ERROR_CAPABILITY;
+
+	name_copy = strdup_safe(name);
+	if (profile->name)
+		free(profile->name);
+
+	profile->name = name_copy;
+
+	return 0;
 }
 
 LIBRATBAG_EXPORT void

--- a/src/libratbag.h
+++ b/src/libratbag.h
@@ -651,6 +651,14 @@ ratbag_device_get_num_leds(struct ratbag_device *device);
  */
 enum ratbag_profile_capability {
 	RATBAG_PROFILE_CAP_NONE = 0,
+	/**
+	 * The device has the capability to write a name to a profile
+	 * and store it in its flash.
+	 *
+	 * Any changes uploaded to the device will be cached in libratbag
+	 * and will be committed to it after a commit only.
+	 */
+	RATBAG_PROFILE_CAP_WRITABLE_NAME = 100,
 };
 /**
  * @ingroup profile
@@ -687,6 +695,31 @@ ratbag_profile_unref(struct ratbag_profile *profile);
 int
 ratbag_profile_has_capability(const struct ratbag_profile *profile,
 			      enum ratbag_profile_capability cap);
+
+/**
+ * @ingroup profile
+ *
+ * Return the ratbag profile name.
+ *
+ * @param profile A previously initialized ratbag profile
+ * @return the profile name
+ */
+const char *
+ratbag_profile_get_name(struct ratbag_profile *profile);
+
+/**
+ * @ingroup profile
+ *
+ * Set the name of a ratbag profile.
+ *
+ * @param profile A previously initialized ratbag profile
+ * @param name the profile name
+ *
+ * @return 0 on success or an error code otherwise
+ */
+int
+ratbag_profile_set_name(struct ratbag_profile *profile,
+			const char *name);
 
 /**
  * @ingroup profile

--- a/src/libratbag.h
+++ b/src/libratbag.h
@@ -648,6 +648,12 @@ ratbag_device_get_num_leds(struct ratbag_device *device);
 
 /**
  * @ingroup profile
+ */
+enum ratbag_profile_capability {
+	RATBAG_PROFILE_CAP_NONE = 0,
+};
+/**
+ * @ingroup profile
  *
  * Add a reference to the profile. A profile is destroyed whenever the
  * reference count reaches 0. See @ref ratbag_profile_unref.
@@ -670,6 +676,17 @@ ratbag_profile_ref(struct ratbag_profile *profile);
  */
 struct ratbag_profile *
 ratbag_profile_unref(struct ratbag_profile *profile);
+
+/**
+ * @ingroup profile
+ *
+ * Check if a profile has a specific capability.
+ *
+ * @return non-zero if the capability is available, zero otherwise.
+ */
+int
+ratbag_profile_has_capability(const struct ratbag_profile *profile,
+			      enum ratbag_profile_capability cap);
 
 /**
  * @ingroup profile

--- a/src/libratbag.sym
+++ b/src/libratbag.sym
@@ -59,6 +59,7 @@ global:
 	ratbag_led_unref;
 	ratbag_device_get_num_leds;
 	ratbag_profile_get_button;
+	ratbag_profile_get_name;
 	ratbag_profile_get_num_resolutions;
 	ratbag_profile_get_resolution;
 	ratbag_profile_get_user_data;
@@ -69,6 +70,7 @@ global:
 	ratbag_profile_set_user_data;
 	ratbag_profile_set_active;
 	ratbag_profile_set_enabled;
+	ratbag_profile_set_name;
 	ratbag_profile_unref;
 	ratbag_resolution_get_dpi;
 	ratbag_resolution_get_dpi_maximum;

--- a/src/libratbag.sym
+++ b/src/libratbag.sym
@@ -62,6 +62,7 @@ global:
 	ratbag_profile_get_num_resolutions;
 	ratbag_profile_get_resolution;
 	ratbag_profile_get_user_data;
+	ratbag_profile_has_capability;
 	ratbag_profile_is_active;
 	ratbag_profile_is_enabled;
 	ratbag_profile_ref;

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -523,6 +523,11 @@ def func_profile_disable(r, args):
     d.commit()
 
 
+def func_device_name_get(r, args):
+    d = find_device(r, args)
+    print(d.name)
+
+
 ################################################################################
 # these are definitions to be reused in the dict that defines our language
 
@@ -637,6 +642,12 @@ parser_def = [
         help_str: 'Show device information',
         func: show_device,
         group: 'Device',
+    },
+    {
+        of_type: command,
+        name: 'name',
+        help_str: 'Returns the device name',
+        func: func_device_name_get,
     },
     {
         of_type: switch,

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -27,7 +27,7 @@ import evdev
 import sys
 import argparse
 
-from ratbagd import Ratbagd, RatbagdDevice, RatbagdProfile, RatbagdResolution, RatbagdButton, RatbagdLed, RatbagdDBusUnavailable  # NOQA
+from ratbagd import Ratbagd, RatbagdDevice, RatbagdProfile, RatbagdResolution, RatbagdButton, RatbagdLed, RatbagdDBusUnavailable, RatbagError, RatbagErrorCapability  # NOQA
 
 button_specials_strmap = {
     RatbagdButton.ACTION_SPECIAL_UNKNOWN: "unknown",
@@ -248,6 +248,7 @@ def print_profile(d, p, level):
                                                        " (disabled)" if not p.enabled else "",
                                                        " (active)" if p.is_active else ""))
     if p.enabled:
+        print(" " * level + "Name : '{}'".format(p.name))
         print(" " * level + "Resolutions:")
         for r in p.resolutions:
             print_resolution(d, p, r, level + 2)
@@ -495,6 +496,19 @@ def func_profile_get(r, args):
     print_profile(d, p, 0)
 
 
+def func_profile_name_get(r, args):
+    p, d = find_profile(r, args)
+    print(p.name)
+
+
+def func_profile_name_set(r, args):
+    p, d = find_profile(r, args)
+    if RatbagdProfile.CAP_WRITABLE_NAME not in p.capabilities:
+        raise RatbagErrorCapability("assigning a profile name is not supported on this profile")
+    p.name = args.name
+    d.commit()
+
+
 def func_profile_active_get(r, args):
     d = find_device(r, args)
     for p in d.profiles:
@@ -696,6 +710,33 @@ parser_def = [
                     name: 'get',
                     help_str: 'Show selected profile information',
                     func: func_profile_get,
+                },
+                {
+                    of_type: switch,
+                    name: 'name',
+                    help_str: 'access profile name information',
+                    switch: [
+                        {
+                            of_type: command,
+                            name: 'get',
+                            help_str: 'Show the name of the profile',
+                            func: func_profile_name_get,
+                        },
+                        {
+                            of_type: command,
+                            name: 'set',
+                            help_str: 'Set the name of the profile',
+                            pos_args: [
+                                {
+                                    of_type: argument,
+                                    name: 'name',
+                                    metavar: 'blah',
+                                    help_str: 'The name to set',
+                                },
+                            ],
+                            func: func_profile_name_set,
+                        },
+                    ],
                 },
                 {
                     of_type: command,

--- a/tools/ratbagctl.test.in
+++ b/tools/ratbagctl.test.in
@@ -116,6 +116,14 @@ class TestRatbagCtlInfo(TestRatbagCtl):
         self.launch_fail_test("info X")
 
 
+class TestRatbagCtlName(TestRatbagCtl):
+    def test_get(self):
+        r = self.launch_good_test("name test_device")
+        self.assertEqual(r, 'Test device')
+        self.launch_fail_test("name test_device X")
+        self.launch_fail_test("name X")
+
+
 class TestRatbgagCtlProfile(TestRatbagCtl):
     @classmethod
     def setUpClass(cls):

--- a/tools/ratbagctl.test.in
+++ b/tools/ratbagctl.test.in
@@ -97,6 +97,11 @@ class TestRatbagCtl(unittest.TestCase):
         self.assertNotEqual(returncode, 0)
         return stdout
 
+    def launch_fail_with_exception_test(self, params, exception):
+        with self.assertRaises(exception):
+            returncode, stdout, stderr = self.run_ratbagctl(params)
+        return ''
+
     @classmethod
     def setProfile(cls, profile):
         cls.run_ratbagctl("Profile active set {} test_device".format(profile))
@@ -129,6 +134,29 @@ class TestRatbgagCtlProfile(TestRatbagCtl):
     def setUpClass(cls):
         super(TestRatbgagCtlProfile, cls).setUpClass()
         cls.setProfile(0)
+
+    def test_profile_name_get(self):
+        command = "profile 0 name get"
+        r = self.launch_good_test(command + " test_device")
+        self.assertEqual(r, 'Profile 1')
+        self.launch_fail_test(command)
+        self.launch_fail_test(command + " X test_device")
+        self.launch_fail_test("profile name get test_device")
+
+    def test_profile_name_set(self):
+        r = self.launch_good_test("profile 1 name get test_device")
+        self.assertEqual(r, 'Profile 2')
+        self.launch_good_test("profile 1 name set banana test_device")
+        r = self.launch_good_test("profile 1 name get test_device")
+        self.assertEqual(r, 'banana')
+        # profile 0 doesn't have the capability RATBAG_PROFILE_CAP_WRITABLE_NAME
+        self.launch_fail_with_exception_test("profile 0 name set kiwi test_device", toolbox.RatbagErrorCapability)
+        # better be safe than sorry, checking that the previous actually failed :)
+        r = self.launch_good_test("profile 0 name get test_device")
+        self.assertNotEqual(r, 'kiwi')
+        self.launch_fail_test("profile 1 name set blah")
+        self.launch_fail_test("profile 1 name set blah X test_device")
+        self.launch_fail_test("profile name set blah test_device")
 
     def test_profile_active_get(self):
         command = "profile active get"

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -293,6 +293,16 @@ class RatbagdProfile(_RatbagdDBus):
         _RatbagdDBus.__init__(self, "Profile", object_path)
 
     @GObject.Property
+    def capabilities(self):
+        """The capabilities of this profile as an array. Capabilities not
+        present on the profile are not in the list. Thus use e.g.
+
+        if RatbagdPorfile.CAP_WRITABLE_NAME is in profile.capabilities:
+            do something
+        """
+        return self._get_dbus_property("Capabilities")
+
+    @GObject.property
     def index(self):
         """The index of this profile."""
         return self._get_dbus_property("Index")

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -289,6 +289,8 @@ class RatbagdDevice(_RatbagdDBus):
 class RatbagdProfile(_RatbagdDBus):
     """Represents a ratbagd profile."""
 
+    CAP_WRITABLE_NAME = 100
+
     def __init__(self, object_path):
         _RatbagdDBus.__init__(self, "Profile", object_path)
 
@@ -297,12 +299,24 @@ class RatbagdProfile(_RatbagdDBus):
         """The capabilities of this profile as an array. Capabilities not
         present on the profile are not in the list. Thus use e.g.
 
-        if RatbagdPorfile.CAP_WRITABLE_NAME is in profile.capabilities:
+        if RatbagdProfile.CAP_WRITABLE_NAME is in profile.capabilities:
             do something
         """
         return self._get_dbus_property("Capabilities")
 
     @GObject.property
+    def name(self):
+        """The name of the profile"""
+        return self._get_dbus_property("Name")
+
+    @name.setter
+    def name(self, name):
+        """Set the name of this profile.
+
+        @param name The new name, as str"""
+        self._set_dbus_property("Name", "s", name)
+
+    @GObject.Property
     def index(self):
         """The index of this profile."""
         return self._get_dbus_property("Index")

--- a/tools/toolbox.py
+++ b/tools/toolbox.py
@@ -100,7 +100,7 @@ def terminate_ratbagd(ratbagd):
 
 ratbagctl = import_non_standard_path(RATBAGCTL_NAME, RATBAGCTL_PATH)
 
-from ratbagctl import open_ratbagd, get_parser
+from ratbagctl import open_ratbagd, get_parser, RatbagError, RatbagErrorCapability
 
 __all__ = [
     RATBAGCTL_NAME,
@@ -112,4 +112,6 @@ __all__ = [
     terminate_ratbagd,
     open_ratbagd,
     get_parser,
+    RatbagError,
+    RatbagErrorCapability,
 ]


### PR DESCRIPTION
Finally, profiles can exist and have a name.

Currently no driver implements the feature because -ETIME.

fixes #266 