### PR TITLE
Set ratbagd_led_get_type to request int for TYPE

### DIFF
--- a/ratbagd/ratbagd-led.c
+++ b/ratbagd/ratbagd-led.c
@@ -98,7 +98,7 @@ static int ratbagd_led_get_type(sd_bus *bus,
 
 	type = ratbag_led_get_type(led->lib_led);
 
-	return sd_bus_message_append(reply, "u", type);
+	return sd_bus_message_append(reply, "i", type);
 }
 
 static int ratbagd_led_get_color(sd_bus *bus,
@@ -258,7 +258,7 @@ const sd_bus_vtable ratbagd_led_vtable[] = {
 				 ratbagd_led_get_mode,
 				 ratbagd_led_set_mode, 0,
 				 SD_BUS_VTABLE_UNPRIVILEGED|SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
-	SD_BUS_PROPERTY("Type", "u", ratbagd_led_get_type, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+	SD_BUS_PROPERTY("Type", "i", ratbagd_led_get_type, 0, SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_WRITABLE_PROPERTY("Color", "(uuu)",
 				 ratbagd_led_get_color, ratbagd_led_set_color, 0,
 				 SD_BUS_VTABLE_UNPRIVILEGED|SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),


### PR DESCRIPTION
Updated DBUS property for the LED Type parameter to correctly handle "unknown" types (-1) as defined in the enumerated type in libratbag.h.

Likely a few similar bugs hiding elsewhere for negative number types.

Should close #364.