### PR TITLE
fix commit() when using ratbagctl.devel

### DIFF
--- a/tools/merge_ratbagd.py
+++ b/tools/merge_ratbagd.py
@@ -55,7 +55,7 @@ def main(argv):
     if ns.output:
         ns.output_file = open(ns.output, 'w')
         st = os.stat(ns.output)
-        os.chmod(ns.output, st.st_mode | stat.S_IEXEC)
+        os.chmod(ns.output, st.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
         sys.stdout = ns.output_file
     print_ratbagctl(ns.ratbagctl, ns.ratbagd, ns.version)
     try:

--- a/tools/ratbagctl.devel.in
+++ b/tools/ratbagctl.devel.in
@@ -26,6 +26,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 import os
+import time
 import toolbox
 import signal
 import sys
@@ -60,6 +61,9 @@ def main(argv):
                 return
             else:
                 f(ratbagd, cmd)
+                # give time for ratbagd to receive async requests before
+                # we try to terminate it
+                time.sleep(0.5)
     finally:
         try:
             if cmd.keepalive:


### PR DESCRIPTION
Initially I thought both ratbagctl and .devel where affected, but it turns out we are just trying to kill ratbagd too soon in ratbagctl.devel. This appeared when we switched to async commits in ratbagd.py.

Adding also a commit that fixes permissions for rabtagctl on my setup (Fedora 26).