### PR TITLE
G9 fix commit

### DIFF
--- a/src/driver-hidpp10.c
+++ b/src/driver-hidpp10.c
@@ -410,40 +410,6 @@ hidpp10drv_write_profile(struct ratbag_profile *profile)
 }
 
 static int
-hidpp10drv_write_resolution_dpi(struct hidpp10_profile *p,
-				struct ratbag_resolution *resolution,
-				int dpi_x, int dpi_y)
-{
-	struct ratbag_profile *profile = resolution->profile;
-	struct ratbag_device *device = profile->device;
-	struct hidpp10drv_data *drv_data = ratbag_get_drv_data(device);
-	struct hidpp10_device *hidpp10 = drv_data->dev;
-	unsigned int index;
-	uint16_t cur_dpi_x, cur_dpi_y;
-	int rc;
-
-	/* store the current resolution */
-	rc = hidpp10_get_current_resolution(hidpp10, &cur_dpi_x, &cur_dpi_y);
-	if (rc)
-		return rc;
-
-	if (resolution->is_active) {
-		/* we need to switch to the new resolution */
-		cur_dpi_x = dpi_x;
-		cur_dpi_y = dpi_y;
-	}
-
-	/* retrieve which resolution is asked to be changed */
-	index = resolution - profile->resolution.modes;
-
-	p->dpi_modes[index].xres = dpi_x;
-	p->dpi_modes[index].yres = dpi_y;
-
-	/* restore the current setting */
-	return hidpp10_set_current_resolution(hidpp10, cur_dpi_x, cur_dpi_y);
-}
-
-static int
 hidpp10drv_fill_from_profile(struct ratbag_device *device, struct hidpp10_device *dev)
 {
 	int rc;
@@ -502,6 +468,7 @@ hidpp10drv_commit(struct ratbag_device *device)
 	struct ratbag_profile *profile;
 	struct ratbag_button *button;
 	struct ratbag_resolution *resolution;
+	struct ratbag_resolution *active_resolution = NULL;
 	struct hidpp10_profile p;
 	int rc;
 	unsigned int i;
@@ -519,12 +486,11 @@ hidpp10drv_commit(struct ratbag_device *device)
 		for (i = 0; i < profile->resolution.num_modes; i++) {
 			resolution = &profile->resolution.modes[i];
 
-			rc = hidpp10drv_write_resolution_dpi(&p,
-							     resolution,
-							     resolution->dpi_x,
-							     resolution->dpi_y);
-			if (rc)
-				return RATBAG_ERROR_DEVICE;
+			p.dpi_modes[i].xres = resolution->dpi_x;
+			p.dpi_modes[i].yres = resolution->dpi_y;
+
+			if (profile->is_active && resolution->is_active)
+				active_resolution = resolution;
 		}
 
 		list_for_each(button, &profile->buttons, link) {
@@ -542,6 +508,17 @@ hidpp10drv_commit(struct ratbag_device *device)
 			rc = hidpp10_set_profile(dev, profile->index, &p);
 			if (rc)
 				return RATBAG_ERROR_DEVICE;
+		}
+
+		/* Update the current resolution in case it changed */
+		if (active_resolution) {
+			rc = hidpp10_set_current_resolution(dev,
+						       active_resolution->dpi_x,
+						       active_resolution->dpi_y);
+			if (rc)
+				return RATBAG_ERROR_DEVICE;
+
+			active_resolution = NULL;
 		}
 	}
 

--- a/src/hidpp10.c
+++ b/src/hidpp10.c
@@ -2109,12 +2109,24 @@ hidpp10_set_current_resolution(struct hidpp10_device *dev,
 			       uint16_t yres)
 {
 	unsigned idx = dev->index;
-	union hidpp10_message resolution = CMD_CURRENT_RESOLUTION(REPORT_ID_LONG, idx, SET_LONG_REGISTER_REQ);
+	union hidpp10_message resolution = CMD_CURRENT_RESOLUTION(REPORT_ID_SHORT, idx, SET_REGISTER_REQ);
+	union hidpp10_message resolution_long = CMD_CURRENT_RESOLUTION(REPORT_ID_LONG, idx, SET_LONG_REGISTER_REQ);
+	int res;
 
-	hidpp_set_unaligned_le_u16(&resolution.data[4], hidpp10_get_dpi_mapping(dev, xres));
-	hidpp_set_unaligned_le_u16(&resolution.data[6], hidpp10_get_dpi_mapping(dev, yres));
+	switch (dev->profile_type) {
+	case HIDPP10_PROFILE_G9:
+		resolution.data[4] = hidpp10_get_dpi_mapping(dev, xres);
+		res = hidpp10_request_command(dev, &resolution);
+		break;
+        default:
+		hidpp_set_unaligned_le_u16(&resolution_long.data[4], hidpp10_get_dpi_mapping(dev, xres));
+		hidpp_set_unaligned_le_u16(&resolution_long.data[6], hidpp10_get_dpi_mapping(dev, yres));
 
-	return hidpp10_request_command(dev, &resolution);
+		res = hidpp10_request_command(dev, &resolution_long);
+		break;
+        }
+
+	return res;
 }
 
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
This fixes writing profiles on the G9. The problem was when setting the current resolution, which is a short report on the G9 but a long on other models. While looking into it I noticed that we are getting/setting the current resolution unnecessarily many times, and that we set it before the profile write which causes the device to jump to its default resolution.