### PR TITLE
Add async commit support

### DIFF
--- a/DBusInterface.md
+++ b/DBusInterface.md
@@ -89,7 +89,9 @@ Provides the list of profile paths for all profiles on this device, see
 #### `Commit() → ()`
 
 Commits the changes to the device. Changes to the device are batched; they
-are not written to the hardware until `Commit()` is invoked.
+are not written to the hardware until `Commit()` is invoked. This method is
+**asynchronous** and always succeeds. When the commit has been completed, a
+**Committed** signal is emitted.
 
 #### `GetSvg(s) → (s)`
 
@@ -99,6 +101,15 @@ none is available.  The theme must be one of
 guaranteed to be available. ratbagd may return the path to a file that
 doesn't exist. This is the case if the device has SVGs available but not for
 the given theme.
+
+### Signals:
+
+#### `Committed(i)`
+
+Signal sent when a previous **Commit** has completed. If the error is positive,
+it is an errno. If the error is negative, it is a libratbag-specific error.
+
+If the error is 0, the commit was successful.
 
 org.freedesktop.ratbag1.Profile
 ===============================


### PR DESCRIPTION
Defer the actual commit so we can return immediately. This fixes the various
timeout issues we've seen on some devices where a commit can take several
seconds.

This commit merely adds the async hook. If the commit itself fails we
should re-sync from libratbag and update all the properties. This is currently
missing.

Fixes #269

Note: this does **NOT** include the ratbagd.py changes because we currently have some issues with syncing that from piper (see #295). There's a piper-commit pending for adding it there, it will be synced back once that's merged.