### PR TITLE
hidpp20 memory rework

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -234,6 +234,15 @@ executable('hidpp20-dump-page',
 	install : false,
 )
 
+#### hidpp20-reset ####
+src_hidpp20_reset = [ 'tools/hidpp20-reset.c' ]
+executable('hidpp20-reset',
+	src_hidpp20_reset,
+	dependencies : [ dep_libhidpp ],
+	include_directories : include_directories('src'),
+	install : false,
+)
+
 #### lur-command ####
 src_lur_command = [ 'tools/lur-command.c' ]
 executable('lur-command',

--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -684,22 +684,6 @@ hidpp20drv_read_color_leds(struct ratbag_device *device)
 	return rc;
 }
 
-static int
-hidpp20drv_read_onboard_profile(struct ratbag_device *device, unsigned index)
-{
-	struct hidpp20drv_data *drv_data = ratbag_get_drv_data(device);
-	int rc;
-
-	if (!(drv_data->capabilities & HIDPP_CAP_ONBOARD_PROFILES_8100))
-		return 0;
-
-	rc = hidpp20_onboard_profiles_read(drv_data->dev, index, drv_data->profiles);
-	if (rc < 0)
-		return rc;
-
-	return 0;
-}
-
 static void
 hidpp20drv_read_profile_8100(struct ratbag_profile *profile, unsigned int index)
 {
@@ -711,8 +695,6 @@ hidpp20drv_read_profile_8100(struct ratbag_profile *profile, unsigned int index)
 	int dpi_index = 0xff;
 
 	profile->is_enabled = drv_data->profiles->profiles[index].enabled;
-
-	hidpp20drv_read_onboard_profile(device, profile->index);
 
 	profile->is_active = false;
 	if ((int)index == hidpp20drv_current_profile(device))

--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -867,6 +867,10 @@ hidpp20drv_init_feature(struct ratbag_device *device, uint16_t feature)
 		if (rc < 0)
 			return rc;
 
+		rc = hidpp20_onboard_profiles_initialize(drv_data->dev, drv_data->profiles);
+		if (rc < 0)
+			return rc;
+
 		drv_data->num_profiles = drv_data->profiles->num_profiles;
 		drv_data->num_resolutions = drv_data->profiles->num_modes;
 		drv_data->num_buttons = drv_data->profiles->num_buttons;

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -1473,7 +1473,7 @@ hidpp20_onboard_profiles_allocate(struct hidpp20_device *device,
 
 	profiles->num_profiles = info.profile_count;
 	profiles->num_rom_profiles = info.profile_count_oob;
-	profiles->num_buttons = info.button_count <= 16 ? info.button_count : 16;
+	profiles->num_buttons = min(info.button_count, 16);
 	profiles->num_modes = HIDPP20_DPI_COUNT;
 	profiles->num_leds = HIDPP20_LED_COUNT;
 	profiles->has_g_shift = (info.mechanical_layout & 0x03) == 2;

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -339,7 +339,7 @@ hidpp20_feature_set_get(struct hidpp20_device *device)
 	if (!feature_count)
 		return -ENOTSUP;
 
-	flist = zalloc(feature_count * sizeof(struct hidpp20_feature));
+	flist = zalloc((feature_count + 1) * sizeof(struct hidpp20_feature));
 
 	/* feature set count does not include the root feature as documented here:
 	 * https://6xq.net/git/lars/lshidpp.git/plain/doc/logitech_hidpp_2.0_specification_draft_2012-06-04.pdf

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -1132,6 +1132,12 @@ hidpp20_onboard_profiles_read_sector(struct hidpp20_device *device,
 	count = sector_size;
 
 	for (offset = 0; offset < sector_size; offset += 16) {
+		/*
+		 * the firmware replies with an ERR_INVALID_ARGUMENT error
+		 * if we try to read past sector_size - 16, so when we are left with
+		 * less than 16 bytes to read we need to read from sector_size - 16
+		 */
+		offset = (sector_size - offset < 16) ? sector_size - 16 : offset;
 		hidpp_set_unaligned_be_u16(&msg.msg.parameters[2], offset);
 		buf = msg;
 		rc = hidpp20_request_command(device, &buf);

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -1476,8 +1476,8 @@ hidpp20_onboard_profiles_allocate(struct hidpp20_device *device,
 	profiles->num_buttons = min(info.button_count, 16);
 	profiles->num_modes = HIDPP20_DPI_COUNT;
 	profiles->num_leds = HIDPP20_LED_COUNT;
-	profiles->has_g_shift = (info.mechanical_layout & 0x03) == 2;
-	profiles->has_dpi_shift = ((info.mechanical_layout & 0x0c) >> 2) == 2;
+	profiles->has_g_shift = (info.mechanical_layout & 0x03) == 0x02;
+	profiles->has_dpi_shift = ((info.mechanical_layout & 0x0c) >> 2) == 0x02;
 	switch(info.various_info & 0x07) {
 	case 1:
 		profiles->corded = 1;

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -1696,35 +1696,6 @@ hidpp20_onboard_profiles_compute_dict_size(const struct hidpp20_device *device,
 	return num_offset;
 }
 
-int
-hidpp20_onboard_profiles_initialize(struct hidpp20_device *device,
-				    struct hidpp20_profiles *profiles)
-{
-	unsigned i;
-	int rc;
-	_cleanup_free_ uint8_t *data = NULL;
-
-	assert(profiles);
-
-	data = hidpp20_onboard_profiles_allocate_sector(profiles);
-
-	rc = hidpp20_onboard_profiles_read_sector(device, 0, profiles->sector_size, data);
-	if (rc < 0)
-		return rc;
-
-	for (i = 0; i < profiles->num_profiles; i++) {
-		uint8_t *d = data + 4 * i;
-
-		if (d[0] == 0xFF && d[1] == 0xFF)
-			break;
-
-		profiles->profiles[i].index = d[1];
-		profiles->profiles[i].enabled = !!d[2];
-	}
-
-	return profiles->num_profiles;
-}
-
 void
 hidpp20_onboard_profiles_destroy(struct hidpp20_profiles *profiles_list)
 {
@@ -2020,6 +1991,35 @@ int hidpp20_onboard_profiles_read(struct hidpp20_device *device,
 		memset(profile->name, 0, sizeof(profile->name));
 
 	return 0;
+}
+
+int
+hidpp20_onboard_profiles_initialize(struct hidpp20_device *device,
+				    struct hidpp20_profiles *profiles)
+{
+	unsigned i;
+	int rc;
+	_cleanup_free_ uint8_t *data = NULL;
+
+	assert(profiles);
+
+	data = hidpp20_onboard_profiles_allocate_sector(profiles);
+
+	rc = hidpp20_onboard_profiles_read_sector(device, 0, profiles->sector_size, data);
+	if (rc < 0)
+		return rc;
+
+	for (i = 0; i < profiles->num_profiles; i++) {
+		uint8_t *d = data + 4 * i;
+
+		if (d[0] == 0xFF && d[1] == 0xFF)
+			break;
+
+		profiles->profiles[i].index = d[1];
+		profiles->profiles[i].enabled = !!d[2];
+	}
+
+	return profiles->num_profiles;
 }
 
 static void

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -1051,6 +1051,30 @@ int hidpp20_adjustable_dpi_set_sensor_dpi(struct hidpp20_device *device,
 #define HIDPP20_ONBOARD_PROFILES_PROFILE_TYPE_G900	0x03
 #define HIDPP20_ONBOARD_PROFILES_MACRO_TYPE_G402	0x01
 
+union hidpp20_internal_profile {
+	uint8_t data[HIDPP20_PROFILE_SIZE];
+	struct {
+		uint8_t report_rate;
+		uint8_t default_dpi;
+		uint8_t switched_dpi;
+		uint16_t dpi[5];
+		struct hidpp20_color profile_color;
+		uint8_t power_mode;
+		uint8_t angle_snapping;
+		uint8_t reserved[14];
+		union hidpp20_button_binding buttons[16];
+		union hidpp20_button_binding alternate_buttons[16];
+		union {
+			char txt[16 * 3];
+			uint8_t raw[16 * 3];
+		} name;
+		struct hidpp20_internal_led leds[2]; /* G303, g502, g900 only */
+		uint8_t free[24];
+		uint16_t crc;
+	} __attribute__((packed)) profile;
+};
+_Static_assert(sizeof(union hidpp20_internal_profile) == HIDPP20_PROFILE_SIZE, "Invalid size");
+
 int
 hidpp20_onboard_profiles_get_profiles_desc(struct hidpp20_device *device,
 					   struct hidpp20_onboard_profiles_info *info)
@@ -1803,30 +1827,6 @@ hidpp20_onboard_profiles_set_enable_profile(struct hidpp20_device *device,
 						   data);
 	return rc;
 }
-
-union hidpp20_internal_profile {
-	uint8_t data[HIDPP20_PROFILE_SIZE];
-	struct {
-		uint8_t report_rate;
-		uint8_t default_dpi;
-		uint8_t switched_dpi;
-		uint16_t dpi[5];
-		struct hidpp20_color profile_color;
-		uint8_t power_mode;
-		uint8_t angle_snapping;
-		uint8_t reserved[14];
-		union hidpp20_button_binding buttons[16];
-		union hidpp20_button_binding alternate_buttons[16];
-		union {
-			char txt[16 * 3];
-			uint8_t raw[16 * 3];
-		} name;
-		struct hidpp20_internal_led leds[2]; /* G303, g502, g900 only */
-		uint8_t free[24];
-		uint16_t crc;
-	} __attribute__((packed)) profile;
-};
-_Static_assert(sizeof(union hidpp20_internal_profile) == HIDPP20_PROFILE_SIZE, "Invalid size");
 
 static void
 hidpp20_buttons_to_cpu(struct hidpp20_device *device,

--- a/src/hidpp20.h
+++ b/src/hidpp20.h
@@ -592,6 +592,13 @@ hidpp20_onboard_profiles_read_sector(struct hidpp20_device *device,
 				     uint16_t sector_size,
 				     uint8_t *data);
 
+int
+hidpp20_onboard_profiles_write_sector(struct hidpp20_device *device,
+				      uint16_t sector,
+				      uint16_t sector_size,
+				      uint8_t *data,
+				      bool write_crc);
+
 static inline uint8_t *
 hidpp20_onboard_profiles_allocate_sector(struct hidpp20_profiles *profiles)
 {

--- a/src/hidpp20.h
+++ b/src/hidpp20.h
@@ -573,16 +573,6 @@ int
 hidpp20_onboard_profiles_set_current_dpi_index(struct hidpp20_device *device,
 					       uint8_t index);
 
-/**
- * parse a given profile from the mouse and fill in the right profile in
- * profiles_list.
- *
- * return 0 or a negative error.
- */
-int hidpp20_onboard_profiles_read(struct hidpp20_device *device,
-				  unsigned int index,
-				  struct hidpp20_profiles *profiles_list);
-
 int hidpp20_onboard_profiles_write(struct hidpp20_device *device,
 				   unsigned int index,
 				   struct hidpp20_profiles *profiles_list);

--- a/src/hidpp20.h
+++ b/src/hidpp20.h
@@ -479,6 +479,21 @@ struct hidpp20_profile {
 	struct hidpp20_led leds[HIDPP20_LED_COUNT];
 };
 
+struct hidpp20_onboard_profiles_info {
+	uint8_t memory_model_id;
+	uint8_t profile_format_id;
+	uint8_t macro_format_id;
+	uint8_t profile_count;
+	uint8_t profile_count_oob;
+	uint8_t button_count;
+	uint8_t sector_count;
+	uint16_t sector_size;
+	uint8_t mechanical_layout;
+	uint8_t various_info;
+	uint8_t reserved[5];
+} __attribute__((packed));
+_Static_assert(sizeof(struct hidpp20_onboard_profiles_info) == 16, "Invalid size");
+
 struct hidpp20_profiles {
 	uint8_t num_profiles;
 	uint8_t num_rom_profiles;
@@ -489,8 +504,19 @@ struct hidpp20_profiles {
 	uint8_t has_dpi_shift;
 	uint8_t corded;
 	uint8_t wireless;
+	uint8_t sector_count;
+	uint16_t sector_size;
 	struct hidpp20_profile profiles[0];
 };
+
+/**
+ * fetches the profiles description as reported by the mouse.
+ *
+ * returns 0 or a negative error.
+ */
+int
+hidpp20_onboard_profiles_get_profiles_desc(struct hidpp20_device *device,
+					   struct hidpp20_onboard_profiles_info *info);
 
 /**
  * allocates a list of profiles that has to be destroyed by the caller.
@@ -506,6 +532,14 @@ int hidpp20_onboard_profiles_allocate(struct hidpp20_device *device,
  */
 void
 hidpp20_onboard_profiles_destroy(struct hidpp20_profiles *profiles_list);
+
+/**
+ * initialize a struct hidpp20_profiles previous allocated with
+ * hidpp20_onboard_profiles_allocate().
+ */
+int
+hidpp20_onboard_profiles_initialize(struct hidpp20_device *device,
+				    struct hidpp20_profiles *profiles);
 
 /**
  * return the current profile index or a negative error.

--- a/src/hidpp20.h
+++ b/src/hidpp20.h
@@ -31,6 +31,7 @@
 #include <stdint.h>
 
 #include "hidpp-generic.h"
+#include "libratbag-util.h"
 
 struct _hidpp20_message {
 	uint8_t report_id;
@@ -506,7 +507,7 @@ struct hidpp20_profiles {
 	uint8_t wireless;
 	uint8_t sector_count;
 	uint16_t sector_size;
-	struct hidpp20_profile profiles[0];
+	struct hidpp20_profile *profiles;
 };
 
 /**
@@ -593,11 +594,16 @@ uint8_t
 hidpp20_onboard_profiles_get_code_from_special(enum ratbag_button_action_special special);
 
 int
-hidpp20_onboard_profiles_read_memory(struct hidpp20_device *device,
-				     uint8_t read_rom,
-				     uint8_t page,
-				     uint16_t section,
-				     uint8_t result[16]);
+hidpp20_onboard_profiles_read_sector(struct hidpp20_device *device,
+				     uint16_t sector,
+				     uint16_t sector_size,
+				     uint8_t *data);
+
+static inline uint8_t *
+hidpp20_onboard_profiles_allocate_sector(struct hidpp20_profiles *profiles)
+{
+	return zalloc(profiles->sector_size);
+}
 
 /* -------------------------------------------------------------------------- */
 /* 0x8110 - Mouse Button Spy                                                  */

--- a/src/hidpp20.h
+++ b/src/hidpp20.h
@@ -573,9 +573,12 @@ int
 hidpp20_onboard_profiles_set_current_dpi_index(struct hidpp20_device *device,
 					       uint8_t index);
 
-int hidpp20_onboard_profiles_write(struct hidpp20_device *device,
-				   unsigned int index,
-				   struct hidpp20_profiles *profiles_list);
+/**
+ * Write the internal state of the device onto the FLASH.
+ */
+int
+hidpp20_onboard_profiles_commit(struct hidpp20_device *device,
+				struct hidpp20_profiles *profiles_list);
 
 enum ratbag_button_action_special
 hidpp20_onboard_profiles_get_special(uint8_t code);

--- a/src/hidpp20.h
+++ b/src/hidpp20.h
@@ -467,7 +467,7 @@ union hidpp20_macro_data {
 _Static_assert(sizeof(union hidpp20_macro_data) == 3, "Invalid size");
 
 struct hidpp20_profile {
-	uint8_t index;
+	uint16_t address;
 	uint8_t enabled;
 	char name[16 * 3];
 	unsigned report_rate;

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -50,9 +50,23 @@ cleanup_resolution(struct ratbag_resolution **r)
 	ratbag_resolution_unref(*r);
 }
 
+static inline void
+cleanup_button(struct ratbag_button **b)
+{
+	ratbag_button_unref(*b);
+}
+
+static inline void
+cleanup_led(struct ratbag_led **l)
+{
+	ratbag_led_unref(*l);
+}
+
 #define _cleanup_device_ _cleanup_(cleanup_device)
 #define _cleanup_profile_ _cleanup_(cleanup_profile)
 #define _cleanup_resolution_ _cleanup_(cleanup_resolution)
+#define _cleanup_button_ _cleanup_(cleanup_button)
+#define _cleanup_led_ _cleanup_(cleanup_led)
 
 #define BUS_ANY					0xffff
 #define VENDOR_ANY				0xffff

--- a/tools/hidpp20-reset.c
+++ b/tools/hidpp20-reset.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2017 Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include <config.h>
+#include <errno.h>
+#include <error.h>
+#include <fcntl.h>
+
+#include <hidpp20.h>
+#include <libratbag-util.h>
+
+static inline int
+reset_sector(struct hidpp20_device *dev, uint16_t sector_size,  uint16_t sector)
+{
+	int rc = 0;
+	_cleanup_free_ uint8_t *data = NULL;
+
+	data = zalloc(sector_size);
+
+	/* this returns error 4: hardware error and is expected */
+	rc = hidpp20_onboard_profiles_write_sector(dev, sector, sector_size, data, false);
+	if (rc == 4)
+		rc = 0;
+
+	return rc;
+}
+
+static int
+reset_all_sectors(struct hidpp20_device *dev, uint16_t sector_size)
+{
+	uint8_t sector;
+	int rc = 0;
+
+	for (sector = 1; sector < 31; sector++) {
+		rc = reset_sector(dev, sector_size, sector);
+		if (rc != 0)
+			break;
+	}
+
+	if (!rc)
+		rc = reset_sector(dev, sector_size, 0);
+
+	return rc;
+}
+
+static void
+usage(void)
+{
+	printf("Usage: %s [sector] /dev/hidraw0\n", program_invocation_short_name);
+}
+
+int
+main(int argc, char **argv)
+{
+	_cleanup_close_ int fd = -1;
+	const char *path;
+	size_t sector = 0;
+	struct hidpp20_device *dev = NULL;
+	struct hidpp_device base;
+	struct hidpp20_onboard_profiles_info info = { 0 };
+	int rc;
+
+	if (argc < 2 || argc > 3) {
+		usage();
+		return 1;
+	}
+
+	path = argv[argc - 1];
+	fd = open(path, O_RDWR);
+	if (fd < 0)
+		error(1, errno, "Failed to open path %s", path);
+
+	hidpp_device_init(&base, fd);
+	dev = hidpp20_device_new(&base, 0xff);
+	if (!dev)
+		error(1, 0, "Failed to open %s as a HID++ 2.0 device", path);
+
+	hidpp20_onboard_profiles_get_profiles_desc(dev, &info);
+
+	if (argc == 2)
+		rc = reset_all_sectors(dev, info.sector_size);
+	else {
+		sector = atoi(argv[1]);
+		rc = reset_sector(dev, info.sector_size, sector);
+	}
+
+	hidpp20_device_destroy(dev);
+
+	return rc;
+}

--- a/tools/ratbag-command.c
+++ b/tools/ratbag-command.c
@@ -441,8 +441,10 @@ ratbag_cmd_info(const struct ratbag_cmd *cmd,
 		printf("  Profile %d (%s)%s\n", i,
 		       ratbag_profile_is_enabled(profile) ? "enabled" : "disabled",
 		       ratbag_profile_is_active(profile) ? " (active)" : "");
-		if (!ratbag_profile_is_enabled(profile))
+		if (!ratbag_profile_is_enabled(profile)) {
+			ratbag_profile_unref(profile);
 			continue;
+		}
 
 		printf("    Resolutions:\n");
 


### PR DESCRIPTION
Fixes both #280 and #122 (hopefully).

This is the first step required before we are finally able to write macros on the device.
The "new" memory API only allows full sectors to be read/written. This ensures we always write the crc and check for it.

Also, now we better detect if the device is using factory profiles or not (see #280).

I still haven't yet implemented caching for the memory. This will be required for macros and to speed up a little bit the parsing of the device.

Please test!

Note: I also quickly wrote a tool to reset the memory to 0x00. This is hopefully the factory default (can't remember if this is true or not).