### PR TITLE
RatbagdButton: make mapping properties writable

### DIFF
--- a/DBusInterface.md
+++ b/DBusInterface.md
@@ -228,20 +228,20 @@ Enum describing the button physical type. This type is unrelated to the
 logical button mapping and serves to easily identify the button on the
 device.
 #### `ButtonMapping`
-- type: `u`, read-only, mutable
+- type: `u`, read-write, mutable
 
 uint of the current button mapping (if mapping to button)
 #### `SpecialMapping`
-- type: `u`, read-only, mutable
+- type: `u`, read-write, mutable
 
 Enum describing the current special mapping (if mapped to special)
 #### `KeyMapping`
-- type: `au`, read-only, mutable
+- type: `au`, read-write, mutable
 
 Array of uints, first entry is the keycode, other entries, if any, are
 modifiers (if mapped to key)
 #### `Macro`
--type: `a(uu)`, read-only, mutable
+-type: `a(uu)`, read-write, mutable
 
 Array of (type, keycode), where type may be one of
 `RATBAG_MACRO_EVENT_KEY_PRESSED` or `RATBAG_MACRO_EVENT_KEY_RELEASED`.
@@ -257,16 +257,6 @@ Array of enum ratbag\_button\_action\_type, possible values for ActionType
 on the current device
 
 ### Methods:
-#### `SetButtonMapping(u) → ()`
-Set the button mapping to the given button
-#### `SetSpecialMapping(u) → ()`
-Set the button mapping to the given special entry
-#### `SetKeyMapping(au) → ()`
-Set the key mapping, first entry is the keycode, other entries, if any, are
-modifier keycodes
-#### `SetMacro(a(uu)) → ()`
-Set the macro, as an array of (type, key) where type may be one of
-`RATBAG_MACRO_EVENT_KEY_PRESSED` or `RATBAG_MACRO_EVENT_KEY_RELEASED`.
 #### `Disable() → ()`
 Disable this button
 

--- a/ratbagd/ratbagd-button.c
+++ b/ratbagd/ratbagd-button.c
@@ -76,7 +76,11 @@ static int ratbagd_button_get_button(sd_bus *bus,
 	return sd_bus_message_append(reply, "u", b);
 }
 
