### PR TITLE
ratbagd: Drop KeyMapping from the DBus interface

### DIFF
--- a/DBusInterface.md
+++ b/DBusInterface.md
@@ -237,11 +237,6 @@ uint of the current button mapping (if mapping to button)
 - type: `u`, read-write, mutable
 
 Enum describing the current special mapping (if mapped to special)
-#### `KeyMapping`
-- type: `au`, read-write, mutable
-
-Array of uints, first entry is the keycode, other entries, if any, are
-modifiers (if mapped to key)
 #### `Macro`
 -type: `a(uu)`, read-write, mutable
 

--- a/ratbagd/ratbagd-button.c
+++ b/ratbagd/ratbagd-button.c
@@ -167,103 +167,6 @@ static int ratbagd_button_set_special(sd_bus *bus,
 	return r;
 }
 
-static int ratbagd_button_get_key(sd_bus *bus,
-				  const char *path,
-				  const char *interface,
-				  const char *property,
-				  sd_bus_message *reply,
-				  void *userdata,
-				  sd_bus_error *error)
-{
-	struct ratbagd_button *button = userdata;
-	unsigned int key;
-	unsigned int modifiers[10] = {0};
-	size_t nmodifiers = ELEMENTSOF(modifiers);
-	size_t i;
-	int r;
-
-	/* Return an array with the first element the key, the rest
-	   are modifiers (or 0 if unset). If no key is set, the array is
-	   just [0] */
-
-	r = sd_bus_message_open_container(reply, 'a', "u");
-	if (r < 0)
-		return r;
-
-	key = ratbag_button_get_key(button->lib_button,
-				    modifiers,
-				    &nmodifiers);
-
-	r = sd_bus_message_append(reply, "u", key);
-	if (r < 0)
-		return r;
-
-	if (key == 0)
-		nmodifiers = 0;
-
-	for (i = 0; i < nmodifiers; i++) {
-		r = sd_bus_message_append(reply, "u", modifiers[0]);
-		if (r < 0)
-			return r;
-	}
-
-	return sd_bus_message_close_container(reply);
-}
-
-static int ratbagd_button_set_key(sd_bus *bus,
-				  const char *path,
-				  const char *interface,
-				  const char *property,
-				  sd_bus_message *m,
-				  void *userdata,
-				  sd_bus_error *error)
-{
-	struct ratbagd_button *button = userdata;
-	unsigned int key;
-	size_t nmodifiers = 10;
-	unsigned int modifiers[nmodifiers];
-	int r;
-
-	/* Expect an array with the first element the key, the rest
-	   are modifiers (or 0 if unset). */
-
-	r = sd_bus_message_enter_container(m, 'a', "u");
-	if (r < 0)
-		return r;
-
-	r = sd_bus_message_read(m, "u", &key);
-	if (r < 0)
-		return r;
-
-	nmodifiers = 0;
-	while ((r = sd_bus_message_read_basic(m, 'u',
-					      &modifiers[nmodifiers++])) > 0)
-		;
-
-	r = sd_bus_message_exit_container(m);
-	if (r < 0)
-		return r;
-
-	r = ratbag_button_set_key(button->lib_button, key, modifiers, nmodifiers);
-
-	if (r == 0) {
-		sd_bus *bus = sd_bus_message_get_bus(m);
-		sd_bus_emit_properties_changed(bus,
-					       button->path,
-					       RATBAGD_NAME_ROOT ".Button",
-					       "KeyMapping",
-					       NULL);
-
-		sd_bus_emit_properties_changed(bus,
-					       button->path,
-					       RATBAGD_NAME_ROOT ".Button",
-					       "ActionType",
-					       NULL);
-	}
-
-	return r;
-}
-
 DEFINE_TRIVIAL_CLEANUP_FUNC(struct ratbag_button_macro *, ratbag_button_macro_unref);
 
 static int ratbagd_button_get_macro(sd_bus *bus,
@@ -382,6 +285,8 @@ static int ratbagd_button_get_action_type(sd_bus *bus,
 	enum ratbag_button_action_type type;
 
 	type = ratbag_button_get_action_type(button->lib_button);
+	if (type == RATBAG_BUTTON_ACTION_TYPE_KEY)
+		type = RATBAG_BUTTON_ACTION_TYPE_UNKNOWN;
 
 	return sd_bus_message_append(reply, "u", type);
 }
@@ -399,7 +304,6 @@ static int ratbagd_button_get_action_types(sd_bus *bus,
 	enum ratbag_button_action_type types[] = {
 		RATBAG_BUTTON_ACTION_TYPE_BUTTON,
 		RATBAG_BUTTON_ACTION_TYPE_SPECIAL,
-		RATBAG_BUTTON_ACTION_TYPE_KEY,
 		RATBAG_BUTTON_ACTION_TYPE_MACRO
 	};
 	enum ratbag_button_action_type *t;
@@ -448,10 +352,6 @@ const sd_bus_vtable ratbagd_button_vtable[] = {
 	SD_BUS_WRITABLE_PROPERTY("SpecialMapping", "u",
 				 ratbagd_button_get_special,
 				 ratbagd_button_set_special,
-				 0, SD_BUS_VTABLE_UNPRIVILEGED | SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
-	SD_BUS_WRITABLE_PROPERTY("KeyMapping", "au",
-				 ratbagd_button_get_key,
-				 ratbagd_button_set_key,
 				 0, SD_BUS_VTABLE_UNPRIVILEGED | SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_WRITABLE_PROPERTY("Macro", "a(uu)",
 				 ratbagd_button_get_macro,

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -187,13 +187,6 @@ def print_button(d, p, b, level):
 
     if b.action_type == RatbagdButton.ACTION_TYPE_BUTTON:
         print("{}'button {}'".format(header, b.mapping))
-    elif b.action_type == RatbagdButton.ACTION_TYPE_KEY:
-        bmap = ""
-        for m in b.key:
-            code = evdev.ecodes.KEY.get(m, m)
-            bmap = bmap + "{}".format(code)
-
-        print("{}'{}'".format(header, bmap))
     elif b.action_type == RatbagdButton.ACTION_TYPE_SPECIAL:
         print("{}'{}'".format(header, button_specials_strmap[b.special]))
     elif b.action_type == RatbagdButton.ACTION_TYPE_MACRO:

--- a/tools/ratbagctl.test.in
+++ b/tools/ratbagctl.test.in
@@ -386,7 +386,7 @@ class TestRatbagCtlButton(TestRatbagCtl):
         r = self.launch_good_test("button 0 get test_device")
         self.assertEqual(r, "Button: 0 type left is mapped to 'button 0'")
         r = self.launch_good_test("button 1 get test_device")
-        self.assertEqual(r, "Button: 1 type middle is mapped to 'KEY_3'")
+        self.assertEqual(r, "Button: 1 type middle is mapped to UNKNOWN")
         r = self.launch_good_test("button 2 get test_device")
         self.assertEqual(r, "Button: 2 type right is mapped to 'profile-cycle-up'")
         r = self.launch_good_test("button 3 get test_device")

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -621,7 +621,6 @@ class RatbagdButton(_RatbagdDBus):
     ACTION_TYPE_NONE = 0
     ACTION_TYPE_BUTTON = 1
     ACTION_TYPE_SPECIAL = 2
-    ACTION_TYPE_KEY = 3
     ACTION_TYPE_MACRO = 4
 
     ACTION_SPECIAL_UNKNOWN = (1 << 30)
@@ -783,7 +782,7 @@ class RatbagdButton(_RatbagdDBus):
     def action_type(self):
         """An enum describing the action type of the button. One of
         ACTION_TYPE_NONE, ACTION_TYPE_BUTTON, ACTION_TYPE_SPECIAL,
-        ACTION_TYPE_KEY, ACTION_TYPE_MACRO. This decides which
+        ACTION_TYPE_MACRO. This decides which
         *Mapping property has a value.
         """
         return self._get_dbus_property("ActionType")


### PR DESCRIPTION
Plan is to remove the key mapping altogether and make it transparent from the
Macro mappings (in libratbag/the drivers). Meanwhile, remove the DBus API so
nothing can actually start using it.

This replaces #322 