### PR TITLE
DBus API change to switch to discrete resolution lists

### DIFF
--- a/doc/dbus.rst
+++ b/doc/dbus.rst
@@ -264,11 +264,19 @@ org.freedesktop.ratbag1.Resolution
 
         uint for the x and y resolution assigned to this entry,
         respectively.  The value for the resolution must be equal to
-        or between the :js:attr:`Minimum` and :js:attr:`Maximum` of
-        this resolution.
+        one of the values in :js:attr:`Resolutions`.
 
         If the resolution does not support separate x/y resolutions,
         x and y must be the same value.
+
+    .. js:attribute:: Resolutions
+
+        :type: au
+        :flags: read-only, constant
+
+        A list of permitted resolutions. Values in this list may be used in
+        the :js:attr:`Resolution` property. This list is always sorted
+        ascending, the lowest resolution is the first item in the list.
 
     .. js:attribute:: ReportRate
 
@@ -280,20 +288,6 @@ org.freedesktop.ratbag1.Resolution
         If the resolution does not have the individual report rate
         capability, changing the report rate on one resolution will
         change the report rate on all resolutions.
-
-    .. js:attribute:: Maximum
-
-        :type: u
-        :flags: read-only, constant
-
-        uint for the maximum resolution
-
-    .. js:attribute:: Minimum
-
-        :type: u
-        :flags: read-only, constant
-
-        uint for the minimum possible resolution
 
     .. js:function:: SetDefault() → ()
 

--- a/ratbagd/ratbagd-test.c
+++ b/ratbagd/ratbagd-test.c
@@ -64,7 +64,7 @@ static const struct ratbag_test_device ratbagd_test_device_descr = {
 				}
 			},
 			.resolutions = {
-				{ .xres = 100, .yres = 200, .hz = 1000 },
+				{ .xres = 100, .yres = 200, .hz = 1000, .dpi_min = 50, .dpi_max = 5000 },
 				{ .xres = 200, .yres = 300, .hz = 1000, .active = true, .dflt = true },
 				{ .xres = 300, .yres = 400, .hz = 1000 },
 			},

--- a/src/driver-hidpp10.c
+++ b/src/driver-hidpp10.c
@@ -437,7 +437,7 @@ hidpp10drv_read_profile(struct ratbag_profile *profile)
 
 		min = hidpp10_dpi_table_get_min_dpi(hidpp10);
 		max = hidpp10_dpi_table_get_max_dpi(hidpp10);
-		ratbag_resolution_set_range(res, min, max);
+		ratbag_resolution_set_dpi_list_from_range(res, min, max);
 	}
 
 	ratbag_profile_for_each_button(profile, button)

--- a/src/driver-hidpp10.c
+++ b/src/driver-hidpp10.c
@@ -417,7 +417,7 @@ hidpp10drv_read_profile(struct ratbag_profile *profile)
 	ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_SWITCHABLE_RESOLUTION);
 
 	ratbag_profile_for_each_resolution(profile, res) {
-		unsigned int min, max;
+		unsigned int dpis[hidpp10->dpi_count];
 
 		ratbag_resolution_set_resolution(res,
 						 p.dpi_modes[res->index].xres,
@@ -435,9 +435,20 @@ hidpp10drv_read_profile(struct ratbag_profile *profile)
 				res->is_active = true;
 		}
 
-		min = hidpp10_dpi_table_get_min_dpi(hidpp10);
-		max = hidpp10_dpi_table_get_max_dpi(hidpp10);
-		ratbag_resolution_set_dpi_list_from_range(res, min, max);
+		if (hidpp10->dpi_table_is_range) {
+			unsigned int min, max;
+
+			min = hidpp10_dpi_table_get_min_dpi(hidpp10);
+			max = hidpp10_dpi_table_get_max_dpi(hidpp10);
+			/* FIXME: this relies on libratbag using the
+			 * same steps that we support */
+			ratbag_resolution_set_dpi_list_from_range(res, min, max);
+		} else {
+			for (int i = 0; i < hidpp10->dpi_count - 1; i++)
+				dpis[i] = hidpp10->dpi_table[i].dpi;
+
+			ratbag_resolution_set_dpi_list(res, dpis, hidpp10->dpi_count);
+		}
 	}
 
 	ratbag_profile_for_each_button(profile, button)

