### PR TITLE
ratbagd.c: unlink before emitting property changed

### DIFF
--- a/ratbagd/ratbagd.c
+++ b/ratbagd/ratbagd.c
@@ -409,13 +409,14 @@ static void ratbagd_process_device(struct ratbagd *ctx,
 	if (streq_ptr("remove", udev_device_get_action(udevice))) {
 		/* device was removed, unlink it and destroy our context */
 		if (device) {
+			ratbagd_device_unlink(device);
+			ratbagd_device_free(device);
+
 			(void) sd_bus_emit_properties_changed(ctx->bus,
 							      RATBAGD_OBJ_ROOT,
 							      RATBAGD_NAME_ROOT ".Manager",
 							      "Devices",
 							      NULL);
-			ratbagd_device_unlink(device);
-			ratbagd_device_free(device);
 		}
 	} else if (device) {
 		/* device already known, refresh our view of the device */


### PR DESCRIPTION
If we emit the changes before unlinking the device, the list of devices hasn't actually changed yet and Piper cannot figure out which devices have been removed. Hence, we simply unlink the device before emitting the signal and all is good again.