### PR TITLE
make sure we check for ratbagd_process returncode

### DIFF
--- a/tools/ratbagctl.devel.in
+++ b/tools/ratbagctl.devel.in
@@ -56,6 +56,13 @@ def main(argv):
 
         ratbagd = toolbox.open_ratbagd()
 
+        # if some old version of ratbagd is still running, ratbagd_process may
+        # have never started but our DBus bindings may succeed. Check for the
+        # return code here, this also gives ratbagd enough time to start and
+        # die. If we check immediately we may not have terminated yet.
+        ratbagd_process.poll()
+        assert ratbagd_process.returncode is None
+
         try:
             f = cmd.func
         except AttributeError:

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -1438,7 +1438,7 @@ def get_parser():
     return RatbagParserRoot(parser_def)
 
 
-def open_ratbagd(ratbagd_process=None):
+def open_ratbagd():
     try:
         r = Ratbagd()
     except RatbagdDBusUnavailable:
@@ -1448,14 +1448,6 @@ def open_ratbagd(ratbagd_process=None):
         if not r.devices:
             print("No devices available.")
         return r
-
-    if ratbagd_process is not None:
-        # if some old version of ratbagd is still running, ratbagd_process may
-        # have never started but our DBus bindings may succeed. Check for the
-        # return code here, this also gives ratbagd enough time to start and
-        # die. If we check immediately we may not have terminated yet.
-        ratbagd_process.poll()
-        assert ratbagd_process.returncode is None
 
 
 def main(argv):

--- a/tools/ratbagctl.test.in
+++ b/tools/ratbagctl.test.in
@@ -564,8 +564,15 @@ def setUpModule():
 
     ratbagd_process = toolbox.start_ratbagd()
 
-    ratbagd = toolbox.open_ratbagd(ratbagd_process)
+    ratbagd = toolbox.open_ratbagd()
     assert ratbagd is not None
+
+    # if some old version of ratbagd is still running, ratbagd_process may
+    # have never started but our DBus bindings may succeed. Check for the
+    # return code here, this also gives ratbagd enough time to start and
+    # die. If we check immediately we may not have terminated yet.
+    ratbagd_process.poll()
+    assert ratbagd_process.returncode is None
 
     parser = toolbox.get_parser()
 


### PR DESCRIPTION
It was accidentally put as a dead code in 6cfca9e34b5.

This can't go pass the last return:
```
try:
  foo
except:
  return None
else:
  return foo
```
It is also verified by the fact that there is no return at the end of the function, while we were expecting an object.

It's 2 lines of code, so we can just have them duplicated.