### PR TITLE
hidpp10: Fix LED read/write

### DIFF
--- a/data/devices/logitech-g9.device
+++ b/data/devices/logitech-g9.device
@@ -3,6 +3,7 @@
 [Device]
 Name=Logitech G9
 DeviceMatch=usb:046d:c048
+LedTypes=dpi
 Driver=hidpp10
 Svg=logitech-g9.svg
 

--- a/src/hidpp10.c
+++ b/src/hidpp10.c
@@ -1515,6 +1515,9 @@ hidpp10_read_profile(struct hidpp10_device *dev, uint8_t number)
 			hidpp10_fill_buttons(dev, profile, buttons, PROFILE_NUM_BUTTONS);
 			break;
 		case HIDPP10_PROFILE_G9:
+			profile->red = p9->red;
+			profile->green = p9->green;
+			profile->blue = p9->blue;
 			profile->default_dpi_mode = p9->default_dpi_mode;
 			profile->refresh_rate = p9->usb_refresh_rate ? 1000/p9->usb_refresh_rate : 0;
 


### PR DESCRIPTION
With this the LEDs can be read and written on the G9.

The G9 is as far as I know the only hid++1.0 mouse with RGB LED. The
other mice are monochrome.