### PR TITLE
data: add a fallback.svg file

### DIFF
--- a/data/gnome/fallback.svg
+++ b/data/gnome/fallback.svg
@@ -1,0 +1,506 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="450"
+   height="450"
+   viewBox="0 0 450.00001 450.00001"
+   id="svg4844"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="fallback.svg">
+  <defs
+     id="defs4846" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.4"
+     inkscape:cx="162.83067"
+     inkscape:cy="254.74718"
+     inkscape:document-units="px"
+     inkscape:current-layer="Device"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1101"
+     inkscape:window-x="1920"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <sodipodi:guide
+       position="20.203051,215.1625"
+       orientation="1,0"
+       id="guide6533" />
+    <sodipodi:guide
+       position="263.64982,40.406102"
+       orientation="0,1"
+       id="guide6535" />
+    <sodipodi:guide
+       position="119.198,430.32499"
+       orientation="0,1"
+       id="guide6537" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata4849">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="Device"
+     inkscape:label="Device"
+     style="display:inline">
+    <g
+       id="mouse"
+       transform="matrix(1.4157338,0,0,1.4150394,-15.907361,-83.397825)"
+       inkscape:label="#g5682">
+      <path
+         sodipodi:nodetypes="csssssscssssccccccccsccccscccccccc"
+         inkscape:connector-curvature="0"
+         id="path5554"
+         d="m 107.18942,257.50398 c -4.99714,2.43535 -12.465604,2.63664 -17.258052,-1.44306 -13.182502,-11.22196 -9.97511,-20.42755 -11.852724,-27.60442 -2.086919,-7.9769 -8.394971,-14.22057 -14.204755,-19.22015 -2.452298,-2.11032 -15.074169,-8.92571 -22.581405,-6.39459 -7.284157,2.45591 -8.927109,7.96865 -7.039536,13.91417 0.942265,2.96796 6.341731,12.02153 3.965931,13.71887 -6.197029,4.42735 -6.062903,-6.5818 -10.547143,-6.17694 -3.155437,2.60598 5.722132,16.20922 13.501397,8.54975 5.287042,-5.20562 -7.079343,-19.36707 -3.390295,-23.44484 9.484404,-10.48379 25.055087,3.37163 28.181213,6.1766 3.122791,2.80198 9.248496,8.52414 9.875553,20.12323 0.843858,15.60941 10.74282,34.96801 34.650426,29.65168 5.06065,14.01778 13.49867,22.70826 23.95424,24.35573 -0.73268,4.29744 8.14899,6.47132 -4.44275,21.19745 3.06561,2.85685 8.01758,11.19489 5.36011,25.42154 -5.7187,3.96316 -16.72683,16.45412 0.58015,5.39321 7.47117,-0.31027 14.12258,9.86529 24.83436,3.31115 -4.03605,-1.39212 -8.28293,-7.96174 -18.1528,-9.13334 -0.39969,-10.26297 -0.36143,-17.7796 5.94065,-24.85378 14.19011,-17.96422 10.92982,-12.10811 13.41925,-19.23937 2.48943,-7.13126 2.52109,-11.34 2.33441,-19.25558 -2.9569,-16.18074 -2.70058,-16.2775 -0.11605,-1.49727 16.61294,-0.76638 32.95879,-6.2945 39.23502,-17.29952 9.79039,-1.32985 22.51147,-7.39605 29.90276,0.56675 -5.22785,1.2715 -19.1955,26.95192 0.95314,7.4515 11.02869,-10.67388 23.99028,5.40711 27.28604,-12.1447 -31.80018,1.43261 -37.30275,-17.43649 -56.67811,-17.25445 -7.30408,-0.27416 -20.44309,-0.17002 -25.52504,9.24102 9.11653,-12.47147 0.88952,-27.94431 -1.51863,-41.85017 -15.02015,-21.13729 -30.18152,-29.86148 -43.79923,-20.54814 -13.65771,11.51411 -22.41864,26.83759 -23.4676,44.34506 -1.03036,11.6519 -3.29737,12.1189 -3.40046,33.94261 z"
+         style="fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:2.11956239;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="zcsccczzczz"
+         inkscape:connector-curvature="0"
+         id="button6"
+         d="m 125.00072,147.3762 c -3.94854,2.46476 -1.91248,4.22271 -6.56842,3.47664 -6.04044,-0.49004 -12.10893,4.61986 -13.01838,8.83118 -1.05538,4.887 0.82228,9.01123 6.09563,9.60013 4.20528,0.52222 4.02895,-1.99743 6.87568,-2.5868 4.10235,6.95899 19.61805,11.70942 26.38361,11.76956 4.71763,-0.6919 4.81094,-3.03006 11.87015,-12.70472 7.05921,-9.67466 6.92045,-10.39092 6.98781,-15.5586 0.0674,-5.16768 5.35659,-7.43289 0.64282,-10.74954 -1.91632,-0.43449 -6.15926,0.21143 -17.24225,0.33896 -11.08299,0.12753 -18.07811,5.11843 -22.02665,7.58319 z"
+         style="fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#babdb6;stroke-width:2.11956239;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:label="#path5399" />
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path5405"
+         d="m 163.20277,150.23723 c -1.06521,-0.0557 -3.7617,0.42888 -4.65914,1.09722 -2,1.49899 -2.78079,2.58243 -4.28466,4.28408"
+         style="fill:none;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:0.70652068px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="zszzcz"
+         inkscape:connector-curvature="0"
+         id="path5414"
+         d="m 140.75099,145.17797 c -1.18229,0.40938 -2.17328,0.089 -3.548,0.54388 -1.29024,0.42688 -0.38888,1.67372 0.70446,2.31451 1.09334,0.64079 4.0134,-0.29332 5.06491,-1.10649 1.05151,-0.81317 1.6576,-2.35673 1.26243,-2.48934 -0.39517,-0.13262 -2.30151,0.32805 -3.4838,0.73744 z"
+         style="fill:none;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:0.70652068px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cscccccccccc"
+         inkscape:connector-curvature="0"
+         id="button4"
+         d="m 78.728764,157.07155 c 2.729308,11.45367 -4.592785,23.20521 4.683418,32.67799 4.193755,4.28262 13.716552,5.67648 28.077598,4.49959 -16.964136,7.07876 -15.435974,11.82485 -18.038124,14.76602 -0.367398,1.93959 3.51961,2.8971 16.874634,15.52043 5.69621,-9.78547 8.32004,-20.52393 15.45362,-28.52298 15.91171,-4.8206 -2.52533,-22.7944 -2.52533,-22.7944 0,0 -6.14675,-4.9701 -9.92352,3.09571 -7.99103,-6.69016 -16.706109,-2.41957 -17.256932,4.64391 1.356748,-6.41288 0.152959,-21.95234 -2.71781,-27.4956 -9.538417,1.9887 -10.559123,3.86954 -14.594684,3.59772 -0.398494,-4.23259 11.719989,-4.91038 14.599568,-3.59704"
+         style="fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:2.11956239;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:label="#path5425" />
+      <path
+         sodipodi:nodetypes="sscscccs"
+         inkscape:connector-curvature="0"
+         id="path5459"
+         d="m 170.57402,194.85052 c 1.27147,3.99383 5.43056,12.02629 7.61859,15.67135 1.67031,2.78261 3.12076,3.57306 4.37974,10.16536 3.35106,-2.36328 2.26625,-4.37687 7.86716,-6.63393 6.78116,-2.73268 10.74994,-17.14078 7.59325,-20.21486 -2.56921,-1.4377 -13.90652,-7.54721 -16.5961,-8.75778 -8.64652,-2.75344 -18.11595,-5.26303 -26.29721,-3.34848 9.47658,1.68644 14.2189,9.2998 15.43457,13.11834 z"
+         style="fill:#babdb6;fill-opacity:1;fill-rule:evenodd;stroke:#babdb6;stroke-width:2.11956239;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cccczccszccccc"
+         inkscape:connector-curvature="0"
+         id="button5"
+         d="m 156.57364,174.60716 c 0.61451,3.45259 -4.17141,8.40305 2.31606,7.85954 11.99907,4.07348 25.62973,4.1469 36.30113,11.66165 7.04625,4.94297 4.95335,13.00607 7.04625,4.94297 1.1521,-9.09961 -1.67322,-15.30143 -7.75899,-16.73475 -6.08578,-1.43332 -8.13701,-3.55535 -13.61967,-4.14262 -2.80249,-1.72124 -8.8609,-0.0129 -18.78998,0.48317 7.50071,-0.84183 14.47216,-0.73196 18.56074,-2.80565 0,0 6.30334,-9.54951 7.53958,-14.37709 1.23624,-4.82758 1.50074,-6.5184 3.27709,-10.38873 -4.42899,-1.01319 -7.07586,-3.6542 -10.44975,-4.61991 -2.18062,4.20089 -3.52881,8.12787 -6.83587,11.50939 -4.41968,6.55835 -8.29193,5.97237 -14.60181,12.79024 -0.89825,2.92739 -2.98478,3.82179 -2.98478,3.82179 z"
+         style="fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#babdb6;stroke-width:2.11956239;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:label="#path5453" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="button2"
+         d="m 129.85315,182.50093 c 3.6135,2.58802 10.74551,5.75132 14.60758,1.93282 0.45507,-2.97455 -0.19296,-6.87423 -0.19285,-7.3212 -7.27257,-0.13193 -16.12143,-4.19401 -22.95494,-6.35683 1.4347,5.55248 6.71272,10.53825 8.54021,11.74521 z"
+         style="fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:2.11956239;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:label="#path5540" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="button3"
+         d="m 147.13503,177.00627 c 1.16519,3.28142 3.63994,3.84875 5.91906,6.18906 4.77775,-2.47336 5.12452,-13.43108 3.9723,-16.57185 -3.79251,3.28442 -5.96683,8.30504 -9.89136,10.38279 z"
+         style="fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:2.11956239;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:label="#path5547" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="button7"
+         d="m 96.280703,132.06305 c 0,0 58.294677,-1.61611 100.929457,-0.83206 -1.27875,-12.91598 2.4481,-38.633128 2.05831,-56.889372 -46.40187,1.475128 -77.8249,2.200365 -105.250613,1.551238 4.495692,30.284264 2.262846,56.170194 2.262846,56.170194 z"
+         style="fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:2.11956239;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:label="#path5566" />
+      <path
+         sodipodi:nodetypes="cscsccsccscsccccc"
+         inkscape:connector-curvature="0"
+         id="button0"
+         d="m 82.544643,155.53571 c 0.305172,-3.31535 0.980416,-11.89491 2.489066,-14.57767 2.810136,-4.99714 6.565433,-8.72285 8.454552,-11.91369 2.686043,-3.2364 2.701225,-4.20604 4.184853,-5.44313 1.47935,-1.23353 7.182396,-9.27661 8.097236,-8.77569 1.51464,3.42922 -5.03984,11.03401 -6.93589,13.34978 2.62462,-2.24644 4.10033,-4.85435 7.49772,-7.85092 3.00882,-2.65384 6.26227,-2.5427 3.72007,0.68937 -2.64048,3.02394 -3.55215,4.11719 -8.76065,8.25327 10.88502,-8.17285 19.09259,-9.06063 9.30462,-2.01748 -1.40825,1.01334 -8.4791,4.08043 -5.58663,2.88614 2.72294,-0.18651 10.84559,-2.68876 10.05588,-0.49162 -1.65227,4.59693 -8.23017,2.61804 -12.09164,4.12386 -2.17312,2.61683 -5.158266,3.64905 -7.879445,5.87814 -1.853363,2.41097 -3.914211,8.13746 -5.08138,13.723 -0.977626,0.29825 -5.450462,1.56098 -7.468362,2.16661 z"
+         style="fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:1.41304147;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:label="#path5561" />
+      <text
+         sodipodi:linespacing="100%"
+         id="text5583"
+         y="117.5"
+         x="110.17857"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:'sans-serif Italic';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#bfc2bb;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:sans-serif;-inkscape-font-specification:'sans-serif Italic';fill:#bfc2bb;fill-opacity:1"
+           y="117.5"
+           x="110.17857"
+           id="tspan5585"
+           sodipodi:role="line">404</tspan></text>
+      <path
+         sodipodi:nodetypes="cccccsscssccccc"
+         inkscape:connector-curvature="0"
+         id="button1"
+         d="m 183.97321,147.27678 c 3.33335,-1.48288 3.09826,-6.77076 3.85156,-9.86053 -0.35674,-3.91061 0.37686,-5.05433 -1.93804,-6.90092 -2.10346,-1.08198 -0.13041,-3.85244 1.93457,-2.9861 2.92925,1.60616 0.94495,6.22838 4.12041,7.61394 0,0 1.87775,-1.15731 1.99206,-3.40725 0.1301,-2.56065 -1.15427,-11.79601 1.03251,-13.08991 0.96059,-0.56838 1.75458,9.82486 2.96125,11.86818 -0.30586,-2.13132 -0.65718,-12.83967 0.19291,-12.16594 3.65618,2.89768 1.37042,11.98208 3.4547,14.61683 1.72735,2.18354 -3.64795,6.53893 -6.93051,11.03314 -2.12109,2.77912 -2.89583,2.76412 -4.9476,6.04875 -2.40971,-1.47777 -3.69229,-1.95944 -5.72384,-2.77019 l 0,0 z"
+         style="fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:1.41304147;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:label="#path5587" />
+      <path
+         style="fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:3.02452755;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 129.71002,288.41558 c -7.1173,2.84692 -18.1026,3.61499 -24.6415,-2.32569 C 86.783262,269.47748 90.830889,256.94793 88.150941,246.7094 85.172248,235.32955 76.168664,226.42233 67.876267,219.28992 64.376063,216.27934 46.360664,206.5565 35.645466,210.16739 25.248672,213.671 22.903661,221.53548 25.597824,230.01736 c 1.34491,4.23409 9.051654,17.14992 5.660636,19.57135 -8.845118,6.31606 -8.653678,-9.3896 -15.054105,-8.81203 -4.503806,3.71769 8.16729,23.12409 19.27076,12.19708 7.546279,-7.42634 -10.10446,-27.62907 -4.839023,-33.44642 13.537242,-14.95619 35.761527,4.80997 40.223496,8.81154 4.45721,3.9973 13.200527,12.16054 14.095535,28.70781 1.204452,22.2684 15.333397,49.88539 49.444437,42.2623 -0.73591,-2.53682 -4.15602,-6.43263 -4.68954,-10.89341 z"
+         id="led0"
+         transform="matrix(0.7006157,0,0,0.70096699,16.318711,55.521354)"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssssscsssscc"
+         inkscape:label="#path6431" />
+      <path
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:3.02452755;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 169.91186,400.60038 c -8.16239,5.65385 -23.87447,23.47346 0.82806,7.69396 10.66372,-0.44263 20.15739,14.07383 35.44648,4.72369 -5.76072,-1.986 -11.82236,-11.35822 -25.88738,-13.10742 -3.01274,0.0336 -8.44501,-0.32858 -10.38716,0.68977 z"
+         id="path6437"
+         transform="matrix(0.7006157,0,0,0.70096699,16.318711,55.521354)"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+    <path
+       inkscape:label="#path6478"
+       style="fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:3.00000024;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 175.72866,392.52094 c -8.09615,5.60803 -23.68073,23.28322 0.82135,7.6316 10.57718,-0.43903 19.9938,13.95978 35.15883,4.68542 -5.71397,-1.96992 -11.72643,-11.26617 -25.67731,-13.0012 -2.98831,0.0334 -8.37648,-0.32592 -10.30287,0.68418 z"
+       id="led1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       sodipodi:nodetypes="csccc"
+       inkscape:connector-curvature="0"
+       id="led2"
+       d="m 314.43906,276.47676 c -7.40123,1.79921 -27.17571,38.13802 1.3494,10.54417 15.61369,-15.10398 33.96384,7.65126 38.62976,-17.18524 -11.69141,0.52644 -20.87204,-0.88448 -28.52139,-3.25631 -0.91845,1.9989 -7.62356,10.08149 -11.45777,9.89738 z"
+       style="fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:3.00000024;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="Buttons"
+     inkscape:label="Buttons"
+     style="display:inline">
+    <g
+       style="display:inline"
+       id="button1-path"
+       inkscape:label="#g131"
+       transform="translate(12.063466,68.669278)">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 282.94764,50.505764 154.05236,0"
+         id="path958"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect968"
+         width="6.999999"
+         height="6.999999"
+         x="277"
+         y="47.005764" />
+      <rect
+         inkscape:label="#rect867"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button1-leader"
+         width="1"
+         height="1"
+         x="437"
+         y="50.005764" />
+    </g>
+    <g
+       transform="translate(12.063466,28.669278)"
+       inkscape:label="#g131"
+       id="button0-path"
+       style="display:inline">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5628"
+         d="m 282.94764,50.505764 154.05236,0"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="cc" />
+      <rect
+         y="47.005764"
+         x="277"
+         height="6.999999"
+         width="6.999999"
+         id="rect5630"
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="50.005764"
+         x="437"
+         height="1"
+         width="1"
+         id="button0-leader"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect867" />
+    </g>
+    <g
+       transform="translate(12.063466,148.66928)"
+       inkscape:label="#g131"
+       id="button3-path"
+       style="display:inline">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5636"
+         d="m 282.94764,50.505764 154.05236,0"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="cc" />
+      <rect
+         y="47.005764"
+         x="277"
+         height="6.999999"
+         width="6.999999"
+         id="rect5638"
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="50.005764"
+         x="437"
+         height="1"
+         width="1"
+         id="button3-leader"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect867" />
+    </g>
+    <g
+       style="display:inline"
+       id="button2-path"
+       inkscape:label="#g131"
+       transform="translate(12.063466,108.66928)">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 282.94764,50.505764 154.05236,0"
+         id="path5644"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect5646"
+         width="6.999999"
+         height="6.999999"
+         x="277"
+         y="47.005764" />
+      <rect
+         inkscape:label="#rect867"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button2-leader"
+         width="1"
+         height="1"
+         x="437"
+         y="50.005764" />
+    </g>
+    <g
+       transform="translate(12.063466,228.66928)"
+       inkscape:label="#g131"
+       id="button5-path"
+       style="display:inline">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5652"
+         d="m 282.94764,50.505764 154.05236,0"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="cc" />
+      <rect
+         y="47.005764"
+         x="277"
+         height="6.999999"
+         width="6.999999"
+         id="rect5654"
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="50.005764"
+         x="437"
+         height="1"
+         width="1"
+         id="button5-leader"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect867" />
+    </g>
+    <g
+       style="display:inline"
+       id="button4-path"
+       inkscape:label="#g131"
+       transform="translate(12.063466,188.66928)">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 282.94764,50.505764 154.05236,0"
+         id="path5660"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect5662"
+         width="6.999999"
+         height="6.999999"
+         x="277"
+         y="47.005764" />
+      <rect
+         inkscape:label="#rect867"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button4-leader"
+         width="1"
+         height="1"
+         x="437"
+         y="50.005764" />
+    </g>
+    <g
+       style="display:inline"
+       id="button7-path"
+       inkscape:label="#g131"
+       transform="translate(12.063466,308.66928)">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 282.94764,50.505764 154.05236,0"
+         id="path5668"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect5670"
+         width="6.999999"
+         height="6.999999"
+         x="277"
+         y="47.005764" />
+      <rect
+         inkscape:label="#rect867"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button7-leader"
+         width="1"
+         height="1"
+         x="437"
+         y="50.005764" />
+    </g>
+    <g
+       transform="translate(12.063466,268.66928)"
+       inkscape:label="#g131"
+       id="g5674"
+       style="display:inline">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5676"
+         d="m 282.94764,50.505764 154.05236,0"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="cc" />
+      <rect
+         y="47.005764"
+         x="277"
+         height="6.999999"
+         width="6.999999"
+         id="rect5678"
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="50.005764"
+         x="437"
+         height="1"
+         width="1"
+         id="button6-leader"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect867" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="LEDs"
+     inkscape:label="LEDs">
+    <g
+       style="display:inline"
+       id="led0-path"
+       inkscape:label="#g131"
+       transform="translate(12.063466,28.669278)">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 282.94764,50.505764 154.05236,0"
+         id="path5785"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect5787"
+         width="6.999999"
+         height="6.999999"
+         x="277"
+         y="47.005764" />
+      <rect
+         inkscape:label="#rect867"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="led0-leader"
+         width="1"
+         height="1"
+         x="437"
+         y="50.005764" />
+    </g>
+    <g
+       transform="translate(12.063466,68.669278)"
+       inkscape:label="#g131"
+       id="led1-path"
+       style="display:inline">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5797"
+         d="m 282.94764,50.505764 154.05236,0"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="cc" />
+      <rect
+         y="47.005764"
+         x="277"
+         height="6.999999"
+         width="6.999999"
+         id="rect5799"
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="50.005764"
+         x="437"
+         height="1"
+         width="1"
+         id="led1-leader"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect867" />
+    </g>
+    <g
+       style="display:inline"
+       id="led2-path"
+       inkscape:label="#g131"
+       transform="translate(12.063466,108.66928)">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 282.94764,50.505764 154.05236,0"
+         id="path6411"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect6413"
+         width="6.999999"
+         height="6.999999"
+         x="277"
+         y="47.005764" />
+      <rect
+         inkscape:label="#rect867"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="led2-leader"
+         width="1"
+         height="1"
+         x="437"
+         y="50.005764" />
+    </g>
+  </g>
+</svg>

