### PR TITLE
set CAP_LED for mice with only 1 LED

### DIFF
--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -712,7 +712,7 @@ ratbag_device_init_profiles(struct ratbag_device *device,
 		ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_SWITCHABLE_RESOLUTION);
 	}
 
-	if (num_leds > 1)
+	if (num_leds > 0)
 		ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_LED);
 
 	return 0;


### PR DESCRIPTION
Even if there is only 1 LED we should set the cap to let Piper change it in the GUI