### PR TITLE
Add HID++2.0 error codes

### DIFF
--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -305,7 +305,7 @@ hidpp20drv_write_button_1b04(struct ratbag_button *button,
 	control->reporting.updated = 1;
 
 	rc = hidpp20_special_key_mouse_set_control(drv_data->dev, control);
-	if (rc == ERR_INVALID_ADDRESS)
+	if (rc == HIDPP20_ERR_INVALID_ARGUMENT)
 		return -EINVAL;
 
 	if (rc)

--- a/src/hidpp-generic.c
+++ b/src/hidpp-generic.c
@@ -36,7 +36,7 @@
 
 #include "libratbag-private.h"
 
-const char *hidpp_errors[0xFF] = {
+const char *hidpp10_errors[0xFF] = {
 	[0x00] = "ERR_SUCCESS",
 	[0x01] = "ERR_INVALID_SUBID",
 	[0x02] = "ERR_INVALID_ADDRESS",
@@ -51,6 +51,20 @@ const char *hidpp_errors[0xFF] = {
 	[0x0B] = "ERR_INVALID_PARAM_VALUE",
 	[0x0C] = "ERR_WRONG_PIN_CODE",
 	[0x0D ... 0xFE] = NULL,
+};
+
+const char *hidpp20_errors[0xFF] = {
+	[0x00] = "ERR_NO_ERROR",
+	[0x01] = "ERR_UNKNOWN",
+	[0x02] = "ERR_INVALID_ARGUMENT",
+	[0x03] = "ERR_OUT_OF_RANGE",
+	[0x04] = "ERR_HARDWARE_ERROR",
+	[0x05] = "ERR_LOGITECH_INTERNAL",
+	[0x06] = "ERR_INVALID_FEATURE_INDEX",
+	[0x07] = "ERR_INVALID_FUNCTION_ID",
+	[0x08] = "ERR_BUSY",
+	[0x09] = "ERR_UNSUPPORTED",
+	[0x0A ... 0xFE] = NULL,
 };
 
 struct hidpp20_1b04_action_mapping {

--- a/src/hidpp-generic.c
+++ b/src/hidpp-generic.c
@@ -36,7 +36,7 @@
 
 #include "libratbag-private.h"
 
-const char *hidpp10_errors[0xFF] = {
+const char *hidpp10_errors[0x100] = {
 	[0x00] = "ERR_SUCCESS",
 	[0x01] = "ERR_INVALID_SUBID",
 	[0x02] = "ERR_INVALID_ADDRESS",
@@ -50,10 +50,10 @@ const char *hidpp10_errors[0xFF] = {
 	[0x0A] = "ERR_REQUEST_UNAVAILABLE",
 	[0x0B] = "ERR_INVALID_PARAM_VALUE",
 	[0x0C] = "ERR_WRONG_PIN_CODE",
-	[0x0D ... 0xFE] = NULL,
+	[0x0D ... 0xFF] = NULL,
 };
 
-const char *hidpp20_errors[0xFF] = {
+const char *hidpp20_errors[0x100] = {
 	[0x00] = "ERR_NO_ERROR",
 	[0x01] = "ERR_UNKNOWN",
 	[0x02] = "ERR_INVALID_ARGUMENT",
@@ -64,7 +64,7 @@ const char *hidpp20_errors[0xFF] = {
 	[0x07] = "ERR_INVALID_FUNCTION_ID",
 	[0x08] = "ERR_BUSY",
 	[0x09] = "ERR_UNSUPPORTED",
-	[0x0A ... 0xFE] = NULL,
+	[0x0A ... 0xFF] = NULL,
 };
 
 struct hidpp20_1b04_action_mapping {

--- a/src/hidpp-generic.h
+++ b/src/hidpp-generic.h
@@ -108,8 +108,8 @@ hidpp_device_set_log_handler(struct hidpp_device *dev,
 			     enum hidpp_log_priority priority,
 			     void *userdata);
 
-extern const char *hidpp10_errors[0xFF];
-extern const char *hidpp20_errors[0xFF];
+extern const char *hidpp10_errors[0x100];
+extern const char *hidpp20_errors[0x100];
 
 const char *
 hidpp20_1b04_get_physical_mapping_name(uint16_t value);

--- a/src/hidpp-generic.h
+++ b/src/hidpp-generic.h
@@ -51,19 +51,30 @@
 #define GET_LONG_REGISTER_RSP			0x83
 #define __ERROR_MSG				0x8F
 
-#define ERR_SUCCESS				0x00
-#define ERR_INVALID_SUBID			0x01
-#define ERR_INVALID_ADDRESS			0x02
-#define ERR_INVALID_VALUE			0x03
-#define ERR_CONNECT_FAIL			0x04
-#define ERR_TOO_MANY_DEVICES			0x05
-#define ERR_ALREADY_EXISTS			0x06
-#define ERR_BUSY				0x07
-#define ERR_UNKNOWN_DEVICE			0x08
-#define ERR_RESOURCE_ERROR			0x09
-#define ERR_REQUEST_UNAVAILABLE			0x0A
-#define ERR_INVALID_PARAM_VALUE			0x0B
-#define ERR_WRONG_PIN_CODE			0x0C
+#define HIDPP10_ERR_SUCCESS				0x00
+#define HIDPP10_ERR_INVALID_SUBID			0x01
+#define HIDPP10_ERR_INVALID_ADDRESS			0x02
+#define HIDPP10_ERR_INVALID_VALUE			0x03
+#define HIDPP10_ERR_CONNECT_FAIL			0x04
+#define HIDPP10_ERR_TOO_MANY_DEVICES			0x05
+#define HIDPP10_ERR_ALREADY_EXISTS			0x06
+#define HIDPP10_ERR_BUSY				0x07
+#define HIDPP10_ERR_UNKNOWN_DEVICE			0x08
+#define HIDPP10_ERR_RESOURCE_ERROR			0x09
+#define HIDPP10_ERR_REQUEST_UNAVAILABLE			0x0A
+#define HIDPP10_ERR_INVALID_PARAM_VALUE			0x0B
+#define HIDPP10_ERR_WRONG_PIN_CODE			0x0C
+
+#define HIDPP20_ERR_NO_ERROR			0x00
+#define HIDPP20_ERR_UNKNOWN			0x01
+#define HIDPP20_ERR_INVALID_ARGUMENT		0x02
+#define HIDPP20_ERR_OUT_OF_RANGE		0x03
+#define HIDPP20_ERR_HARDWARE_ERROR		0x04
+#define HIDPP20_ERR_LOGITECH_INTERNAL		0x05
+#define HIDPP20_ERR_INVALID_FEATURE_INDEX	0x06
+#define HIDPP20_ERR_INVALID_FUNCTION_ID		0x07
+#define HIDPP20_ERR_BUSY			0x08
+#define HIDPP20_ERR_UNSUPPORTED			0x09
 
 /* Keep this in sync with ratbag_log_priority */
 enum hidpp_log_priority {
@@ -97,7 +108,8 @@ hidpp_device_set_log_handler(struct hidpp_device *dev,
 			     enum hidpp_log_priority priority,
 			     void *userdata);
 
-extern const char *hidpp_errors[0xFF];
+extern const char *hidpp10_errors[0xFF];
+extern const char *hidpp20_errors[0xFF];
 
 const char *
 hidpp20_1b04_get_physical_mapping_name(uint16_t value);

--- a/src/hidpp10.c
+++ b/src/hidpp10.c
@@ -268,7 +268,7 @@ hidpp10_request_command(struct hidpp10_device *dev, union hidpp10_message *msg)
 				"    HID++ error from the %s (%d): %s (%02x)\n",
 				read_buffer.msg.device_idx == HIDPP_RECEIVER_IDX ? "receiver" : "device",
 				read_buffer.msg.device_idx,
-				hidpp_errors[hidpp_err] ? hidpp_errors[hidpp_err] : "Undocumented error code",
+				hidpp10_errors[hidpp_err] ? hidpp10_errors[hidpp_err] : "Undocumented error code",
 				hidpp_err);
 			break;
 		}

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -130,13 +130,13 @@ hidpp20_request_command_allow_error(struct hidpp20_device *device, union hidpp20
 				hidpp_log_debug(&device->base,
 						"    HID++ error from the device (%d): %s (%02x)\n",
 						read_buffer.msg.device_idx,
-						hidpp_errors[hidpp_err] ? hidpp_errors[hidpp_err] : "Undocumented error code",
+						hidpp20_errors[hidpp_err] ? hidpp20_errors[hidpp_err] : "Undocumented error code",
 						hidpp_err);
 			else
 				hidpp_log_error(&device->base,
 						"    HID++ error from the device (%d): %s (%02x)\n",
 						read_buffer.msg.device_idx,
-						hidpp_errors[hidpp_err] ? hidpp_errors[hidpp_err] : "Undocumented error code",
+						hidpp20_errors[hidpp_err] ? hidpp20_errors[hidpp_err] : "Undocumented error code",
 						hidpp_err);
 			break;
 		}
@@ -241,7 +241,7 @@ hidpp20_root_get_protocol_version(struct hidpp20_device *device,
 
 	rc = hidpp20_request_command_allow_error(device, &msg, true);
 
-	if (rc == ERR_INVALID_SUBID) {
+	if (rc == HIDPP10_ERR_INVALID_SUBID) {
 		*major = 1;
 		*minor = 0;
 		return 0;


### PR DESCRIPTION
libratbag was printing ERR_INVALID_ADDRESS when it should have been ERR_INVALID_ARGUMENT (a detail from issue #280). This should fix some misleading error messages.

I have left the HID++1.0 error codes in hidpp-generic since they are used in hidpp20.c (for checking the protocol version), but the HID++2.0 error codes could be moved in hidpp20.h if you prefer.

I also extended the string arrays because the value 0xFF was previously excluded but not checked before accessing the array.