### PR TITLE
led: change RGB to RGB888 and add 1-bit RGB

### DIFF
--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -281,7 +281,7 @@ hidpp20drv_read_led(struct ratbag_led *led)
 	led->color.blue = h_led->color.blue;
 	led->hz = h_led->period;  /* FIXME: should be ceil(1000.0 / h_led->period), but that would be very small */
 	led->brightness = h_led->brightness * 255 / 100;
-	led->colordepth = RATBAG_LED_COLORDEPTH_RGB;
+	led->colordepth = RATBAG_LED_COLORDEPTH_RGB_888;
 }
 
 static int

--- a/src/driver-logitech-g300.c
+++ b/src/driver-logitech-g300.c
@@ -390,7 +390,7 @@ logitech_g300_read_led(struct ratbag_led *led)
 
 	led->type = RATBAG_LED_TYPE_SIDE;
 	led->mode = RATBAG_LED_ON;
-	led->colordepth = RATBAG_LED_COLORDEPTH_MONOCHROME;
+	led->colordepth = RATBAG_LED_COLORDEPTH_RGB_111;
 	led->color.red = profile_report->led_red * 255;
 	led->color.green = profile_report->led_green * 255;
 	led->color.blue = profile_report->led_blue * 255;

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -599,7 +599,7 @@ ratbag_create_led(struct ratbag_profile *profile, unsigned int index)
 	led->refcount = 0;
 	led->profile = profile;
 	led->index = index;
-	led->colordepth = RATBAG_LED_COLORDEPTH_RGB;
+	led->colordepth = RATBAG_LED_COLORDEPTH_RGB_888;
 
 	list_insert(&profile->leds, &led->link);
 

--- a/src/libratbag.h
+++ b/src/libratbag.h
@@ -1530,10 +1530,13 @@ enum ratbag_led_colordepth {
 	 */
 	RATBAG_LED_COLORDEPTH_MONOCHROME = 400,
 	/**
-	 * The device supports RBG colors of an unspecified depth,
-	 * but with at least 8 bits per color.
+	 * The device supports RBG color with 8 bits per color.
 	 */
-	RATBAG_LED_COLORDEPTH_RGB,
+	RATBAG_LED_COLORDEPTH_RGB_888,
+	/**
+	 * The device supports RBG colors with 1 bit per color.
+	 */
+	RATBAG_LED_COLORDEPTH_RGB_111,
 };
 
 /**

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -132,7 +132,8 @@ def print_led(d, p, l, level):
     }
     depths = {
         RatbagdLed.COLORDEPTH_MONOCHROME: "monochrome",
-        RatbagdLed.COLORDEPTH_RGB: "rgb",
+        RatbagdLed.COLORDEPTH_RGB_888: "rgb",
+        RatbagdLed.COLORDEPTH_RGB_111: "rgb111",
     }
     if l.mode == RatbagdLed.MODE_OFF:
         print(" " * level + "LED: {} type: {}, depth: {}, mode: {}".format(l.index,

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -890,7 +890,8 @@ class RatbagdLed(_RatbagdDBus):
     MODE_BREATHING = 3
 
     COLORDEPTH_MONOCHROME = 400
-    COLORDEPTH_RGB = 401
+    COLORDEPTH_RGB_888 = 401
+    COLORDEPTH_RGB_111 = 402
 
     LED_DESCRIPTION = {
         # Translators: the LED is off.


### PR DESCRIPTION
1-bit RGB is needed for the Logitech G300, let's rename the main RGB to
indicate how many bits we actually have.

See #335

