### PR TITLE
Drop key modifiers from action type Key

### DIFF
--- a/DBusInterface.md
+++ b/DBusInterface.md
@@ -238,10 +238,9 @@ uint of the current button mapping (if mapping to button)
 
 Enum describing the current special mapping (if mapped to special)
 #### `KeyMapping`
-- type: `au`, read-write, mutable
+- type: `u`, read-write, mutable
 
-Array of uints, first entry is the keycode, other entries, if any, are
-modifiers (if mapped to key)
+uint of the keycode in linux/input.h form (if mapping to key)
 #### `Macro`
 -type: `a(uu)`, read-write, mutable
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,8 @@
 libratbag_references:
   default_settings: &default_settings
     working_directory: ~/libratbag
+    environment:
+      LANG: C.UTF-8
   build_default: &build_default
     name: Build
     command: |

--- a/src/driver-gskill.c
+++ b/src/driver-gskill.c
@@ -1266,13 +1266,13 @@ gskill_read_button(struct ratbag_button *button)
 		break;
 	case GSKILL_BUTTON_FUNCTION_KBD:
 		act->type = RATBAG_BUTTON_ACTION_TYPE_KEY;
-		act->action.key.key =
+		act->action.key =
 			ratbag_hidraw_get_keycode_from_keyboard_usage(
 			    device, bcfg->params.kbd.hid_code);
 		break;
 	case GSKILL_BUTTON_FUNCTION_CONSUMER:
 		act->type = RATBAG_BUTTON_ACTION_TYPE_KEY;
-		act->action.key.key =
+		act->action.key =
 			ratbag_hidraw_get_keycode_from_consumer_usage(
 			    device, bcfg->params.consumer.code);
 		break;
@@ -1372,13 +1372,13 @@ gskill_update_button(struct ratbag_button *button)
 		break;
 	case RATBAG_BUTTON_ACTION_TYPE_KEY:
 		code = ratbag_hidraw_get_keyboard_usage_from_keycode(
-		    device, action->action.key.key);
+		    device, action->action.key);
 		if (code) {
 			bcfg->type = GSKILL_BUTTON_FUNCTION_KBD;
 			bcfg->params.kbd.hid_code = code;
 		} else {
 			code = ratbag_hidraw_get_consumer_usage_from_keycode(
-			    device, action->action.key.key);
+			    device, action->action.key);
 
 			bcfg->type = GSKILL_BUTTON_FUNCTION_CONSUMER;
 			bcfg->params.consumer.code = code;