--- a/meson.build
+++ b/meson.build
@@ -306,6 +306,7 @@ install_data(default_svg_files,
 	     install_dir : join_paths(get_option('datadir'), 'libratbag', 'default'))
 
 gnome_svg_files = [
+	'data/gnome/fallback.svg',
 	'data/gnome/logitech-g303.svg',
 	'data/gnome/logitech-g403.svg',
 	'data/gnome/logitech-g500.svg',

--- a/meson.build
+++ b/meson.build
@@ -37,6 +37,7 @@ add_project_arguments(cppflags, language: 'cpp')
 # is generated at the end of this file
 config_h = configuration_data()
 config_h.set('_GNU_SOURCE', '1')
+config_h.set_quoted('FALLBACK_SVG_NAME', 'fallback.svg')
 libratbag_data_dir = join_paths(get_option('prefix'),
 				get_option('datadir'),
 				'libratbag')

--- a/ratbagd/ratbagd-device.c
+++ b/ratbagd/ratbagd-device.c
@@ -171,14 +171,13 @@ static int ratbagd_device_get_theme_svg(sd_bus_message *m,
 
 	svg = ratbag_device_get_svg_name(device->lib_device);
 	if (!svg) {
-		log_error("Unable to fetch SVG for %s\n",
+		log_error("Unable to fetch SVG for %s, using fallback\n",
 			  ratbagd_device_get_name(device));
-		goto out;
+		svg = FALLBACK_SVG_NAME;
 	}
 
 	sprintf(svg_path, "%s/%s/%s", LIBRATBAG_DATA_DIR, theme, svg);
 
-out:
 	return sd_bus_reply_method_return(m, "s", svg_path);
 }
 

--- a/ratbagd/ratbagd.c
+++ b/ratbagd/ratbagd.c
@@ -196,7 +196,7 @@ static const struct ratbag_test_device ratbagd_test_device_descr = {
 	.num_resolutions = 3,
 	.num_buttons = 4,
 	.num_leds = 3,
-	.svg = "logitech-g500.svg",
+	.svg = "fallback.svg",
 	.profiles = {
 		{
 			.buttons = {


### PR DESCRIPTION
This SVG is generic enough to cover 7-button mice with up to 3 LEDs that are
supported but don't have an SVG. The SVG style is intentionally NOT a generic
mouse to make it obvious that something isn't right here. If we use a generic
mouse, people may not put the effort into a proper SVG style because the
generic mouse is good enough.

The fallback is currently only used for test devices