### PR TITLE
ratbagd: fix assertion error when quitting with more than 1 devices attached

### DIFF
--- a/ratbagd/ratbagd.c
+++ b/ratbagd/ratbagd.c
@@ -486,12 +486,12 @@ static const struct ratbag_interface ratbagd_lib_interface = {
 
 static struct ratbagd *ratbagd_free(struct ratbagd *ctx)
 {
-	struct ratbagd_device *device;
+	struct ratbagd_device *device, *tmp;
 
 	if (!ctx)
 		return NULL;
 
-	RATBAGD_DEVICE_FOREACH(device, ctx)
+	RATBAGD_DEVICE_FOREACH_SAFE(device, tmp, ctx)
 		ratbagd_device_unlink(device);
 
 	ctx->bus = sd_bus_flush_close_unref(ctx->bus);

--- a/ratbagd/ratbagd.h
+++ b/ratbagd/ratbagd.h
@@ -169,6 +169,12 @@ struct ratbagd_device *ratbagd_device_next(struct ratbagd_device *device);
 	     (_device);					\
 	     (_device) = ratbagd_device_next(_device))
 
+#define RATBAGD_DEVICE_FOREACH_SAFE(_device, _safe, _ctx)	\
+	for ((_device) = ratbagd_device_first(_ctx),		\
+	     (_device) ? _safe = ratbagd_device_next(_device) : NULL; \
+	     (_device);						\
+	     (_device) = _safe,				\
+	     _safe = _safe ? ratbagd_device_next(_device) : NULL)
 /*
  * Context
  */


### PR DESCRIPTION


RATBAGD_FOREACH_DEVICE does not allow unlinking the device during the loop.