--- a/src/driver-hidpp10.c
+++ b/src/driver-hidpp10.c
@@ -176,12 +176,12 @@ hidpp10drv_map_button(struct ratbag_device *device,
 		break;
 	case PROFILE_BUTTON_TYPE_KEYS:
 		button->action.type = RATBAG_BUTTON_ACTION_TYPE_KEY;
-		button->action.action.key.key = ratbag_hidraw_get_keycode_from_keyboard_usage(device,
+		button->action.action.key = ratbag_hidraw_get_keycode_from_keyboard_usage(device,
 							profile.buttons[button->index].keys.key);
 		break;
 	case PROFILE_BUTTON_TYPE_CONSUMER_CONTROL:
 		button->action.type = RATBAG_BUTTON_ACTION_TYPE_KEY;
-		button->action.action.key.key = ratbag_hidraw_get_keycode_from_consumer_usage(device,
+		button->action.action.key = ratbag_hidraw_get_keycode_from_consumer_usage(device,
 							profile.buttons[button->index].consumer_control.consumer_control);
 		break;
 	case PROFILE_BUTTON_TYPE_SPECIAL:
@@ -309,9 +309,9 @@ hidpp10drv_write_button(struct hidpp10_profile *profile,
 		profile->buttons[button->index].button.button = action->action.button;
 		break;
 	case RATBAG_BUTTON_ACTION_TYPE_KEY:
-		code = ratbag_hidraw_get_keyboard_usage_from_keycode(device, action->action.key.key);
+		code = ratbag_hidraw_get_keyboard_usage_from_keycode(device, action->action.key);
 		if (code == 0) {
-			code = ratbag_hidraw_get_consumer_usage_from_keycode(device, action->action.key.key);
+			code = ratbag_hidraw_get_consumer_usage_from_keycode(device, action->action.key);
 			if (code == 0)
 				return -EINVAL;
 

--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -208,12 +208,12 @@ hidpp20drv_read_button_8100(struct ratbag_button *button)
 			break;
 		case HIDPP20_BUTTON_HID_TYPE_KEYBOARD:
 			button->action.type = RATBAG_BUTTON_ACTION_TYPE_KEY;
-			button->action.action.key.key = ratbag_hidraw_get_keycode_from_keyboard_usage(device,
+			button->action.action.key = ratbag_hidraw_get_keycode_from_keyboard_usage(device,
 								profile->buttons[button->index].keyboard_keys.key);
 			break;
 		case HIDPP20_BUTTON_HID_TYPE_CONSUMER_CONTROL:
 			button->action.type = RATBAG_BUTTON_ACTION_TYPE_KEY;
-			button->action.action.key.key = ratbag_hidraw_get_keycode_from_consumer_usage(device,
+			button->action.action.key = ratbag_hidraw_get_keycode_from_consumer_usage(device,
 								profile->buttons[button->index].consumer_control.consumer_control);
 			break;
 		}
@@ -341,10 +341,10 @@ hidpp20drv_update_button_8100(struct ratbag_button *button,
 	case RATBAG_BUTTON_ACTION_TYPE_KEY:
 		type = HIDPP20_BUTTON_HID_TYPE;
 		subtype = HIDPP20_BUTTON_HID_TYPE_KEYBOARD;
-		code = ratbag_hidraw_get_keyboard_usage_from_keycode(device, action->action.key.key);
+		code = ratbag_hidraw_get_keyboard_usage_from_keycode(device, action->action.key);
 		if (code == 0) {
 			subtype = HIDPP20_BUTTON_HID_TYPE_CONSUMER_CONTROL;
-			code = ratbag_hidraw_get_consumer_usage_from_keycode(device, action->action.key.key);
+			code = ratbag_hidraw_get_consumer_usage_from_keycode(device, action->action.key);
 			if (code == 0)
 				return -EINVAL;
 		}

--- a/src/driver-logitech-g300.c
+++ b/src/driver-logitech-g300.c
@@ -336,7 +336,7 @@ logitech_g300_read_button(struct ratbag_button *button)
 		struct ratbag_button_action *key_action = &button->action;
 
 		key_action->type = RATBAG_BUTTON_ACTION_TYPE_KEY;
-		key_action->action.key.key = ratbag_hidraw_get_keycode_from_keyboard_usage(
+		key_action->action.key = ratbag_hidraw_get_keycode_from_keyboard_usage(
 			device, button_report->key);
 	}
 }
@@ -448,7 +448,7 @@ logitech_g300_write_profile(struct ratbag_profile *profile)
 		raw_button->key = 0x00;
 		if (action->type == RATBAG_BUTTON_ACTION_TYPE_KEY) {
 			raw_button->key = ratbag_hidraw_get_keyboard_usage_from_keycode(
-				device, action->action.key.key);
+				device, action->action.key);
 		}
 	}
 

--- a/src/driver-test.c
+++ b/src/driver-test.c
@@ -116,7 +116,7 @@ test_read_button(struct ratbag_button *button)
 		break;
 	case RATBAG_BUTTON_ACTION_TYPE_KEY:
 		button->action.type = RATBAG_BUTTON_ACTION_TYPE_KEY;
-		button->action.action.key.key = p->buttons[button->index].key;
+		button->action.action.key = p->buttons[button->index].key;
 		break;
 	case RATBAG_BUTTON_ACTION_TYPE_MACRO:
 		button->action.type = RATBAG_BUTTON_ACTION_TYPE_MACRO;

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -291,7 +291,7 @@ struct ratbag_profile {
 	.action.special = sp_ }
 #define BUTTON_ACTION_KEY(k_) \
  { .type = RATBAG_BUTTON_ACTION_TYPE_KEY, \
-	.action.key.key = k_ }
+	.action.key = k_ }
 #define BUTTON_ACTION_MACRO \
  { .type = RATBAG_BUTTON_ACTION_TYPE_MACRO, \
 	/* FIXME: add the macro keys */ }
@@ -321,10 +321,7 @@ struct ratbag_button_action {
 	union ratbag_btn_action {
 		unsigned int button; /* action_type == button */
 		enum ratbag_button_action_special special; /* action_type == special */
-		struct {
-			unsigned int key; /* action_type == key */
-			/* FIXME: modifiers */
-		} key;
+		unsigned int key; /* action_type == key */
 	} action;
 	struct ratbag_macro *macro; /* dynamically allocated, so kept aside */
 };
@@ -419,7 +416,7 @@ ratbag_button_action_match(const struct ratbag_button_action *action,
 	case RATBAG_BUTTON_ACTION_TYPE_BUTTON:
 		return match->action.button == action->action.button;
 	case RATBAG_BUTTON_ACTION_TYPE_KEY:
-		return match->action.key.key == action->action.key.key;
+		return match->action.key == action->action.key;
 	case RATBAG_BUTTON_ACTION_TYPE_SPECIAL:
 		return match->action.special == action->action.special;
 	case RATBAG_BUTTON_ACTION_TYPE_MACRO:

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -1306,23 +1306,17 @@ ratbag_button_set_special(struct ratbag_button *button,
 }
 
 LIBRATBAG_EXPORT unsigned int
-ratbag_button_get_key(struct ratbag_button *button,
-		      unsigned int *modifiers,
-		      size_t *sz)
+ratbag_button_get_key(struct ratbag_button *button)
 {
 	if (button->action.type != RATBAG_BUTTON_ACTION_TYPE_KEY)
 		return 0;
 
-	/* FIXME: modifiers */
-	*sz = 0;
-	return button->action.action.key.key;
+	return button->action.action.key;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
 ratbag_button_set_key(struct ratbag_button *button,
-		      unsigned int key,
-		      unsigned int *modifiers,
-		      size_t sz)
+		      unsigned int key)
 {
 	struct ratbag_button_action action = {0};
 
@@ -1332,10 +1326,8 @@ ratbag_button_set_key(struct ratbag_button *button,
 					  RATBAG_DEVICE_CAP_BUTTON_KEY))
 		return RATBAG_ERROR_CAPABILITY;
 
-	/* FIXME: modifiers */
-
 	action.type = RATBAG_BUTTON_ACTION_TYPE_KEY;
-	action.action.key.key = key;
+	action.action.key = key;
 
 	button->action = action;
 	button->dirty = true;

--- a/src/libratbag.h
+++ b/src/libratbag.h
@@ -562,8 +562,7 @@ enum ratbag_device_capability {
 	RATBAG_DEVICE_CAP_BUTTON = 300,
 
 	/**
-	 * The device supports assigning button numbers, key events or key +
-	 * modifier combinations.
+	 * The device supports assigning button numbers or key events
 	 */
 	RATBAG_DEVICE_CAP_BUTTON_KEY,
 
@@ -1298,7 +1297,7 @@ enum ratbag_button_action_type {
 	 */
 	RATBAG_BUTTON_ACTION_TYPE_SPECIAL,
 	/**
-	 * Button sends a key or key + modifier combination
+	 * Button sends a key
 	 */
 	RATBAG_BUTTON_ACTION_TYPE_KEY,
 	/**
@@ -1624,44 +1623,28 @@ ratbag_button_set_special(struct ratbag_button *button,
  * this function returns the key or button configured for this button.
  *
  * If the button's action type is not @ref RATBAG_BUTTON_ACTION_TYPE_KEY,
- * this function returns 0 and leaves modifiers and sz untouched.
+ * this function returns 0.
  *
  * @param button A previously initialized ratbag button
- * @param[out] modifiers Will be filled with the modifiers required for this
- * action. The modifiers are as defined in linux/input.h.
- * @param[in,out] sz Takes the size of the modifiers array and returns the
- * number of modifiers filled in. sz may be 0 if no modifiers are required.
  *
- * @note The caller must ensure that modifiers is large enough to accomodate
- * for the key combination.
- *
- * @return The button number
+ * @return The key code as one of the codes defined in linux/input.h
  */
 unsigned int
-ratbag_button_get_key(struct ratbag_button *button,
-		      unsigned int *modifiers,
-		      size_t *sz);
+ratbag_button_get_key(struct ratbag_button *button);
 
 /**
  * @ingroup button
  *
  * @param button A previously initialized ratbag button
- * @param key The button number to assign to this button, one of BTN_* as
+ * @param key The button number to assign to this button, one of KEY_* as
  * defined in linux/input.h
- * @param modifiers The modifiers required for this action. The
- * modifiers are as defined in linux/input.h, in the order they should be
- * pressed.
- * @param sz The size of the modifiers array. sz may be 0 if no modifiers
- * are required.
  *
  * @return 0 on success or an error code otherwise. On success, the button's
  * action is set to @ref RATBAG_BUTTON_ACTION_TYPE_KEY.
  */
 enum ratbag_error_code
 ratbag_button_set_key(struct ratbag_button *button,
-		      unsigned int key,
-		      unsigned int *modifiers,
-		      size_t sz);
+		      unsigned int key);
 
 /**
  * @ingroup button

--- a/tools/ratbag-command.c
+++ b/tools/ratbag-command.c
@@ -515,8 +515,6 @@ ratbag_cmd_switch_etekcity(const struct ratbag_cmd *cmd,
 	struct ratbag_button *button_6, *button_7;
 	struct ratbag_profile *profile = NULL;
 	int commit = 0;
-	unsigned int modifiers[10];
-	size_t modifiers_sz = 10;
 
 	device = options->device;
 	profile = options->profile;
@@ -531,15 +529,15 @@ ratbag_cmd_switch_etekcity(const struct ratbag_cmd *cmd,
 	button_6 = ratbag_profile_get_button(profile, 6);
 	button_7 = ratbag_profile_get_button(profile, 7);
 
-	if (ratbag_button_get_key(button_6, modifiers, &modifiers_sz) == KEY_VOLUMEUP &&
-	    ratbag_button_get_key(button_7, modifiers, &modifiers_sz) == KEY_VOLUMEDOWN) {
+	if (ratbag_button_get_key(button_6) == KEY_VOLUMEUP &&
+	    ratbag_button_get_key(button_7) == KEY_VOLUMEDOWN) {
 		ratbag_button_disable(button_6);
 		ratbag_button_disable(button_7);
 		commit = 1;
 	} else if (ratbag_button_get_action_type(button_6) == RATBAG_BUTTON_ACTION_TYPE_NONE &&
 		   ratbag_button_get_action_type(button_7) == RATBAG_BUTTON_ACTION_TYPE_NONE) {
-		ratbag_button_set_key(button_6, KEY_VOLUMEUP, modifiers, 0);
-		ratbag_button_set_key(button_7, KEY_VOLUMEDOWN, modifiers, 0);
+		ratbag_button_set_key(button_6, KEY_VOLUMEUP);
+		ratbag_button_set_key(button_7, KEY_VOLUMEDOWN);
 		commit = 2;
 	}
 
@@ -729,7 +727,7 @@ ratbag_cmd_change_button(const struct ratbag_cmd *cmd,
 		rc = ratbag_button_set_button(button, btnkey);
 		break;
 	case RATBAG_BUTTON_ACTION_TYPE_KEY:
-		rc = ratbag_button_set_key(button, btnkey, NULL, 0);
+		rc = ratbag_button_set_key(button, btnkey);
 		break;
 	case RATBAG_BUTTON_ACTION_TYPE_SPECIAL:
 		rc = ratbag_button_set_special(button, special);
@@ -1331,7 +1329,7 @@ ratbag_cmd_button_set_key(const struct ratbag_cmd *cmd,
 		return ERR_UNSUPPORTED;
 
 	button = options->button;
-	rc = ratbag_button_set_key(button, keycode, NULL, 0);
+	rc = ratbag_button_set_key(button, keycode);
 	if (rc != 0)
 		return ERR_DEVICE;
 

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -188,12 +188,8 @@ def print_button(d, p, b, level):
     if b.action_type == RatbagdButton.ACTION_TYPE_BUTTON:
         print("{}'button {}'".format(header, b.mapping))
     elif b.action_type == RatbagdButton.ACTION_TYPE_KEY:
-        bmap = ""
-        for m in b.key:
-            code = evdev.ecodes.KEY.get(m, m)
-            bmap = bmap + "{}".format(code)
-
-        print("{}'{}'".format(header, bmap))
+        code = evdev.ecodes.KEY.get(b.key)
+        print("{}'key {}'".format(header, code))
     elif b.action_type == RatbagdButton.ACTION_TYPE_SPECIAL:
         print("{}'{}'".format(header, button_specials_strmap[b.special]))
     elif b.action_type == RatbagdButton.ACTION_TYPE_MACRO:

--- a/tools/ratbagctl.test.in
+++ b/tools/ratbagctl.test.in
@@ -386,7 +386,7 @@ class TestRatbagCtlButton(TestRatbagCtl):
         r = self.launch_good_test("button 0 get test_device")
         self.assertEqual(r, "Button: 0 type left is mapped to 'button 0'")
         r = self.launch_good_test("button 1 get test_device")
-        self.assertEqual(r, "Button: 1 type middle is mapped to 'KEY_3'")
+        self.assertEqual(r, "Button: 1 type middle is mapped to 'key KEY_3'")
         r = self.launch_good_test("button 2 get test_device")
         self.assertEqual(r, "Button: 2 type right is mapped to 'profile-cycle-up'")
         r = self.launch_good_test("button 3 get test_device")

--- a/tools/shared.c
+++ b/tools/shared.c
@@ -197,10 +197,8 @@ char *
 button_action_key_to_str(struct ratbag_button *button)
 {
 	const char *str;
-	unsigned int modifiers[10];
-	size_t m_size = 10;
 
-	str = libevdev_event_code_get_name(EV_KEY, ratbag_button_get_key(button, modifiers, &m_size));
+	str = libevdev_event_code_get_name(EV_KEY, ratbag_button_get_key(button));
 	if (!str)
 		str = "UNKNOWN";
 


### PR DESCRIPTION
Originally I thought we could transparently wrap this in macros inside libratbag, but that's a bit more work. So meanwhile, let's just drop the modifiers so we're at least a step closer to sanity.

I'm not 100% sure anymore whether we should really map this to macros, it seems that the keys have quite a fair bit of limitation (i.e. what key can be mapped) which macros don't have, so maybe keeping it separate is better here.