### PR TITLE
ratbagd.devel tidyup

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -448,7 +448,8 @@ executable('ratbagd.devel',
 	   dependencies : deps_ratbagd,
 	   include_directories : include_directories('src'),
 	   install : false,
-	   c_args : '-DRATBAG_DBUS_INTERFACE="ratbag_devel1_@0@"'.format(ratbagd_sha),
+	   c_args : ['-DRATBAG_DBUS_INTERFACE="ratbag_devel1_@0@"'.format(ratbagd_sha),
+		     '-DDISABLE_COREDUMP=1'],
 )
 
 config_ratbagd_devel = configuration_data()

--- a/ratbagd/ratbagd.c
+++ b/ratbagd/ratbagd.c
@@ -33,6 +33,7 @@
 #include <libudev.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/resource.h>
 #include <systemd/sd-bus.h>
 #include <systemd/sd-event.h>
 #include "ratbagd.h"
@@ -522,6 +523,12 @@ int main(int argc, char *argv[])
 {
 	struct ratbagd *ctx = NULL;
 	int r;
+
+#if DISABLE_COREDUMP
+	const struct rlimit corelimit = { 0, 0 };
+
+	setrlimit(RLIMIT_CORE, &corelimit);
+#endif
 
 	if (argc > 1) {
 		if (streq(argv[1], "--verbose=raw")) {

--- a/tools/ratbagctl.devel.in
+++ b/tools/ratbagctl.devel.in
@@ -42,6 +42,7 @@ def main(argv):
         argv = ["list"]
 
     cmd = None
+    ratbagd_process = None
     try:
         parser = toolbox.get_parser()
         parser.want_keepalive = True

--- a/tools/toolbox.py
+++ b/tools/toolbox.py
@@ -62,8 +62,7 @@ def start_ratbagd(verbosity=0):
     import time
 
     # first copy the policy for the ratbagd daemon to be allowed to run
-    shutil.copy(os.path.join('@MESON_BUILD_ROOT@',
-                DBUS_CONF_NAME),
+    shutil.copy(os.path.join('@MESON_BUILD_ROOT@', DBUS_CONF_NAME),
                 DBUS_CONF_DIR)
 
     # FIXME: kill any running ratbagd.devel

--- a/tools/toolbox.py
+++ b/tools/toolbox.py
@@ -102,12 +102,16 @@ def start_ratbagd(verbosity=0):
 
 
 def terminate_ratbagd(ratbagd):
+    if ratbagd is not None:
+        try:
+            ratbagd.terminate()
+            ratbagd.wait(5)
+        except subprocess.TimeoutExpired:
+            ratbagd.kill()
     try:
-        ratbagd.terminate()
-        ratbagd.wait(5)
-    except subprocess.TimeoutExpired:
-        ratbagd.kill()
-    os.unlink(DBUS_CONF_PATH)
+        os.unlink(DBUS_CONF_PATH)
+    except FileNotFoundError:
+        pass
 
 
 def sync_dbus():

--- a/tools/toolbox.py
+++ b/tools/toolbox.py
@@ -63,7 +63,7 @@ def start_ratbagd(verbosity=0):
 
     # first copy the policy for the ratbagd daemon to be allowed to run
     shutil.copy(os.path.join('@MESON_BUILD_ROOT@', DBUS_CONF_NAME),
-                DBUS_CONF_DIR)
+                DBUS_CONF_PATH)
 
     # FIXME: kill any running ratbagd.devel
 


### PR DESCRIPTION
Fixes the exception when ratbagd.devel doesn't start up properly. And avoids the journal being filled up with backtraces