### PR TITLE
Don't install ratbag-command manpage

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -212,7 +212,7 @@ man_ratbag_command = configure_file (
 	input: 'tools/ratbag-command.man',
 	output: 'ratbag-command.1',
 	configuration: man_config,
-	install : true,
+	install : false,
 	install_dir : join_paths(get_option('mandir'), 'man1')
 )
 


### PR DESCRIPTION
Since we no longer install ratbag-command itself, there isn't much
point installing its manpage.

Signed-off-by: Stephen Kitt <steve@sk2.org>