-static int ratbagd_button_set_button(sd_bus_message *m,
+static int ratbagd_button_set_button(sd_bus *bus,
+				     const char *path,
+				     const char *interface,
+				     const char *property,
+				     sd_bus_message *m,
 				     void *userdata,
 				     sd_bus_error *error)
 {
@@ -108,7 +112,7 @@ static int ratbagd_button_set_button(sd_bus_message *m,
 					       NULL);
 	}
 
-	return sd_bus_reply_method_return(m, "u", r);
+	return r;
 }
 
 static int ratbagd_button_get_special(sd_bus *bus,
@@ -127,7 +131,11 @@ static int ratbagd_button_get_special(sd_bus *bus,
 	return sd_bus_message_append(reply, "u", special);
 }
 
-static int ratbagd_button_set_special(sd_bus_message *m,
+static int ratbagd_button_set_special(sd_bus *bus,
+				      const char *path,
+				      const char *interface,
+				      const char *property,
+				      sd_bus_message *m,
 				      void *userdata,
 				      sd_bus_error *error)
 {
@@ -156,7 +164,7 @@ static int ratbagd_button_set_special(sd_bus_message *m,
 					       NULL);
 	}
 
-	return sd_bus_reply_method_return(m, "u", r);
+	return r;
 }
 
 static int ratbagd_button_get_key(sd_bus *bus,
@@ -202,7 +210,11 @@ static int ratbagd_button_get_key(sd_bus *bus,
 	return sd_bus_message_close_container(reply);
 }
 
-static int ratbagd_button_set_key(sd_bus_message *m,
+static int ratbagd_button_set_key(sd_bus *bus,
+				  const char *path,
+				  const char *interface,
+				  const char *property,
+				  sd_bus_message *m,
 				  void *userdata,
 				  sd_bus_error *error)
 {
@@ -249,58 +261,7 @@ static int ratbagd_button_set_key(sd_bus_message *m,
 					       NULL);
 	}
 
-	return sd_bus_reply_method_return(m, "u", r);
-}
-
-static int ratbagd_button_get_action_type(sd_bus *bus,
-					  const char *path,
-					  const char *interface,
-					  const char *property,
-					  sd_bus_message *reply,
-					  void *userdata,
-					  sd_bus_error *error)
-{
-	struct ratbagd_button *button = userdata;
-	enum ratbag_button_action_type type;
-
-	type = ratbag_button_get_action_type(button->lib_button);
-
-	return sd_bus_message_append(reply, "u", type);
-}
-
-static int ratbagd_button_get_action_types(sd_bus *bus,
-					   const char *path,
-					   const char *interface,
-					   const char *property,
-					   sd_bus_message *reply,
-					   void *userdata,
-					   sd_bus_error *error)
-{
-	struct ratbagd_button *button = userdata;
-	int r;
-	enum ratbag_button_action_type types[] = {
-		RATBAG_BUTTON_ACTION_TYPE_BUTTON,
-		RATBAG_BUTTON_ACTION_TYPE_SPECIAL,
-		RATBAG_BUTTON_ACTION_TYPE_KEY,
-		RATBAG_BUTTON_ACTION_TYPE_MACRO
-	};
-	enum ratbag_button_action_type *t;
-
-
-	r = sd_bus_message_open_container(reply, 'a', "u");
-	if (r < 0)
-		return r;
-
-	ARRAY_FOR_EACH(types, t) {
-		if (!ratbag_button_has_action_type(button->lib_button, *t))
-			continue;
-
-		r = sd_bus_message_append(reply, "u", *t);
-		if (r < 0)
-			return r;
-	}
-
-	return sd_bus_message_close_container(reply);
+	return r;
 }
 
 DEFINE_TRIVIAL_CLEANUP_FUNC(struct ratbag_button_macro *, ratbag_button_macro_unref);
@@ -355,7 +316,11 @@ out:
 	return sd_bus_message_close_container(reply);
 }
 
-static int ratbagd_button_set_macro(sd_bus_message *m,
+static int ratbagd_button_set_macro(sd_bus *bus,
+				    const char *path,
+				    const char *interface,
+				    const char *property,
+				    sd_bus_message *m,
 				    void *userdata,
 				    sd_bus_error *error)
 {
@@ -400,7 +365,58 @@ static int ratbagd_button_set_macro(sd_bus_message *m,
 					       NULL);
 	}
 
-	return sd_bus_reply_method_return(m, "u", r);
+	return r;
+}
+
+static int ratbagd_button_get_action_type(sd_bus *bus,
+					  const char *path,
+					  const char *interface,
+					  const char *property,
+					  sd_bus_message *reply,
+					  void *userdata,
+					  sd_bus_error *error)
+{
+	struct ratbagd_button *button = userdata;
+	enum ratbag_button_action_type type;
+
+	type = ratbag_button_get_action_type(button->lib_button);
+
+	return sd_bus_message_append(reply, "u", type);
+}
+
+static int ratbagd_button_get_action_types(sd_bus *bus,
+					   const char *path,
+					   const char *interface,
+					   const char *property,
+					   sd_bus_message *reply,
+					   void *userdata,
+					   sd_bus_error *error)
+{
+	struct ratbagd_button *button = userdata;
+	int r;
+	enum ratbag_button_action_type types[] = {
+		RATBAG_BUTTON_ACTION_TYPE_BUTTON,
+		RATBAG_BUTTON_ACTION_TYPE_SPECIAL,
+		RATBAG_BUTTON_ACTION_TYPE_KEY,
+		RATBAG_BUTTON_ACTION_TYPE_MACRO
+	};
+	enum ratbag_button_action_type *t;
+
+
+	r = sd_bus_message_open_container(reply, 'a', "u");
+	if (r < 0)
+		return r;
+
+	ARRAY_FOR_EACH(types, t) {
+		if (!ratbag_button_has_action_type(button->lib_button, *t))
+			continue;
+
+		r = sd_bus_message_append(reply, "u", *t);
+		if (r < 0)
+			return r;
+	}
+
+	return sd_bus_message_close_container(reply);
 }
 
 static int ratbagd_button_disable(sd_bus_message *m,
@@ -423,16 +439,24 @@ const sd_bus_vtable ratbagd_button_vtable[] = {
 	SD_BUS_VTABLE_START(0),
 	SD_BUS_PROPERTY("Index", "u", NULL, offsetof(struct ratbagd_button, index), SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_PROPERTY("Type", "u", ratbagd_button_get_type, 0, SD_BUS_VTABLE_PROPERTY_CONST),
-	SD_BUS_PROPERTY("ButtonMapping", "u", ratbagd_button_get_button, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
-	SD_BUS_PROPERTY("SpecialMapping", "u", ratbagd_button_get_special, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
-	SD_BUS_PROPERTY("KeyMapping", "au", ratbagd_button_get_key, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
+	SD_BUS_WRITABLE_PROPERTY("ButtonMapping", "u",
+				 ratbagd_button_get_button,
+				 ratbagd_button_set_button,
+				 0, SD_BUS_VTABLE_UNPRIVILEGED | SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
+	SD_BUS_WRITABLE_PROPERTY("SpecialMapping", "u",
+				 ratbagd_button_get_special,
+				 ratbagd_button_set_special,
+				 0, SD_BUS_VTABLE_UNPRIVILEGED | SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
+	SD_BUS_WRITABLE_PROPERTY("KeyMapping", "au",
+				 ratbagd_button_get_key,
+				 ratbagd_button_set_key,
+				 0, SD_BUS_VTABLE_UNPRIVILEGED | SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
+	SD_BUS_WRITABLE_PROPERTY("Macro", "a(uu)",
+				 ratbagd_button_get_macro,
+				 ratbagd_button_set_macro,
+				 0, SD_BUS_VTABLE_UNPRIVILEGED | SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_PROPERTY("ActionType", "u", ratbagd_button_get_action_type, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_PROPERTY("ActionTypes", "au", ratbagd_button_get_action_types, 0, SD_BUS_VTABLE_PROPERTY_CONST),
-	SD_BUS_PROPERTY("Macro", "a(uu)", ratbagd_button_get_macro, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
-	SD_BUS_METHOD("SetButtonMapping", "u", "u", ratbagd_button_set_button, SD_BUS_VTABLE_UNPRIVILEGED),
-	SD_BUS_METHOD("SetSpecialMapping", "u", "u", ratbagd_button_set_special, SD_BUS_VTABLE_UNPRIVILEGED),
-	SD_BUS_METHOD("SetKeyMapping", "au", "u", ratbagd_button_set_key, SD_BUS_VTABLE_UNPRIVILEGED),
-	SD_BUS_METHOD("SetMacro", "a(uu)", "u", ratbagd_button_set_macro, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("Disable", "", "u", ratbagd_button_disable, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_VTABLE_END,
 };

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -513,8 +513,7 @@ class RatbagdButton(_RatbagdDBus):
 
         @param button The button to map to, as int
         """
-        ret = self._dbus_call("SetButtonMapping", "u", button)
-        self._set_dbus_property("ButtonMapping", "u", button, readwrite=False)
+        ret = self._set_dbus_property("ButtonMapping", "u", button)
         self.notify("action-type")
         return ret
 
@@ -535,8 +534,7 @@ class RatbagdButton(_RatbagdDBus):
 
         @param macro A list of (type, value) tuples to form the new macro.
         """
-        ret = self._dbus_call("SetMacro", "a(uu)", macro)
-        self._set_dbus_property("Macro", "a(uu)", macro, readwrite=False)
+        ret = self._set_dbus_property("Macro", "a(uu)", macro)
         self.notify("action-type")
         return ret
 
@@ -551,8 +549,7 @@ class RatbagdButton(_RatbagdDBus):
 
         @param special The special entry, as one of RatbagdButton.ACTION_SPECIAL_*
         """
-        ret = self._dbus_call("SetSpecialMapping", "u", special)
-        self._set_dbus_property("SpecialMapping", "u", special, readwrite=False)
+        ret = self._set_dbus_property("SpecialMapping", "u", special)
         self.notify("action-type")
         return ret
 
@@ -569,8 +566,7 @@ class RatbagdButton(_RatbagdDBus):
         @param keys A list of integers, the first being the keycode and the rest
                     modifiers.
         """
-        ret = self._dbus_call("SetKeyMapping", "au", keys)
-        self._set_dbus_property("KeyMapping", "au", keys, readwrite=False)
+        ret = self._set_dbus_property("KeyMapping", "au", keys)
         self.notify("action-type")
         return ret
 


### PR DESCRIPTION
This brings RatbagdButton in line with the other Ratbagd* objects, and
more importantly solves https://github.com/libratbag/piper/issues/140.