--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -667,7 +667,9 @@ hidpp20drv_read_resolution_dpi(struct ratbag_profile *profile)
 
 			/* FIXME: retrieve the refresh rate */
 			ratbag_resolution_set_resolution(res, sensor->dpi, sensor->dpi, 0);
-			ratbag_resolution_set_range(res, sensor->dpi_min, sensor->dpi_max);
+			ratbag_resolution_set_dpi_list_from_range(res,
+								  sensor->dpi_min,
+								  sensor->dpi_max);
 
 			/* FIXME: we mark all resolutions as active because
 			 * they are from different sensors */
@@ -874,7 +876,10 @@ hidpp20drv_read_profile_8100(struct ratbag_profile *profile)
 				res->is_active = true;
 		}
 
-		ratbag_resolution_set_range(res, sensor->dpi_min, sensor->dpi_max);
+		ratbag_resolution_set_dpi_list_from_range(res,
+							  sensor->dpi_min,
+							  sensor->dpi_max);
+
 	}
 }
 

--- a/src/driver-logitech-g300.c
+++ b/src/driver-logitech-g300.c
@@ -393,9 +393,9 @@ logitech_g300_read_profile(struct ratbag_profile *profile)
 		resolution->is_default = res->is_default;
 		resolution->is_active = res->is_default;
 
-		ratbag_resolution_set_range(resolution,
-					    LOGITECH_G300_DPI_MIN,
-					    LOGITECH_G300_DPI_MAX);
+		ratbag_resolution_set_dpi_list_from_range(resolution,
+							  LOGITECH_G300_DPI_MIN,
+							  LOGITECH_G300_DPI_MAX);
 	}
 
 	ratbag_profile_for_each_button(profile, button)

