### PR TITLE
Fix Logitech wireless identification

### DIFF
--- a/data/devices/data-parse-test.py
+++ b/data/devices/data-parse-test.py
@@ -164,7 +164,7 @@ def check_section_hidpp10(section):
 
 
 def check_section_hidpp20(section):
-    permitted = ['DeviceIndex']
+    permitted = ['DeviceIndex', 'IsWireless']
     for key in section.keys():
         assert(key in permitted)
 

--- a/data/devices/logitech-wireless-receiver.device
+++ b/data/devices/logitech-wireless-receiver.device
@@ -1,0 +1,11 @@
+# Logitech G403, G603, G703, G900 and G903 over wireless USB
+[Device]
+Name=Logitech G403, G603, G703, G900 and G903
+DeviceMatch=usb:046d:c539
+Driver=hidpp20
+# This is not used since the real svg name is discovered later
+Svg=logitech-g900.svg 
+
+[Driver/hidpp20]
+DeviceIndex=1
+IsWireless=true

--- a/meson.build
+++ b/meson.build
@@ -141,7 +141,9 @@ src_libratbag = [
 	'src/libratbag-private.h',
 	'src/libratbag-test.c',
 	'src/libratbag-test.h',
-	'src/usb-ids.h'
+	'src/usb-ids.h',
+	'src/liblur.c',
+	'src/liblur.h',
 ]
 
 deps_libratbag = [
@@ -264,6 +266,7 @@ man_lur_command = configure_file (
 data_files = files(
 	'data/devices/etekcity-fixme.device',
 	'data/devices/gskill-MX-780.device',
+	'data/devices/logitech-wireless-receiver.device',
 	'data/devices/logitech-g300.device',
 	'data/devices/logitech-g303.device',
 	'data/devices/logitech-g403.device',

--- a/src/liblur.c
+++ b/src/liblur.c
@@ -122,7 +122,7 @@ lur_device_disconnect(struct lur_device *dev)
 _EXPORT_ int
 lur_is_receiver(uint16_t vid, uint16_t pid)
 {
-	return (vid == USB_VENDOR_ID_LOGITECH && (pid == 0xc52b || pid == 0xc532));
+	return (vid == USB_VENDOR_ID_LOGITECH && (pid == 0xc52b || pid == 0xc532 || pid == 0xc539));
 }
 
 static bool

--- a/src/libratbag-data.h
+++ b/src/libratbag-data.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include <stdbool.h>
+
 struct ratbag_device_data;
 
 struct ratbag_device_data *
@@ -42,6 +44,10 @@ const char *
 ratbag_device_data_get_name(const struct ratbag_device_data *data);
 const char *
 ratbag_device_data_get_svg(const struct ratbag_device_data *data);
+bool
+ratbag_device_data_hidpp20_is_wireless(const struct ratbag_device_data *data);
+void
+ratbag_device_data_hidpp20_set_svg(struct ratbag_device_data *data, char* svg);
 
 /* HID++ 1.0 */
 /**


### PR DESCRIPTION
This is a working fix for #380, though I wanted some feedback on design first. 

- First, I've had to merge liblur into libhidpp in order to talk to the USB receiver during the hidpp20 driver probe phase
- Since the SVG is not known until speaking with the receiver, the ratbag_device_data structure needs to be updated during the probe phase or we need to change ratbag's device identification procedure. 
- This fix avoids making big changes to the general device discovery since this is Logitech-specific at the cost of making the ratbag_device_data structure mutable from outside `libratbag-data.c`. What do you think is the best way?
- Small change to liblur to consider the Logitech gaming mouse USB receiver (046d:c539) as a unifying receiver

Signed-off-by: Ogier Bouvier <obouvier@logitech.com>