### PR TITLE
fix help behavior

### DIFF
--- a/tools/ratbagctl.devel.in
+++ b/tools/ratbagctl.devel.in
@@ -52,7 +52,13 @@ def main(argv):
         if cmd.help:
             parser.print_help()
         else:
-            cmd.func(ratbagd, cmd)
+            try:
+                f = cmd.func
+            except AttributeError:
+                parser.print_help()
+                return
+            else:
+                f(ratbagd, cmd)
     finally:
         try:
             if cmd.keepalive:

--- a/tools/ratbagctl.devel.in
+++ b/tools/ratbagctl.devel.in
@@ -49,7 +49,10 @@ def main(argv):
 
     try:
         cmd = parser.parse(argv)
-        cmd.func(ratbagd, cmd)
+        if cmd.help:
+            parser.print_help()
+        else:
+            cmd.func(ratbagd, cmd)
     finally:
         try:
             if cmd.keepalive:

--- a/tools/ratbagctl.devel.in
+++ b/tools/ratbagctl.devel.in
@@ -45,6 +45,8 @@ def main(argv):
     parser.want_keepalive = True
     print('export RATBAGCTL_DEVEL="{}"\n'.format(os.environ['RATBAGCTL_DEVEL']))
 
+    cmd = None
+
     try:
         cmd = parser.parse(argv)
         cmd.func(ratbagd, cmd)
@@ -53,6 +55,8 @@ def main(argv):
             if cmd.keepalive:
                 signal.pause()
         except KeyboardInterrupt:
+            pass
+        except AttributeError:  # in case the parsing failed and cmd is None
             pass
         toolbox.terminate_ratbagd(ratbagd_process)
 

--- a/tools/ratbagctl.devel.in
+++ b/tools/ratbagctl.devel.in
@@ -43,7 +43,6 @@ def main(argv):
     ratbagd = toolbox.open_ratbagd()
     parser = toolbox.get_parser()
     parser.want_keepalive = True
-    print('export RATBAGCTL_DEVEL="{}"\n'.format(os.environ['RATBAGCTL_DEVEL']))
 
     cmd = None
 
@@ -62,6 +61,7 @@ def main(argv):
     finally:
         try:
             if cmd.keepalive:
+                print('\nexport RATBAGCTL_DEVEL="{}"\n'.format(os.environ['RATBAGCTL_DEVEL']))
                 signal.pause()
         except KeyboardInterrupt:
             pass

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -531,6 +531,8 @@ def func_profile_disable(r, args):
 of_type = 'type'
 """the name of the element, it'll be the one matching the args on the CLI"""
 name = 'name'
+"""the group to logically associate commands while printing the help"""
+group = 'group'
 """list of positional arguments for the given command"""
 pos_args = 'pos_args'
 """a tag that we can refer latrer in an element of type 'link'"""