--- a/src/driver-test.c
+++ b/src/driver-test.c
@@ -169,7 +169,9 @@ test_read_profile(struct ratbag_profile *profile)
 {
 	struct ratbag_test_device *d = ratbag_get_drv_data(profile->device);
 	struct ratbag_test_profile *p;
+	struct ratbag_test_profile *p0;
 	struct ratbag_test_resolution *r;
+	struct ratbag_test_resolution *r0;
 	struct ratbag_button *button;
 	struct ratbag_led *led;
 	unsigned int i;
@@ -179,6 +181,9 @@ test_read_profile(struct ratbag_profile *profile)
 	assert(profile->index < d->num_profiles);
 
 	p = &d->profiles[profile->index];
+	p0 = &d->profiles[0];
+	r0 = &p0->resolutions[0];
+
 	for (i = 0; i < d->num_resolutions; i++) {
 		_cleanup_resolution_ struct ratbag_resolution *res;
 
@@ -187,6 +192,8 @@ test_read_profile(struct ratbag_profile *profile)
 		res = ratbag_profile_get_resolution(profile, i);
 		assert(res);
 		ratbag_resolution_set_resolution(res, r->xres, r->yres, r->hz);
+		if (r0->dpi_min != 0 && r0->dpi_max != 0)
+			ratbag_resolution_set_range(res, r0->dpi_min, r0->dpi_max);
 		res->is_active = r->active;
 		if (r->active)
 			active_set = true;

--- a/src/driver-test.c
+++ b/src/driver-test.c
@@ -193,7 +193,9 @@ test_read_profile(struct ratbag_profile *profile)
 		assert(res);
 		ratbag_resolution_set_resolution(res, r->xres, r->yres, r->hz);
 		if (r0->dpi_min != 0 && r0->dpi_max != 0)
-			ratbag_resolution_set_range(res, r0->dpi_min, r0->dpi_max);
+			ratbag_resolution_set_dpi_list_from_range(res,
+								  r0->dpi_min,
+								  r0->dpi_max);
 		res->is_active = r->active;
 		if (r->active)
 			active_set = true;

--- a/src/hidpp10.c
+++ b/src/hidpp10.c
@@ -123,6 +123,7 @@ hidpp10_build_dpi_table_from_list(struct hidpp10_device *dev,
 
 	dev->dpi_count = list->nentries;
 	dev->dpi_table = zalloc(list->nentries * sizeof(*dev->dpi_table));
+	dev->dpi_table_is_range = false;
 
 	for (i = 0; i < list->nentries; i++) {
 		dev->dpi_table[i].raw_value = i + 0x80;
@@ -150,6 +151,7 @@ hidpp10_build_dpi_table_from_dpi_info(struct hidpp10_device *dev,
 
 	dev->dpi_count = raw_max + 1;
 	dev->dpi_table = zalloc((raw_max + 1) * sizeof(*dev->dpi_table));
+	dev->dpi_table_is_range = true;
 
 	for (i = 1; i <= raw_max; i++) {
 		dev->dpi_table[i].raw_value = i;

--- a/src/hidpp10.h
+++ b/src/hidpp10.h
@@ -60,6 +60,8 @@ struct hidpp10_dpi_mapping {
 struct hidpp10_device  {
 	struct hidpp_device base;
 	unsigned index;
+
+	bool dpi_table_is_range;
 	uint8_t dpi_count;
 	struct hidpp10_dpi_mapping *dpi_table;
 	enum hidpp10_profile_type profile_type;

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -34,6 +34,34 @@
 
 #define RATBAG_LED_TYPE_UNKNOWN 0
 
+void
+log_msg_va(struct ratbag *ratbag,
+	   enum ratbag_log_priority priority,
+	   const char *format,
+	   va_list args)
+	LIBRATBAG_ATTRIBUTE_PRINTF(3, 0);
+void log_msg(struct ratbag *ratbag,
+	enum ratbag_log_priority priority,
+	const char *format, ...)
+	LIBRATBAG_ATTRIBUTE_PRINTF(3, 4);
+void
+log_buffer(struct ratbag *ratbag,
+	enum ratbag_log_priority priority,
+	const char *header,
+	uint8_t *buf, size_t len);
+
+#define log_raw(li_, ...) log_msg((li_), RATBAG_LOG_PRIORITY_RAW, __VA_ARGS__)
+#define log_debug(li_, ...) log_msg((li_), RATBAG_LOG_PRIORITY_DEBUG, __VA_ARGS__)
+#define log_info(li_, ...) log_msg((li_), RATBAG_LOG_PRIORITY_INFO, __VA_ARGS__)
+#define log_error(li_, ...) log_msg((li_), RATBAG_LOG_PRIORITY_ERROR, __VA_ARGS__)
+#define log_bug_kernel(li_, ...) log_msg((li_), RATBAG_LOG_PRIORITY_ERROR, "kernel bug: " __VA_ARGS__)
+#define log_bug_libratbag(li_, ...) log_msg((li_), RATBAG_LOG_PRIORITY_ERROR, "libratbag bug: " __VA_ARGS__)
+#define log_bug_client(li_, ...) log_msg((li_), RATBAG_LOG_PRIORITY_ERROR, "client bug: " __VA_ARGS__)
+#define log_buf_raw(li_, h_, buf_, len_) log_buffer(li_, RATBAG_LOG_PRIORITY_RAW, h_, buf_, len_)
+#define log_buf_debug(li_, h_, buf_, len_) log_buffer(li_, RATBAG_LOG_PRIORITY_DEBUG, h_, buf_, len_)
+#define log_buf_info(li_, h_, buf_, len_) log_buffer(li_, RATBAG_LOG_PRIORITY_INFO, h_, buf_, len_)
+#define log_buf_error(li_, h_, buf_, len_) log_buffer(li_, RATBAG_LOG_PRIORITY_ERROR, h_, buf_, len_)
+
 static inline void
 cleanup_device(struct ratbag_device **d)
 {
@@ -459,34 +487,6 @@ ratbag_resolution_set_cap(struct ratbag_resolution *res,
 
 	res->capabilities = (1 << cap);
 }
-
-void
-log_msg_va(struct ratbag *ratbag,
-	   enum ratbag_log_priority priority,
-	   const char *format,
-	   va_list args)
-	LIBRATBAG_ATTRIBUTE_PRINTF(3, 0);
-void log_msg(struct ratbag *ratbag,
-	enum ratbag_log_priority priority,
-	const char *format, ...)
-	LIBRATBAG_ATTRIBUTE_PRINTF(3, 4);
-void
-log_buffer(struct ratbag *ratbag,
-	enum ratbag_log_priority priority,
-	const char *header,
-	uint8_t *buf, size_t len);
-
-#define log_raw(li_, ...) log_msg((li_), RATBAG_LOG_PRIORITY_RAW, __VA_ARGS__)
-#define log_debug(li_, ...) log_msg((li_), RATBAG_LOG_PRIORITY_DEBUG, __VA_ARGS__)
-#define log_info(li_, ...) log_msg((li_), RATBAG_LOG_PRIORITY_INFO, __VA_ARGS__)
-#define log_error(li_, ...) log_msg((li_), RATBAG_LOG_PRIORITY_ERROR, __VA_ARGS__)
-#define log_bug_kernel(li_, ...) log_msg((li_), RATBAG_LOG_PRIORITY_ERROR, "kernel bug: " __VA_ARGS__)
-#define log_bug_libratbag(li_, ...) log_msg((li_), RATBAG_LOG_PRIORITY_ERROR, "libratbag bug: " __VA_ARGS__)
-#define log_bug_client(li_, ...) log_msg((li_), RATBAG_LOG_PRIORITY_ERROR, "client bug: " __VA_ARGS__)
-#define log_buf_raw(li_, h_, buf_, len_) log_buffer(li_, RATBAG_LOG_PRIORITY_RAW, h_, buf_, len_)
-#define log_buf_debug(li_, h_, buf_, len_) log_buffer(li_, RATBAG_LOG_PRIORITY_DEBUG, h_, buf_, len_)
-#define log_buf_info(li_, h_, buf_, len_) log_buffer(li_, RATBAG_LOG_PRIORITY_INFO, h_, buf_, len_)
-#define log_buf_error(li_, h_, buf_, len_) log_buffer(li_, RATBAG_LOG_PRIORITY_ERROR, h_, buf_, len_)
 
 /* list of all supported drivers */
 struct ratbag_driver etekcity_driver;

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -512,6 +512,21 @@ ratbag_resolution_set_dpi_list_from_range(struct ratbag_resolution *res,
 }
 
 static inline void
+ratbag_resolution_set_dpi_list(struct ratbag_resolution *res,
+			       unsigned int *dpis,
+			       size_t ndpis)
+{
+	assert(ndpis <= ARRAY_LENGTH(res->dpis));
+	_Static_assert(sizeof(*dpis) == sizeof(*res->dpis), "Mismatching size");
+
+	for (size_t i = 0; i < ndpis; i++) {
+		res->dpis[i] = dpis[i];
+		if (i > 0)
+			assert(dpis[i] > dpis[i - 1]);
+	}
+}
+
+static inline void
 ratbag_resolution_set_cap(struct ratbag_resolution *res,
 			  enum ratbag_resolution_capability cap)
 {

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -478,16 +478,13 @@ static inline void
 ratbag_resolution_set_dpi_list_from_range(struct ratbag_resolution *res,
 					  unsigned int min, unsigned int max)
 {
-	const unsigned int stepsize = 50;
+	unsigned int stepsize = 50;
+	unsigned int dpi = min;
 	bool maxed_out = false;
 
 	res->ndpis = 0;
 
-	/* FIXME: this should use an exponential approach, because who cares
-	 * about 8200 vs 8250 dpi. */
 	while (res->ndpis < ARRAY_LENGTH(res->dpis)) {
-		unsigned int dpi = min + res->ndpis * stepsize;
-
 		if (dpi > (unsigned)max) {
 			maxed_out = true;
 			break;
@@ -495,6 +492,17 @@ ratbag_resolution_set_dpi_list_from_range(struct ratbag_resolution *res,
 
 		res->dpis[res->ndpis] = dpi;
 		res->ndpis++;
+
+		if (dpi < 1000)
+			stepsize = 50;
+		else if (dpi < 2600)
+			stepsize = 100;
+		else if (dpi < 5000)
+			stepsize = 200;
+		else
+			stepsize = 500;
+
+		dpi += stepsize;
 	}
 
 	if (!maxed_out)

--- a/src/libratbag-test.h
+++ b/src/libratbag-test.h
@@ -55,6 +55,8 @@ struct ratbag_test_resolution {
 	bool active;
 	bool dflt;
 	uint32_t caps;
+
+	int dpi_min, dpi_max;
 };
 
 struct ratbag_test_color {

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -1122,16 +1122,19 @@ ratbag_resolution_get_dpi(struct ratbag_resolution *resolution)
 	return resolution->dpi_x;
 }
 
-LIBRATBAG_EXPORT int
-ratbag_resolution_get_dpi_maximum(struct ratbag_resolution *resolution)
+LIBRATBAG_EXPORT size_t
+ratbag_resolution_get_dpi_list(struct ratbag_resolution *resolution,
+			       unsigned int *resolutions,
+			       size_t nres)
 {
-	return resolution->dpi_max;
-}
+	_Static_assert(sizeof(*resolutions) == sizeof(*resolution->dpis), "type mismatch");
 
-LIBRATBAG_EXPORT int
-ratbag_resolution_get_dpi_minimum(struct ratbag_resolution *resolution)
-{
-	return resolution->dpi_min;
+	assert(nres > 0);
+
+	memcpy(resolutions, resolution->dpis,
+	       sizeof(unsigned int) * min(nres, resolution->ndpis));
+
+	return resolution->ndpis;
 }
 
 LIBRATBAG_EXPORT int

--- a/src/libratbag.h
+++ b/src/libratbag.h
@@ -843,28 +843,26 @@ ratbag_resolution_get_dpi(struct ratbag_resolution *resolution);
 /**
  * @ingroup resolution
  *
- * Get the maximum allowed resolution in DPI for the resolution mode.
+ * Get the number of resolutions in DPI available for this resolution.
+ * The list of DPI values is sorted in ascending order but may be filtered
+ * by libratbag and does not necessarily reflect all resolutions supported
+ * by the physical device.
  *
- * @param resolution A previously initialized ratbag resolution
+ * This function writes at most nres values but returns the number of
+ * DPI values available on this resolution. In other words, if it returns a
+ * number larger than nres, call it again with an array the size of the
+ * return value.
  *
- * @return The maximum resolution in dpi
- * @retval 0 The maximum resolution is unknown to libratbag
+ * @param[out] resolutions Set to the supported DPI values in ascending order
+ * @param[in] nres The number of elements in resolutions
+ *
+ * @return The number of valid items in resolutions. If the returned value
+ * is larger than nres, the list was truncated.
  */
-int
-ratbag_resolution_get_dpi_maximum(struct ratbag_resolution *resolution);
-
-/**
- * @ingroup resolution
- *
- * Get the minimum allowed resolution in DPI for the resolution mode.
- *
- * @param resolution A previously initialized ratbag resolution
- *
- * @return The minimum resolution in dpi
- * @retval 0 The minimum resolution is unknown to libratbag
- */
-int
-ratbag_resolution_get_dpi_minimum(struct ratbag_resolution *resolution);
+size_t
+ratbag_resolution_get_dpi_list(struct ratbag_resolution *resolution,
+			       unsigned int *resolutions,
+			       size_t nres);
 
 /**
  * @ingroup resolution

--- a/test/test-device.c
+++ b/test/test-device.c
@@ -342,7 +342,7 @@ START_TEST(device_resolutions)
 	struct ratbag_resolution *res;
 	int nprofiles, nresolutions;
 	int i, j;
-	int xres, yres, rate;
+	int xres, yres, rate, dpi_min, dpi_max;
 	int device_freed_count = 0;
 	bool is_active;
 
@@ -353,7 +353,7 @@ START_TEST(device_resolutions)
 		.profiles = {
 			{
 			.resolutions = {
-				{ .xres = 100, .yres = 200, .hz = 1000 },
+				{ .xres = 100, .yres = 200, .hz = 1000, .dpi_min = 50, .dpi_max = 5000},
 				{ .xres = 200, .yres = 300, .hz = 1000, .active = true },
 				{ .xres = 300, .yres = 400, .hz = 1000 },
 			},
@@ -394,11 +394,16 @@ START_TEST(device_resolutions)
 			yres = ratbag_resolution_get_dpi_y(res);
 			rate = ratbag_resolution_get_report_rate(res);
 			is_active = ratbag_resolution_is_active(res);
+			dpi_min = ratbag_resolution_get_dpi_minimum(res);
+			dpi_max = ratbag_resolution_get_dpi_maximum(res);
 
 			ck_assert_int_eq(xres, i * 1000 + (j + 1) * 100);
 			ck_assert_int_eq(yres, i * 1000 + (j + 1) * 100 + 100);
 			ck_assert_int_eq(xres, ratbag_resolution_get_dpi(res));
 			ck_assert_int_eq(is_active, (j == 1));
+
+			ck_assert_int_eq(dpi_min, 50);
+			ck_assert_int_eq(dpi_max, 5000);
 
 			ck_assert_int_eq(rate, (i + 1) * 1000);
 

--- a/test/test-device.c
+++ b/test/test-device.c
@@ -34,6 +34,7 @@
 #include <sys/resource.h>
 
 #include "libratbag.h"
+#include "libratbag-util.h"
 #include "libratbag-test.h"
 
 static void
@@ -342,7 +343,7 @@ START_TEST(device_resolutions)
 	struct ratbag_resolution *res;
 	int nprofiles, nresolutions;
 	int i, j;
-	int xres, yres, rate, dpi_min, dpi_max;
+	int xres, yres, rate;
 	int device_freed_count = 0;
 	bool is_active;
 
@@ -388,22 +389,27 @@ START_TEST(device_resolutions)
 		ck_assert_int_eq(nresolutions, 3);
 
 		for (j = 0; j < nresolutions; j++) {
+			unsigned int dpis[200];
+			int ndpis = ARRAY_LENGTH(dpis);
+
 			res = ratbag_profile_get_resolution(p, j);
 
 			xres = ratbag_resolution_get_dpi_x(res);
 			yres = ratbag_resolution_get_dpi_y(res);
 			rate = ratbag_resolution_get_report_rate(res);
 			is_active = ratbag_resolution_is_active(res);
-			dpi_min = ratbag_resolution_get_dpi_minimum(res);
-			dpi_max = ratbag_resolution_get_dpi_maximum(res);
+
+			ndpis = ratbag_resolution_get_dpi_list(res, dpis, ndpis);
+			ck_assert_int_lt(ndpis, ARRAY_LENGTH(dpis));
+			ck_assert_int_gt(ndpis, 20);
 
 			ck_assert_int_eq(xres, i * 1000 + (j + 1) * 100);
 			ck_assert_int_eq(yres, i * 1000 + (j + 1) * 100 + 100);
 			ck_assert_int_eq(xres, ratbag_resolution_get_dpi(res));
 			ck_assert_int_eq(is_active, (j == 1));
 
-			ck_assert_int_eq(dpi_min, 50);
-			ck_assert_int_eq(dpi_max, 5000);
+			ck_assert_int_eq(dpis[0], 50);
+			ck_assert_int_eq(dpis[ndpis - 1], 5000);
 
 			ck_assert_int_eq(rate, (i + 1) * 1000);
 

--- a/tools/ratbag-command.c
+++ b/tools/ratbag-command.c
@@ -433,6 +433,8 @@ ratbag_cmd_info(const struct ratbag_cmd *cmd,
 		_cleanup_profile_ struct ratbag_profile *profile = NULL;
 		_cleanup_resolution_ struct ratbag_resolution *res0 = NULL;
 		int dpi, rate;
+		unsigned int dpis[300];
+		int ndpis = ARRAY_LENGTH(dpis);
 
 		profile = ratbag_device_get_profile(device, i);
 		if (!profile)
@@ -447,9 +449,8 @@ ratbag_cmd_info(const struct ratbag_cmd *cmd,
 		printf("    Resolutions:\n");
 
 		res0 = ratbag_profile_get_resolution(profile, 0);
-		printf("      Range: [%d, %d]\n",
-		       ratbag_resolution_get_dpi_minimum(res0),
-		       ratbag_resolution_get_dpi_maximum(res0));
+		ndpis = ratbag_resolution_get_dpi_list(res0, dpis, ndpis);
+		printf("      Range: [%d, %d]\n", dpis[0], dpis[ndpis - 1]);
 
 		for (unsigned int j = 0; j < ratbag_profile_get_num_resolutions(profile); j++) {
 			_cleanup_resolution_ struct ratbag_resolution *res = NULL;

--- a/tools/ratbag-command.c
+++ b/tools/ratbag-command.c
@@ -962,7 +962,7 @@ ratbag_cmd_resolution_dpi_get(const struct ratbag_cmd *cmd,
 
 	resolution = options->resolution;
 	dpi = ratbag_resolution_get_dpi(resolution);
-	printf("%d\n", dpi);
+	printf("%ddpi\n", dpi);
 
 	return SUCCESS;
 }

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -421,6 +421,12 @@ def func_dpi_get(r, args):
         print("{}dpi".format(r.resolution[0]))
 
 
+def func_dpi_get_all(r, args):
+    r, p, d = find_resolution(r, args)
+    dpis = r.resolutions
+    print(" ".join([str(x) for x in dpis]))
+
+
 def func_dpi_set(r, args):
     r, p, d = find_resolution(r, args)
     r.resolution = (args.dpi_n[0], args.dpi_n[1])
@@ -857,6 +863,12 @@ active resolution of the active profile if none are given.""",
                 name: 'get',
                 help_str: 'Show current DPI value',
                 func: func_dpi_get,
+            },
+            {
+                of_type: command,
+                name: 'get-all',
+                help_str: 'Show all available DPIs',
+                func: func_dpi_get_all,
             },
             {
                 of_type: command,

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -418,7 +418,7 @@ def func_dpi_get(r, args):
     if RatbagdResolution.CAP_SEPARATE_XY_RESOLUTION in r.capabilities:
         print("{}x{}dpi".format(r.resolution[0], r.resolution[1]))
     else:
-        print(r.resolution[0])
+        print("{}dpi".format(r.resolution[0]))
 
 
 def func_dpi_set(r, args):

--- a/tools/ratbagctl.test.in
+++ b/tools/ratbagctl.test.in
@@ -278,7 +278,7 @@ class TestRatbagCtlDPI(TestRatbagCtl):
     def test_dpi_get(self):
         command = "DPI get"
         r = self.launch_good_test(command + " test_device")
-        self.assertEqual(int(r), 200)
+        self.assertEqual(int(r[:-3]), 200) # drop 'dpi' suffix
         self.setProfile(1)
         r = self.launch_good_test(command + " test_device")
         self.assertEqual(r, "1300x1400dpi")
@@ -290,11 +290,11 @@ class TestRatbagCtlDPI(TestRatbagCtl):
         command = "DPI set"
         self.setProfile(0)
         r = self.launch_good_test("DPI get test_device")
-        res = int(r) + 50
+        res = int(r[:-3]) + 50 # drop 'dpi' suffix
         r = self.launch_good_test(command + " {} test_device".format(res))
         self.assertEqual(r, '')
         r = self.launch_good_test("DPI get test_device")
-        self.assertEqual(int(r), res)
+        self.assertEqual(int(r[:-3]), res) # drop 'dpi' suffix
         self.launch_fail_test(command)
         self.launch_fail_test(command + " X test_device")
         self.launch_fail_test(command + " 100 test_device X")
@@ -325,7 +325,7 @@ class TestRatbagCtlDPI(TestRatbagCtl):
         r = self.launch_good_test("Profile 1 Resolution 1 DPI get test_device")
         self.assertEqual(r, "1200x1300dpi")
         r = self.launch_good_test("Resolution 2 DPI get test_device")
-        self.assertEqual(int(r), 300)
+        self.assertEqual(int(r[:-3]), 300) # drop 'dpi' suffix
         self.launch_fail_test("Profile 1 Profile 1 DPI get test_device")
         self.launch_fail_test("Profile 1 Resolution 1 Resolution 2 DPI get test_device")
 

--- a/tools/ratbagctl.test.in
+++ b/tools/ratbagctl.test.in
@@ -286,6 +286,15 @@ class TestRatbagCtlDPI(TestRatbagCtl):
         self.launch_fail_test(command + " 1 test_device")
         self.launch_fail_test(command + " test_device X")
 
+    def test_dpi_get_all_self(self):
+        dpi_list = "50 100 150 200 250 300 350 400 450 500 550 600 650 700 750 800 850 900 950 1000 1100 1200 1300 1400 1500 1600 1700 1800 1900 2000 2100 2200 2300 2400 2500 2600 2800 3000 3200 3400 3600 3800 4000 4200 4400 4600 4800 5000"
+        command = "DPI get-all"
+        r = self.launch_good_test(command + " test_device")
+        self.assertEqual(r, dpi_list)
+        self.setProfile(1)
+        r = self.launch_good_test(command + " test_device")
+        self.assertEqual(r, dpi_list)
+
     def test_dpi_set(self):
         command = "DPI set"
         self.setProfile(0)

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -581,14 +581,9 @@ class RatbagdResolution(_RatbagdDBus):
         self._set_dbus_property("ReportRate", "u", rate)
 
     @GObject.Property
-    def maximum(self):
-        """The maximum possible resolution."""
-        return self._get_dbus_property("Maximum")
-
-    @GObject.Property
-    def minimum(self):
-        """The minimum possible resolution."""
-        return self._get_dbus_property("Minimum")
+    def resolutions(self):
+        """The list of supported DPI values"""
+        return self._get_dbus_property("Resolutions")
 
     @GObject.Property
     def is_active(self):


### PR DESCRIPTION
This builds on top of #392 

Changes from a dpi min/max to a discrete list of "here are the resolutions we support". This makes it easier for clients to do the right thing.