### PR TITLE
improve error for missing device files

### DIFF
--- a/src/libratbag-data.c
+++ b/src/libratbag-data.c
@@ -326,8 +326,8 @@ ratbag_device_data_new_for_id(struct ratbag *ratbag, const struct input_id *id)
 
 	n = scandir(LIBRATBAG_DATA_DIR, &files, filter_device_files, alphasort);
 	if (n <= 0) {
-		log_error(ratbag, "Unable to locate device files: %s\n",
-			  n == 0 ? "No files found" : strerror(errno));
+		log_error(ratbag, "Unable to locate device files in %s: %s\n",
+			  LIBRATBAG_DATA_DIR, n == 0 ? "No files found" : strerror(errno));
 		return NULL;
 	}
 

--- a/src/libratbag-data.c
+++ b/src/libratbag-data.c
@@ -97,6 +97,7 @@ init_data_hidpp10(struct ratbag *ratbag,
 	if (error)
 		g_error_free(error);
 
+	error = NULL;
 	num = g_key_file_get_integer(keyfile, group, "Profiles", &error);
 	if (num > 0 || !error)
 		data->hidpp10.profile_count = num;


### PR DESCRIPTION
Before 340e5b7d86fc9cc04dc563dc755d1efffe9a97c5 I got:
ratbag error: libratbag bug: Logitech G9 Laser Mouse: no profile set as active profile
No supported devices found

After 340e5b7d86fc9cc04dc563dc755d1efffe9a97c5 I get:
ratbag error: Unable to locate device files: No such file or directory
ratbag error: Unable to locate device files: No such file or directory
ratbag error: Unable to locate device files: No such file or directory
No supported devices found

With this PR we give a hint to the user about where libratbag is looking for the files.