### PR TITLE
Fix sync of ratbagd profile IsActive properties

### DIFF
--- a/ratbagd/ratbagd-profile.c
+++ b/ratbagd/ratbagd-profile.c
@@ -268,17 +268,13 @@ static int ratbagd_profile_find_led(sd_bus *bus,
 static int ratbagd_profile_active_signal_cb(sd_bus *bus,
 					    struct ratbagd_profile *profile)
 {
-	struct ratbag_profile *lib_profile = profile->lib_profile;
-
 	/* FIXME: we should cache is active and only send the signal for
 	 * those profiles where it changed */
-
-	(void) sd_bus_emit_signal(bus,
-				  profile->path,
-				  RATBAGD_NAME_ROOT ".Profile",
-				  "IsActive",
-				  "b",
-				  ratbag_profile_is_active(lib_profile));
+	(void) sd_bus_emit_properties_changed(bus,
+					      profile->path,
+					      RATBAGD_NAME_ROOT ".Profile",
+					      "IsActive",
+					      NULL);
 
 	return 0;
 }

--- a/ratbagd/ratbagd-resolution.c
+++ b/ratbagd/ratbagd-resolution.c
@@ -82,17 +82,8 @@ ratbagd_resolution_set_report_rate(sd_bus *bus,
 static int ratbagd_resolution_active_signal_cb(sd_bus *bus,
 						struct ratbagd_resolution *resolution)
 {
-	struct ratbag_resolution *lib_resolution = resolution->lib_resolution;
-
 	/* FIXME: we should cache is_active and only send the signal for
 	 * those resolutions where it changed */
-
-	(void) sd_bus_emit_signal(bus,
-				  resolution->path,
-				  RATBAGD_NAME_ROOT ".Resolution",
-				  "IsActive",
-				  "b",
-				  ratbag_resolution_is_active(lib_resolution));
 
 	(void) sd_bus_emit_properties_changed(bus,
 					      resolution->path,
@@ -124,17 +115,8 @@ static int ratbagd_resolution_set_active(sd_bus_message *m,
 static int ratbagd_resolution_default_signal_cb(sd_bus *bus,
 						struct ratbagd_resolution *resolution)
 {
-	struct ratbag_resolution *lib_resolution = resolution->lib_resolution;
-
 	/* FIXME: we should cache is default and only send the signal for
 	 * those resolutions where it changed */
-
-	(void) sd_bus_emit_signal(bus,
-				  resolution->path,
-				  RATBAGD_NAME_ROOT ".Resolution",
-				  "IsDefault",
-				  "b",
-				  ratbag_resolution_is_default(lib_resolution));
 
 	(void) sd_bus_emit_properties_changed(bus,
 					      resolution->path,


### PR DESCRIPTION
We sent a useless signal, but didn't update the actual properties.