### PR TITLE
tools: don't return a ratbagd_process if things failed

### DIFF
--- a/tools/ratbagctl.devel.in
+++ b/tools/ratbagctl.devel.in
@@ -39,6 +39,8 @@ def main(argv):
         argv = ["list"]
 
     ratbagd_process = toolbox.start_ratbagd()
+    if ratbagd_process is None:
+        sys.exit("Failed to start or connect to ratbagd")
 
     ratbagd = toolbox.open_ratbagd()
     parser = toolbox.get_parser()

--- a/tools/toolbox.py
+++ b/tools/toolbox.py
@@ -84,6 +84,9 @@ def start_ratbagd():
 
     os.environ['RATBAGCTL_DEVEL'] = "org.freedesktop.ratbag_devel1_@ratbagd_sha@"
 
+    if name_owner is None or ratbagd_process.poll() is not None:
+        return None
+
     return ratbagd_process
 
 


### PR DESCRIPTION
If we couldn't find the name on the bus or the ratbagd process already
terminated, return None and fail.

