### PR TITLE
reset GError before reuse

### DIFF
--- a/src/libratbag-data.c
+++ b/src/libratbag-data.c
@@ -97,6 +97,7 @@ init_data_hidpp10(struct ratbag *ratbag,
 	if (error)
 		g_error_free(error);
 
+	error = NULL;
 	num = g_key_file_get_integer(keyfile, group, "Profiles", &error);
 	if (num > 0 || !error)
 		data->hidpp10.profile_count = num;


### PR DESCRIPTION
If the error variable is not reset then we may end up freeing it
again in the next block. This can cause problems later for glib.

Fixes #311 