### PR TITLE
add --keepalive to let piper use ratbagd.devel

### DIFF
--- a/tools/ratbagctl.devel.in
+++ b/tools/ratbagctl.devel.in
@@ -27,6 +27,7 @@
 
 import os
 import toolbox
+import signal
 import sys
 
 
@@ -41,11 +42,18 @@ def main(argv):
 
     ratbagd = toolbox.open_ratbagd()
     parser = toolbox.get_parser()
+    parser.want_keepalive = True
+    print('export RATBAGCTL_DEVEL="{}"\n'.format(os.environ['RATBAGCTL_DEVEL']))
 
     try:
         cmd = parser.parse(argv)
         cmd.func(ratbagd, cmd)
     finally:
+        try:
+            if cmd.keepalive:
+                signal.pause()
+        except KeyboardInterrupt:
+            pass
         toolbox.terminate_ratbagd(ratbagd_process)
 
 

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -1283,7 +1283,7 @@ class RatbagParserRoot(object):
                                               add_help=False)
         self.parser.add_argument("-V", "--version", action="version", version="@version@")
         self.parser.add_argument('--verbose', '-v', action='count', default=0)
-        self.parser.add_argument('--help', '-h', action='store_true', default=0)
+        self.parser.add_argument('--help', '-h', action='store_true', default=False)
 
         ns, rest = self.parser.parse_known_args(input_string)
 
@@ -1346,12 +1346,9 @@ def main(argv):
 
     parser = get_parser()
     cmd = parser.parse(argv)
-    try:
-        if cmd.help:
-            parser.print_help()
-            return
-    except AttributeError:
-        pass
+    if cmd.help:
+        parser.print_help()
+        return
 
     r = open_ratbagd()
     if r is not None:

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -1272,6 +1272,7 @@ classes = {
 class RatbagParserRoot(object):
     def __init__(self, commands):
         self.children = [classes[def_parser[of_type]](**def_parser) for def_parser in commands]
+        self.want_keepalive = False
 
     def parse(self, input_string):
         # we do not care about case, use lower case for the input string
@@ -1284,6 +1285,8 @@ class RatbagParserRoot(object):
         self.parser.add_argument("-V", "--version", action="version", version="@version@")
         self.parser.add_argument('--verbose', '-v', action='count', default=0)
         self.parser.add_argument('--help', '-h', action='store_true', default=False)
+        if self.want_keepalive:
+            self.parser.add_argument('--keepalive', action='store_true', default=False)
 
         ns, rest = self.parser.parse_known_args(input_string)
 


### PR DESCRIPTION
keeps the ratbagd.devel instance alive so we can run easily piper against the test devices.

best use is something like `./build/ratbagctl.devel --keepalive list` and then connect piper.