### PR TITLE
Correct G403 ID. Added Wireless-specific G403 device file.

### DIFF
--- a/data/devices/logitech-g403-wireless.device
+++ b/data/devices/logitech-g403-wireless.device
@@ -1,6 +1,6 @@
-# Logitech G403 over USB
+# Logitech G403 Wireless
 [Device]
 Name=Logitech G403
-DeviceMatch=usb:046d:c083
+DeviceMatch=usb:046d:c082
 Driver=hidpp20
 Svg=logitech-g403.svg


### PR DESCRIPTION
Resolves #384. Confirmed [under Solus](https://dev.solus-project.com/R3780:07a0590216760778cfd272f40fc79d17f7325ac9) while packaging.