@@ -625,20 +627,23 @@ parser_def = [
     {
         of_type: command,
         name: 'list',
-        help_str: 'List available configurable devices',
+        help_str: 'List supported devices (does not take a device argument)',
         func: list_devices,
+        group: 'General',
     },
     {
         of_type: command,
         name: 'info',
         help_str: 'Show device information',
         func: show_device,
+        group: 'Device',
     },
     {
         of_type: switch,
         name: 'profile',
         help_str: 'Access profile information',
         tag: 'profile',
+        group: 'Profile',
         switch: [
             {
                 of_type: switch,
@@ -678,7 +683,7 @@ parser_def = [
                 {
                     of_type: command,
                     name: 'get',
-                    help_str: 'Show current active profile',
+                    help_str: 'Show selected profile information',
                     func: func_profile_get,
                 },
                 {
@@ -719,8 +724,12 @@ parser_def = [
     {
         of_type: switch,
         name: 'resolution',
-        help_str: 'Access resolution information',
+        help_str: """Access resolution information
+
+Resolution commands work on the given profile, or on the
+active profile if none is given.""",
         tag: 'resolution',
+        group: 'Resolution',
         switch: [
             {
                 of_type: switch,
@@ -805,8 +814,12 @@ parser_def = [
     {
         of_type: switch,
         name: 'dpi',
-        help_str: 'Access DPI information',
+        help_str: """Access DPI information
+
+DPI commands work on the given profile and resolution, or on the
+active resolution of the active profile if none are given.""",
         tag: 'dpi',
+        group: 'DPI',
         switch: [
             {
                 of_type: command,
@@ -834,8 +847,12 @@ parser_def = [
     {
         of_type: switch,
         name: 'rate',
-        help_str: 'Access report rate information',
+        help_str: """Access report rate information
+
+Rate commands work on the given profile and resolution, or on the
+active resolution of the active profile if none are given.""",
         tag: 'rate',
+        group: 'Rate',
         switch: [
             {
                 of_type: command,
@@ -863,8 +880,12 @@ parser_def = [
     {
         of_type: switch,
         name: 'button',
-        help_str: 'Access Button information',
+        help_str: """Access Button information
+
+Button commands work on the given profile, or on the
+active profile if none is given.""",
         tag: 'button',
+        group: 'Button',
         switch: [
             {
                 of_type: command,
@@ -924,7 +945,7 @@ parser_def = [
                                         {
                                             of_type: argument,
                                             name: 'target_special',
-                                            metavar: 'special',
+                                            metavar: 'S',
                                             help_str: 'The new special value to assign',
                                             choices: [
                                                 "unknown",
@@ -954,12 +975,20 @@ parser_def = [
                                 {
                                     of_type: command,
                                     name: 'macro',
-                                    help_str: 'Set the button action to the given macro',
+                                    help_str: """Set the button action to the given macro
+
+  Macro syntax:
+        A macro is a series of key events or waiting periods.
+        Keys must be specified in linux/input.h key names.
+        KEY_A                   Press and release 'a'
+        +KEY_A                  Press 'a'
+        -KEY_A                  Release 'a'
+        t300                    Wait 300ms""",
                                     pos_args: [
                                         {
                                             of_type: argument,
                                             name: 'target_macro',
-                                            metavar: 'macro',
+                                            metavar: '...',
                                             help_str: 'The new macro to assign',
                                             nargs: argparse.REMAINDER,
                                         },
@@ -976,8 +1005,12 @@ parser_def = [
     {
         of_type: switch,
         name: 'led',
-        help_str: 'Access LED information',
+        help_str: """Access LED information
+
+LED commands work on the given profile, or on the
+active profile if none is given.""",
         tag: 'led',
+        group: 'LED',
         switch: [
             {
                 of_type: command,
@@ -1039,7 +1072,7 @@ parser_def = [
                                 {
                                     of_type: argument,
                                     name: 'rate',
-                                    metavar: 'rate',
+                                    metavar: 'R',
                                     help_str: 'The rate in Hz to set as current',
                                     arg_type: int,
                                 },
@@ -1053,7 +1086,7 @@ parser_def = [
                                 {
                                     of_type: argument,
                                     name: 'brightness',
-                                    metavar: 'brightness',
+                                    metavar: 'B',
                                     help_str: 'The brightness to set as current',
                                     arg_type: u8,
                                 },
@@ -1083,10 +1116,11 @@ class ParseError(Exception):
 class RatbagParser(object):
     tagged = {}
 
-    def __init__(self, type, name, tag=None, func=None, help=None):
+    def __init__(self, type, name, group=None, tag=None, func=None, help=None):
         self.type = type
         self.name = name
         self.tag = tag
+        self.group = group
         if tag is not None:
             RatbagParser.tagged[tag] = self
         self.func = func
@@ -1119,17 +1153,22 @@ class RatbagParser(object):
         pr_debug(ns, "<.. {}: {} | {}".format(self.type, self.name, input_string))
         return r
 
-    def print_help(self):
-        return str(type(self))
-
     def build_cmd_args_name(self):
         """uniquely tag the arguments of the command in the namespace"""
         return "{}_args_{}".format(self.name)
 
+    def print_help(self, group, prefix=""):
+        if self.group is not None:
+            print("\n{} Commands:".format(self.group))
+        self._print_help(prefix)
+
+    def _print_help(self, prefix):
+        raise ParseError("please implement _print_help on {}".format(type(self)))
+
 
 class RatbagParserSwitch(RatbagParser):
-    def __init__(self, type, name, switch=[], N_access=None, tag=None, func=None, help=None):
-        super(RatbagParserSwitch, self).__init__(type, name, tag, func, help)
+    def __init__(self, type, name, group=None, switch=[], N_access=None, tag=None, func=None, help=None):
+        super(RatbagParserSwitch, self).__init__(type, name, group, tag, func, help)
         self.switch = [classes[obj[of_type]](**obj) for obj in switch]
         if N_access is not None:
             self.N_access = RatbagParserNAccess(**N_access)
@@ -1154,9 +1193,11 @@ class RatbagParserSwitch(RatbagParser):
             else:
                 # we have a single int as first argument, switch to the
                 # N_access subtree of the command
-                return self.N_access.sub_parse(input_string, ns)
+                return self.N_access._sub_parse(self, input_string, ns)
 
-        parser = argparse.ArgumentParser(add_help=False)
+        parser = argparse.ArgumentParser(prog="{} {}".format(sys.argv[0], self.name),
+                                         description=self.help,
+                                         add_help=False)
 
         # create a new subparser to handle all commands
         subs = parser.add_subparsers(title="COMMANDS", help=None)
@@ -1165,17 +1206,28 @@ class RatbagParserSwitch(RatbagParser):
 
         return parser
 
+    def _print_help(self, prefix):
+        if self.help and self.group is not None:
+            string = self.help.split('\n')
+            string = "\n  ".join(string)
+            print(" ", string, '\n')
+        for e in self.switch:
+            e.print_help(None, "{}{} ".format(prefix, self.name))
+        if self.N_access is not None:
+            self.N_access.print_help(None, self.name + " ")
+
     def __repr__(self):
         return "switch({})".format(self.repr_args())
 
 
 class RatbagParserNAccess(RatbagParserSwitch):
-    def __init__(self, type, name, switch=[], metavar=None, tag=None, func=None, help=None):
-        super(RatbagParserNAccess, self).__init__(type, name, switch, None, tag, func, help)
+    def __init__(self, type, name, group=None, switch=[], metavar=None, tag=None, func=None, help=None):
+        super(RatbagParserNAccess, self).__init__(type, name, group, switch, None, tag, func, help)
         self.metavar = metavar
 
-    def _sub_parse(self, input_string, ns):
-        parser = argparse.ArgumentParser(add_help=False)
+    def _sub_parse(self, parent, input_string, ns):
+        parser = argparse.ArgumentParser(prog="{} {}".format(sys.argv[0], parent.name),
+                                         add_help=False)
         parser.add_argument(self.name, help=self.help, type=int)
         # create a new subparser to handle all commands
         subs = parser.add_subparsers(title="COMMANDS", help=None)
@@ -1189,17 +1241,22 @@ class RatbagParserNAccess(RatbagParserSwitch):
     def __repr__(self):
         return "N_Access({})".format(self.repr_args())
 
+    def _print_help(self, prefix):
+        for e in self.switch:
+            e.print_help(None, "{}N ".format(prefix))
+
 
 class RatbagParserSet(RatbagParserSwitch):
-    def __init__(self, type, name, switch=[], N_access=None, tag=None, func=None, help=None):
-        super(RatbagParserSet, self).__init__(type, name, switch, N_access, tag, func, help)
+    def __init__(self, type, name, group=None, switch=[], N_access=None, tag=None, func=None, help=None):
+        super(RatbagParserSet, self).__init__(type, name, group, switch, N_access, tag, func, help)
 
     def _add_to_subparsers(self, parent):
         parser = parent.add_parser(self.name, help=self.help)
         parser.set_defaults(subparse=self.sub_parse)
 
     def _sub_parse(self, input_string, ns):
-        parser = argparse.ArgumentParser(add_help=False)
+        parser = argparse.ArgumentParser(prog="{} {}".format(sys.argv[0], self.name),
+                                         add_help=False)
         # create a new subparser to handle all commands
         subs = parser.add_subparsers(title="COMMANDS", help=None)
         for e in self.switch:
@@ -1216,10 +1273,17 @@ class RatbagParserSet(RatbagParserSwitch):
     def __repr__(self):
         return "set({})".format(self.repr_args())
 
+    def _print_help(self, prefix):
+        command = prefix + "{COMMAND} ..."
+        print("  {:<36}{}".format(command,
+                                  self.help if self.help else ""))
+        for e in self.switch:
+            e.print_help(None, " " * len(prefix))
+
 
 class RatbagParserCommand(RatbagParser):
-    def __init__(self, type, name, pos_args=[], tag=None, func=None, help=None):
-        super(RatbagParserCommand, self).__init__(type, name, tag, func, help)
+    def __init__(self, type, name, group=None, pos_args=[], tag=None, func=None, help=None):
+        super(RatbagParserCommand, self).__init__(type, name, group, tag, func, help)
         self.pos_args = [classes[obj[of_type]](**obj) for obj in pos_args]
 
     def _add_to_subparsers(self, parent):
@@ -1231,10 +1295,20 @@ class RatbagParserCommand(RatbagParser):
     def __repr__(self):
         return "command({})".format(self.repr_args())
 
+    def _print_help(self, prefix):
+        command = prefix + self.name
+        for a in self.pos_args:
+            if a.choices is None or len(a.choices) > 5:
+                command += " {}".format(a.metavar)
+            else:
+                command += " [{}]".format("|".join(a.choices))
+        print("  {:<36}{}".format(command,
+                                  self.help if self.help else ""))
+
 
 class RatbagParserArgument(RatbagParser):
-    def __init__(self, type, name, arg_type=None, metavar=None, nargs=None, choices=None, tag=None, func=None, help=None):
-        super(RatbagParserArgument, self).__init__(type, name, tag, func, help)
+    def __init__(self, type, name, group=None, arg_type=None, metavar=None, nargs=None, choices=None, tag=None, func=None, help=None):
+        super(RatbagParserArgument, self).__init__(type, name, group, tag, func, help)
         self.arg_type = arg_type
         self.metavar = metavar
         self.nargs = nargs
@@ -1245,17 +1319,24 @@ class RatbagParserArgument(RatbagParser):
 
 
 class RatbagParserLink(RatbagParser):
-    def __init__(self, type, dest=None, tag=None, func=None, help=None):
-        super(RatbagParserLink, self).__init__(type, dest, tag, func, help)
+    def __init__(self, type, dest=None, group=None, tag=None, func=None, help=None):
+        super(RatbagParserLink, self).__init__(type, dest, group, tag, func, help)
         self.dest = dest
 
-    def _add_to_subparsers(self, parent):
+    def get_dest(self):
         try:
-            e = RatbagParser.tagged[self.dest]
+            dest = RatbagParser.tagged[self.dest]
         except KeyError:
             raise ParseError("link '{}' points to nothing".format(self.dest))
-        else:
-            e.add_to_subparsers(parent)
+        return dest
+
+    def _add_to_subparsers(self, parent):
+        dest = self.get_dest()
+        dest.add_to_subparsers(parent)
+
+    def _print_help(self, prefix):
+        dest = self.get_dest()
+        print("  {:<36}Use {}for '{} Commands'".format(prefix + self.dest + " ...", prefix, dest.group))
 
 classes = {
     switch: RatbagParserSwitch,
@@ -1278,7 +1359,7 @@ class RatbagParserRoot(object):
             if not string.startswith('-'):
                 input_string[i] = string.lower()
 
-        self.parser = argparse.ArgumentParser(description="Inspect and modify configurable mice",
+        self.parser = argparse.ArgumentParser(description="Inspect and modify a configurable device",
                                               add_help=False)
         self.parser.add_argument("-V", "--version", action="version", version="@version@")
         self.parser.add_argument('--verbose', '-v', action='count', default=0)
@@ -1289,7 +1370,10 @@ class RatbagParserRoot(object):
         # retrieve the global options now and remove them from the processing
         ns, rest = self.parser.parse_known_args(input_string)
 
-        subs = self.parser.add_subparsers(title="COMMANDS", help='sub-command help')
+        if ns.help:
+            return ns
+
+        subs = self.parser.add_subparsers(title="COMMANDS")
 
         subparser = self.parser
 
@@ -1316,7 +1400,34 @@ class RatbagParserRoot(object):
         return ns
 
     def print_help(self):
-        self.parser.print_help()
+        print("usage: {} [OPTIONS] {{COMMAND}} ... /path/to/device\n".format(self.parser.prog))
+        print(self.parser.description)
+        print("""
+Common options:
+    --versionm -V               show program's version number and exit
+    --verbose, -v
+    --help, -h                  show this help and exit""")
+        if self.want_keepalive:
+            print("    --keepalive                 do not terminate ratbagd after the processing")
+        for c in self.children:
+            c.print_help(None)
+        print("""
+Examples:
+  {0} profile active get
+  {0} profile 0 resolution active set 4
+  {0} profile 0 resolution 1 dpi get
+  {0} resolution 4 rate get
+  {0} dpi set 800
+  {0} profile 0 led 0 set mode on
+  {0} profile 0 led 0 set color ff00ff
+  {0} profile 0 led 0 set rate 20
+
+Exit codes:
+  0     Success
+  1     Unsupported feature, index out of available range or invalid device
+  2     Commandline arguments are invalid
+  3     A command failed on the device
+""".format(self.parser.prog))
 
 
 def get_parser():

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -1144,7 +1144,7 @@ class RatbagParserSwitch(RatbagParser):
         parser.set_defaults(subparse=self.sub_parse)
 
     def _sub_parse(self, input_string, ns):
-        if len(input_string) >= 0 and self.N_access is not None:
+        if len(input_string) > 0 and self.N_access is not None:
             # retrieve first numbered element if any
             try:
                 int(input_string[0])
@@ -1301,10 +1301,10 @@ class RatbagParserRoot(object):
 
         ns.subparse = None
 
-        while subparser:
+        while rest and subparser:
             old_rest = rest
             ns, rest = subparser.parse_known_args(rest, namespace=ns)
-            if not rest or old_rest == rest:
+            if old_rest == rest:
                 break
             pr_debug(ns, ns, rest)
             if ns.subparse:

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -1300,8 +1300,9 @@ class RatbagParserRoot(object):
             pr_debug(ns, "<<< {}: {} | {}".format(child.type, child.name, rest))
 
         while subparser:
+            old_rest = rest
             ns, rest = subparser.parse_known_args(rest, namespace=ns)
-            if not rest:
+            if not rest or old_rest == rest:
                 break
             pr_debug(ns, ns, rest)
             try:

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -1104,13 +1104,11 @@ class RatbagParser(object):
             if 'list' not in self.name:
                 parser.add_argument("device", metavar='eventX')
 
-    def _parse(self, parent, input_string, ns):
-        raise ParseError("please implement _parse on {}".format(type(self)))
+    def _add_to_subparsers(self, parent, input_string, ns):
+        raise ParseError("please implement _add_to_subparsers on {}".format(type(self)))
 
-    def parse(self, parent, input_string, ns):
-        pr_debug(ns, ">>> {}: {} | {}".format(self.type, self.name, input_string))
-        self._parse(parent, input_string, ns)
-        pr_debug(ns, "<<< {}: {} | {}".format(self.type, self.name, input_string))
+    def add_to_subparsers(self, parent):
+        self._add_to_subparsers(parent)
 
     def _sub_parse(self, input_string, ns):
         raise ParseError("please implement _sub_parse on {}".format(type(self)))
@@ -1141,7 +1139,7 @@ class RatbagParserSwitch(RatbagParser):
     def repr_args(self):
         return """switch='{}', N_access='{}', {}""".format([repr(o) for o in self.switch], self.N_access, RatbagParser.repr_args(self))
 
-    def _parse(self, parent, input_string, ns):
+    def _add_to_subparsers(self, parent):
         parser = parent.add_parser(self.name, help=self.help)
         parser.set_defaults(subparse=self.sub_parse)
 
@@ -1163,7 +1161,7 @@ class RatbagParserSwitch(RatbagParser):
         # create a new subparser to handle all commands
         subs = parser.add_subparsers(title="COMMANDS", help=None)
         for e in self.switch:
-            e.parse(subs, input_string, ns)
+            e.add_to_subparsers(subs)
 
         return parser
 
@@ -1182,7 +1180,7 @@ class RatbagParserNAccess(RatbagParserSwitch):
         # create a new subparser to handle all commands
         subs = parser.add_subparsers(title="COMMANDS", help=None)
         for e in self.switch:
-            e.parse(subs, input_string, ns)
+            e.add_to_subparsers(subs)
         return parser
 
     def repr_args(self):
@@ -1196,7 +1194,7 @@ class RatbagParserSet(RatbagParserSwitch):
     def __init__(self, type, name, switch=[], N_access=None, tag=None, func=None, help=None):
         super(RatbagParserSet, self).__init__(type, name, switch, N_access, tag, func, help)
 
-    def _parse(self, parent, input_string, ns):
+    def _add_to_subparsers(self, parent):
         parser = parent.add_parser(self.name, help=self.help)
         parser.set_defaults(subparse=self.sub_parse)
 
@@ -1205,7 +1203,7 @@ class RatbagParserSet(RatbagParserSwitch):
         # create a new subparser to handle all commands
         subs = parser.add_subparsers(title="COMMANDS", help=None)
         for e in self.switch:
-            e.parse(subs, input_string, ns)
+            e.add_to_subparsers(subs)
         if len(input_string) == 3:
             self.store_function(parser)
         elif len(input_string) == 2:
@@ -1224,10 +1222,10 @@ class RatbagParserCommand(RatbagParser):
         super(RatbagParserCommand, self).__init__(type, name, tag, func, help)
         self.pos_args = [classes[obj[of_type]](**obj) for obj in pos_args]
 
-    def _parse(self, parent, input_string, ns):
+    def _add_to_subparsers(self, parent):
         parser = parent.add_parser(self.name, help=self.help)
         for a in self.pos_args:
-            a.parse(parser, input_string, ns)
+            a.add_to_subparsers(parser)
         self.store_function(parser)
 
     def __repr__(self):
@@ -1242,7 +1240,7 @@ class RatbagParserArgument(RatbagParser):
         self.nargs = nargs
         self.choices = choices
 
-    def _parse(self, parent, input_string, ns):
+    def _add_to_subparsers(self, parent):
         parent.add_argument(self.name, metavar=self.metavar, help=self.help, type=self.arg_type, nargs=self.nargs, choices=self.choices)
 
 
@@ -1251,13 +1249,13 @@ class RatbagParserLink(RatbagParser):
         super(RatbagParserLink, self).__init__(type, dest, tag, func, help)
         self.dest = dest
 
-    def _parse(self, parent, input_string, ns):
+    def _add_to_subparsers(self, parent):
         try:
             e = RatbagParser.tagged[self.dest]
         except KeyError:
             raise ParseError("link '{}' points to nothing".format(self.dest))
         else:
-            e.parse(parent, input_string, ns)
+            e.add_to_subparsers(parent)
 
 classes = {
     switch: RatbagParserSwitch,
@@ -1295,8 +1293,11 @@ class RatbagParserRoot(object):
 
         subparser = self.parser
 
+        pr_debug(ns, rest)
         for child in self.children:
-            child.parse(subs, rest, ns)
+            pr_debug(ns, ">>> {}: {} | {}".format(child.type, child.name, rest))
+            child.add_to_subparsers(subs)
+            pr_debug(ns, "<<< {}: {} | {}".format(child.type, child.name, rest))
 
         while subparser:
             ns, rest = subparser.parse_known_args(rest, namespace=ns)

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -1158,7 +1158,7 @@ class RatbagParserSwitch(RatbagParser):
                 # N_access subtree of the command
                 return self.N_access.sub_parse(input_string, ns)
 
-        parser = argparse.ArgumentParser()
+        parser = argparse.ArgumentParser(add_help=False)
 
         # create a new subparser to handle all commands
         subs = parser.add_subparsers(title="COMMANDS", help=None)
@@ -1177,7 +1177,7 @@ class RatbagParserNAccess(RatbagParserSwitch):
         self.metavar = metavar
 
     def _sub_parse(self, input_string, ns):
-        parser = argparse.ArgumentParser()
+        parser = argparse.ArgumentParser(add_help=False)
         parser.add_argument(self.name, help=self.help, type=int)
         # create a new subparser to handle all commands
         subs = parser.add_subparsers(title="COMMANDS", help=None)
@@ -1201,7 +1201,7 @@ class RatbagParserSet(RatbagParserSwitch):
         parser.set_defaults(subparse=self.sub_parse)
 
     def _sub_parse(self, input_string, ns):
-        parser = argparse.ArgumentParser()
+        parser = argparse.ArgumentParser(add_help=False)
         # create a new subparser to handle all commands
         subs = parser.add_subparsers(title="COMMANDS", help=None)
         for e in self.switch:
@@ -1288,15 +1288,15 @@ class RatbagParserRoot(object):
         if self.want_keepalive:
             self.parser.add_argument('--keepalive', action='store_true', default=False)
 
+        # retrieve the global options now and remove them from the processing
         ns, rest = self.parser.parse_known_args(input_string)
 
         subs = self.parser.add_subparsers(title="COMMANDS", help='sub-command help')
 
         subparser = self.parser
-        rest = input_string
 
         for child in self.children:
-            child.parse(subs, input_string, ns)
+            child.parse(subs, rest, ns)
 
         while subparser:
             ns, rest = subparser.parse_known_args(rest, namespace=ns)

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -1299,18 +1299,16 @@ class RatbagParserRoot(object):
             child.add_to_subparsers(subs)
             pr_debug(ns, "<<< {}: {} | {}".format(child.type, child.name, rest))
 
+        ns.subparse = None
+
         while subparser:
             old_rest = rest
             ns, rest = subparser.parse_known_args(rest, namespace=ns)
             if not rest or old_rest == rest:
                 break
             pr_debug(ns, ns, rest)
-            try:
-                subparse_call = ns.subparse
-            except AttributeError:
-                break
-            else:
-                subparser = subparse_call(rest, ns)
+            if ns.subparse:
+                subparser = ns.subparse(rest, ns)
 
         if rest:
             self.parser.error("extra arguments: '{}'".format(" ".join(rest)))

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -1356,7 +1356,13 @@ def main(argv):
 
     r = open_ratbagd()
     if r is not None:
-        cmd.func(r, cmd)
+        try:
+            f = cmd.func
+        except AttributeError:
+            parser.print_help()
+            return
+        else:
+            f(r, cmd)
 
 if __name__ == "__main__":
     main(sys.argv[1:])


### PR DESCRIPTION
I originally intended to have a dynamic use of argparse to generate the commands, but it turned out to be a nightmare.

Just go down the tree of arguments and format the help properly, and have the same crazy output than the one in ratbag-command.

Fixes #288