### PR TITLE
RatbagdResolution: emit properties changed from signal callbacks

### DIFF
--- a/ratbagd/ratbagd-resolution.c
+++ b/ratbagd/ratbagd-resolution.c
@@ -94,6 +94,12 @@ static int ratbagd_resolution_active_signal_cb(sd_bus *bus,
 				  "b",
 				  ratbag_resolution_is_active(lib_resolution));
 
+	(void) sd_bus_emit_properties_changed(bus,
+					      resolution->path,
+					      RATBAGD_NAME_ROOT ".Resolution",
+					      "IsActive",
+					      NULL);
+
 	return 0;
 }
 

--- a/ratbagd/ratbagd-resolution.c
+++ b/ratbagd/ratbagd-resolution.c
@@ -136,6 +136,12 @@ static int ratbagd_resolution_default_signal_cb(sd_bus *bus,
 				  "b",
 				  ratbag_resolution_is_default(lib_resolution));
 
+	(void) sd_bus_emit_properties_changed(bus,
+					      resolution->path,
+					      RATBAGD_NAME_ROOT ".Resolution",
+					      "IsDefault",
+					      NULL);
+
 	return 0;
 }
 


### PR DESCRIPTION
This allows clients to respond to changes in the active resolution. It's not the cleanest approach, but it works. To clean it up, we could cache the changed resolutions and make sure to only emit the signal on those, just as the FIXME already notes.

References https://github.com/libratbag/piper/pull/132.