### PR TITLE
Add a ratbag_dispatch() method to allow hooking into a mainloop

### DIFF
--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -79,8 +79,20 @@ struct ratbag_test_device;
 struct ratbag_driver;
 struct ratbag_button_action;
 
+typedef void (*ratbag_source_dispatch_t)(void *data);
+
+struct ratbag_source {
+	struct list link;
+	ratbag_source_dispatch_t dispatch;
+	void *userdata;
+	int fd;
+};
+
 struct ratbag {
 	const struct ratbag_interface *interface;
+	int epoll_fd;
+	struct list source_destroy_list;
+
 	void *userdata;
 
 	struct udev *udev;
@@ -538,3 +550,12 @@ void
 ratbag_button_copy_macro(struct ratbag_button *button,
 			 const struct ratbag_button_macro *macro);
 
+struct ratbag_source *
+ratbag_add_source(struct ratbag *ratbag,
+		  int fd,
+		  ratbag_source_dispatch_t dispatch,
+		  void *userdata);
+
+void
+ratbag_remove_source(struct ratbag *ratbag,
+		     struct ratbag_source *source);

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -24,6 +24,7 @@
 #include "config.h"
 #include <assert.h>
 #include <errno.h>
+#include <sys/epoll.h>
 #include <libudev.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -516,21 +517,29 @@ ratbag_create_context(const struct ratbag_interface *interface,
 		      void *userdata)
 {
 	struct ratbag *ratbag;
+	int epoll_fd;
 
 	assert(interface != NULL);
 	assert(interface->open_restricted != NULL);
 	assert(interface->close_restricted != NULL);
 
+	epoll_fd = epoll_create1(EPOLL_CLOEXEC);
+	if (epoll_fd < 0)
+		return NULL;
+
 	ratbag = zalloc(sizeof(*ratbag));
 	ratbag->refcount = 1;
 	ratbag->interface = interface;
 	ratbag->userdata = userdata;
+	ratbag->epoll_fd = epoll_fd;
 
 	list_init(&ratbag->drivers);
 	list_init(&ratbag->devices);
+	list_init(&ratbag->source_destroy_list);
 	ratbag->udev = udev_new();
 	if (!ratbag->udev) {
 		free(ratbag);
+		close(epoll_fd);
 		return NULL;
 	}
 
@@ -554,6 +563,17 @@ ratbag_ref(struct ratbag *ratbag)
 	return ratbag;
 }
 
+static inline void
+ratbag_drop_destroyed_sources(struct ratbag *ratbag)
+{
+	struct ratbag_source *source, *next;
+
+	list_for_each_safe(source, next, &ratbag->source_destroy_list, link)
+		free(source);
+
+	list_init(&ratbag->source_destroy_list);
+}
+
 LIBRATBAG_EXPORT struct ratbag *
 ratbag_unref(struct ratbag *ratbag)
 {
@@ -563,6 +583,8 @@ ratbag_unref(struct ratbag *ratbag)
 	assert(ratbag->refcount > 0);
 	ratbag->refcount--;
 	if (ratbag->refcount == 0) {
+		ratbag_drop_destroyed_sources(ratbag);
+		close(ratbag->epoll_fd);
 		ratbag->udev = udev_unref(ratbag->udev);
 		free(ratbag);
 	}
@@ -1793,4 +1815,68 @@ ratbag_button_macro_new(const char *name)
 	macro->macro.name = strdup_safe(name);
 
 	return macro;
+}
+
+LIBRATBAG_EXPORT int
+ratbag_dispatch(struct ratbag *ratbag)
+{
+	struct ratbag_source *source;
+	struct epoll_event ep[32];
+	int count;
+
+	count = epoll_wait(ratbag->epoll_fd, ep, ARRAY_LENGTH(ep), 0);
+	if (count < 0)
+		return -errno;
+
+	for (int i = 0; i < count; i++) {
+		source = ep[i].data.ptr;
+		if (source->fd == -1)
+			continue;
+
+		source->dispatch(source->userdata);
+	}
+
+	ratbag_drop_destroyed_sources(ratbag);
+
+	return 0;
+}
+
+LIBRATBAG_EXPORT int
+ratbag_get_fd(struct ratbag *ratbag)
+{
+	return ratbag->epoll_fd;
+}
+
+struct ratbag_source *
+ratbag_add_source(struct ratbag *ratbag,
+		  int fd,
+		  ratbag_source_dispatch_t dispatch,
+		  void *userdata)
+{
+	struct ratbag_source *source;
+	struct epoll_event ep = {0};
+
+	source = zalloc(sizeof *source);
+	source->dispatch = dispatch;
+	source->userdata = userdata;
+	source->fd = fd;
+
+	ep.events = EPOLLIN;
+	ep.data.ptr = source;
+
+	if (epoll_ctl(ratbag->epoll_fd, EPOLL_CTL_ADD, fd, &ep) < 0) {
+		free(source);
+		source = NULL;
+	}
+
+	return source;
+}
+
+void
+ratbag_remove_source(struct ratbag *ratbag,
+		     struct ratbag_source *source)
+{
+        epoll_ctl(ratbag->epoll_fd, EPOLL_CTL_DEL, source->fd, NULL);
+        source->fd = -1;
+        list_insert(&ratbag->source_destroy_list, &source->link);
 }

--- a/src/libratbag.h
+++ b/src/libratbag.h
@@ -294,6 +294,8 @@ ratbag_log_set_handler(struct ratbag *ratbag,
 		       ratbag_log_handler log_handler);
 
 
+typedef int (*ratbag_event_callback)(void *user_data);
+
 /**
  * @ingroup base
  * @struct ratbag_interface
@@ -393,6 +395,33 @@ ratbag_ref(struct ratbag *ratbag);
  */
 struct ratbag *
 ratbag_unref(struct ratbag *ratbag);
+
+/**
+ * @ingroup base
+ *
+ * Main event dispatchment function. Reads events of the file descriptors
+ * and processes them internally.
+ *
+ * This function must be called immediately by the calling process whenever
+ * events are available on the fd returned by ratbag_get_fd().
+ *
+ * @param ratbag A previously initialized ratbag context
+ * @return 0 on success or a negative errno on failure
+ */
+int
+ratbag_dispatch(struct ratbag *ratbag);
+
+/**
+ * @ingroup base
+ *
+ * Returns the file descriptor for this ratbag context. The calling process
+ * must call ratbag_dispatch() whenever events become available on this fd.
+ * must be added to the caller's main loop and monitored for events.
+ *
+ * @return The file descriptor used to notify of pending events.
+ */
+int
+ratbag_get_fd(struct ratbag *ratbag);
 
 /**
  * @ingroup base


### PR DESCRIPTION
This is something we'll eventually need when we start monitoring events. We don't have a user for this just yet, so we shouldn't merge it.

I'm sending this as PR now because the code is written and I think that's the approach we want. So once we need it, we can rebase this and push it out.