### PR TITLE
G300: fix writing multiple profiles

### DIFF
--- a/src/driver-logitech-g300.c
+++ b/src/driver-logitech-g300.c
@@ -480,7 +480,13 @@ logitech_g300_write_profile(struct ratbag_profile *profile)
 				       HID_FEATURE_REPORT,
 				       HID_REQ_SET_REPORT);
 
-	return rc;
+	if (rc < (signed)sizeof(*report)) {
+		log_error(device->ratbag,
+			  "Error while writing profile: %d\n", rc);
+		return rc;
+	}
+
+	return 0;
 }
 
 static int

--- a/src/driver-logitech-g300.c
+++ b/src/driver-logitech-g300.c
@@ -313,7 +313,7 @@ logitech_g300_read_profile(struct ratbag_profile *profile, unsigned int index)
 					       HID_FEATURE_REPORT,
 					       HID_REQ_GET_REPORT);
 
-	if (rc < (signed)sizeof(*report)) {
+	if (rc < (int)sizeof(*report)) {
 		log_error(device->ratbag,
 			  "Error while requesting profile: %d\n", rc);
 		return;
@@ -480,7 +480,7 @@ logitech_g300_write_profile(struct ratbag_profile *profile)
 				       HID_FEATURE_REPORT,
 				       HID_REQ_SET_REPORT);
 
-	if (rc < (signed)sizeof(*report)) {
+	if (rc < (int)sizeof(*report)) {
 		log_error(device->ratbag,
 			  "Error while writing profile: %d\n", rc);
 		return rc;


### PR DESCRIPTION
Writing multiple changed profiles was broken as we would exit the
loop after the first profile write. We were returning the number
of bytes written and this was interpreted as an error.

Fix it my returning 0 when we have written the correct number of
bytes to the mouse.