### PR TITLE
Add a list of supported report rates to the resolution

### DIFF
--- a/doc/dbus.rst
+++ b/doc/dbus.rst
@@ -292,6 +292,18 @@ org.freedesktop.ratbag1.Resolution
         capability, changing the report rate on one resolution will
         change the report rate on all resolutions.
 
+    .. js:attribute:: ReportRates
+
+        :type: au
+        :flags: read-write, constant
+
+        A list of permitted report rates. Values in this list may be used
+        in the :js:attr:`ReportRate` property. This list is always sorted
+        ascending, the lowest report rate is the first item in the list.
+
+        This list may be empty if the device does not support reading and/or
+        writing to resolutions.
+
     .. js:function:: SetDefault() → ()
 
         Set this resolution to be the default

--- a/doc/dbus.rst
+++ b/doc/dbus.rst
@@ -278,6 +278,9 @@ org.freedesktop.ratbag1.Resolution
         the :js:attr:`Resolution` property. This list is always sorted
         ascending, the lowest resolution is the first item in the list.
 
+        This list may be empty if the device does not support reading and/or
+        writing to resolutions.
+
     .. js:attribute:: ReportRate
 
         :type: u

--- a/ratbagd/ratbagd-test.c
+++ b/ratbagd/ratbagd-test.c
@@ -64,7 +64,9 @@ static const struct ratbag_test_device ratbagd_test_device_descr = {
 				}
 			},
 			.resolutions = {
-				{ .xres = 100, .yres = 200, .hz = 1000, .dpi_min = 50, .dpi_max = 5000 },
+				{ .xres = 100, .yres = 200, .hz = 1000,
+					.dpi_min = 50, .dpi_max = 5000,
+					.report_rates = { 500, 1000 } },
 				{ .xres = 200, .yres = 300, .hz = 1000, .active = true, .dflt = true },
 				{ .xres = 300, .yres = 400, .hz = 1000 },
 			},

--- a/src/driver-etekcity.c
+++ b/src/driver-etekcity.c
@@ -430,6 +430,7 @@ etekcity_read_profile(struct ratbag_profile *profile)
 	unsigned int report_rate;
 	int dpi_x, dpi_y, hz;
 	int rc;
+	unsigned int report_rates[] = { 125, 250, 500, 1000 };
 
 	assert(profile->index <= ETEKCITY_PROFILE_MAX);
 
@@ -446,12 +447,9 @@ etekcity_read_profile(struct ratbag_profile *profile)
 		return;
 
 	/* first retrieve the report rate, it is set per profile */
-	switch (setting_report->report_rate) {
-	case 0x00: report_rate = 125; break;
-	case 0x01: report_rate = 250; break;
-	case 0x02: report_rate = 500; break;
-	case 0x03: report_rate = 1000; break;
-	default:
+	if (setting_report->report_rate < ARRAY_LENGTH(report_rates)) {
+		report_rate = report_rates[setting_report->report_rate];
+	} else {
 		log_error(device->ratbag,
 			  "error while reading the report rate of the mouse (0x%02x)\n",
 			  buf[26]);
@@ -473,6 +471,9 @@ etekcity_read_profile(struct ratbag_profile *profile)
 		ratbag_resolution_set_cap(resolution,
 					  RATBAG_RESOLUTION_CAP_SEPARATE_XY_RESOLUTION);
 		resolution->is_active = (resolution->index == setting_report->current_dpi);
+
+		ratbag_resolution_set_report_rate_list(resolution, report_rates,
+						       ARRAY_LENGTH(report_rates));
 	}
 
 	ratbag_profile_for_each_button(profile, button)

--- a/src/driver-gskill.c
+++ b/src/driver-gskill.c
@@ -988,6 +988,8 @@ gskill_read_resolutions(struct ratbag_profile *profile,
 
 	for (i = 0; i < report->dpi_num; i++) {
 		_cleanup_resolution_ struct ratbag_resolution *resolution;
+		unsigned int rates[] = { 500, 1000 }; /* let's assume that is true */
+
 		dpi_x = report->dpi_levels[i].x * GSKILL_DPI_UNIT;
 		dpi_y = report->dpi_levels[i].y * GSKILL_DPI_UNIT;
 
@@ -1001,6 +1003,8 @@ gskill_read_resolutions(struct ratbag_profile *profile,
 
 		ratbag_resolution_set_dpi_list_from_range(resolution,
 							  GSKILL_MIN_DPI, GSKILL_MAX_DPI);
+		ratbag_resolution_set_report_rate_list(resolution, rates,
+						       ARRAY_LENGTH(rates));
 	}
 }
 

--- a/src/driver-gskill.c
+++ b/src/driver-gskill.c
@@ -972,6 +972,7 @@ gskill_write_button_macro(struct ratbag_device *device,
 
 	return 0;
 }
+
 static void
 gskill_read_resolutions(struct ratbag_profile *profile,
 			struct gskill_profile_report *report)

--- a/src/driver-gskill.c
+++ b/src/driver-gskill.c
@@ -997,6 +997,9 @@ gskill_read_resolutions(struct ratbag_profile *profile,
 
 		ratbag_resolution_set_cap(resolution,
 					  RATBAG_RESOLUTION_CAP_SEPARATE_XY_RESOLUTION);
+
+		ratbag_resolution_set_dpi_list_from_range(resolution,
+							  GSKILL_MIN_DPI, GSKILL_MAX_DPI);
 	}
 }
 

--- a/src/driver-hidpp10.c
+++ b/src/driver-hidpp10.c
@@ -397,6 +397,10 @@ hidpp10drv_read_profile(struct ratbag_profile *profile)
 	uint16_t xres, yres;
 	uint8_t idx;
 
+	/* 0x64 USB_REFRESH_RATE has time between reports in ms. so let's
+	 * assume the 1000/500/250 rates exist on the devices */
+	unsigned int rates[] = {250, 500, 1000};
+
 	drv_data = ratbag_get_drv_data(device);
 	hidpp10 = drv_data->dev;
 	rc = hidpp10_get_profile(hidpp10, profile->index, &p);
@@ -449,6 +453,9 @@ hidpp10drv_read_profile(struct ratbag_profile *profile)
 
 			ratbag_resolution_set_dpi_list(res, dpis, hidpp10->dpi_count);
 		}
+
+		ratbag_resolution_set_report_rate_list(res, rates,
+						       ARRAY_LENGTH(rates));
 	}
 
 	ratbag_profile_for_each_button(profile, button)

--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -669,6 +669,7 @@ hidpp20drv_read_resolution_dpi(struct ratbag_profile *profile)
 
 		ratbag_profile_for_each_resolution(profile, res) {
 			struct hidpp20_sensor *sensor;
+			unsigned int rate = 500; /* let's assume that one is just present */
 
 			/* We only look at the first sensor. Multiple
 			 * sensors is too niche to care about right now */
@@ -679,6 +680,7 @@ hidpp20drv_read_resolution_dpi(struct ratbag_profile *profile)
 			ratbag_resolution_set_dpi_list_from_range(res,
 								  sensor->dpi_min,
 								  sensor->dpi_max);
+			ratbag_resolution_set_report_rate_list(res, &rate, 1);
 
 			/* FIXME: we mark all resolutions as active because
 			 * they are from different sensors */
@@ -866,6 +868,7 @@ hidpp20drv_read_profile_8100(struct ratbag_profile *profile)
 
 	ratbag_profile_for_each_resolution(profile, res) {
 		struct hidpp20_sensor *sensor;
+		unsigned int rate = p->report_rate;
 
 		/* We only look at the first sensor. Multiple
 		 * sensors is too niche to care about right now */
@@ -888,7 +891,7 @@ hidpp20drv_read_profile_8100(struct ratbag_profile *profile)
 		ratbag_resolution_set_dpi_list_from_range(res,
 							  sensor->dpi_min,
 							  sensor->dpi_max);
-
+		ratbag_resolution_set_report_rate_list(res, &rate, 1);
 	}
 }
 

--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -52,9 +52,9 @@
 #define HIDPP_CAP_BUTTON_KEY_1b04			(1 << 2)
 #define HIDPP_CAP_BATTERY_LEVEL_1000			(1 << 3)
 #define HIDPP_CAP_KBD_REPROGRAMMABLE_KEYS_1b00		(1 << 4)
-#define HIDPP_CAP_COLOR_LED_EFFECTS_8070			(1 << 5)
+#define HIDPP_CAP_COLOR_LED_EFFECTS_8070		(1 << 5)
 #define HIDPP_CAP_ONBOARD_PROFILES_8100			(1 << 6)
-#define HIDPP_CAP_LED_SW_CONTROL_1300            (1 << 7)
+#define HIDPP_CAP_LED_SW_CONTROL_1300			(1 << 7)
 
 struct hidpp20drv_data {
 	struct hidpp20_device *dev;

--- a/src/driver-logitech-g300.c
+++ b/src/driver-logitech-g300.c
@@ -396,6 +396,7 @@ logitech_g300_read_profile(struct ratbag_profile *profile)
 		ratbag_resolution_set_dpi_list_from_range(resolution,
 							  LOGITECH_G300_DPI_MIN,
 							  LOGITECH_G300_DPI_MAX);
+		ratbag_resolution_set_report_rate_list(resolution, &hz, 1);
 	}
 
 	ratbag_profile_for_each_button(profile, button)

--- a/src/driver-roccat.c
+++ b/src/driver-roccat.c
@@ -704,6 +704,7 @@ roccat_read_profile(struct ratbag_profile *profile)
 	unsigned int report_rate;
 	int dpi_x, dpi_y, hz;
 	int rc;
+	unsigned int report_rates[] = { 125, 250, 500, 1000 };
 
 	assert(profile->index <= ROCCAT_PROFILE_MAX);
 
@@ -720,12 +721,9 @@ roccat_read_profile(struct ratbag_profile *profile)
 		return;
 
 	/* first retrieve the report rate, it is set per profile */
-	switch (setting_report->report_rate) {
-	case 0x00: report_rate = 125; break;
-	case 0x01: report_rate = 250; break;
-	case 0x02: report_rate = 500; break;
-	case 0x03: report_rate = 1000; break;
-	default:
+	if (setting_report->report_rate < ARRAY_LENGTH(report_rates)) {
+		report_rate = report_rates[setting_report->report_rate];
+	} else {
 		log_error(device->ratbag,
 			  "error while reading the report rate of the mouse (0x%02x)\n",
 			  buf[26]);
@@ -747,6 +745,9 @@ roccat_read_profile(struct ratbag_profile *profile)
 		ratbag_resolution_set_cap(resolution,
 					  RATBAG_RESOLUTION_CAP_SEPARATE_XY_RESOLUTION);
 		resolution->is_active = (resolution->index == setting_report->current_dpi);
+
+		ratbag_resolution_set_report_rate_list(resolution, report_rates,
+						       ARRAY_LENGTH(report_rates));
 	}
 
 	ratbag_profile_for_each_button(profile, button)

--- a/src/driver-test.c
+++ b/src/driver-test.c
@@ -191,6 +191,7 @@ test_read_profile(struct ratbag_profile *profile)
 
 	for (i = 0; i < d->num_resolutions; i++) {
 		_cleanup_resolution_ struct ratbag_resolution *res;
+		size_t nrates = 0;
 
 		r = &p->resolutions[i];
 
@@ -201,6 +202,17 @@ test_read_profile(struct ratbag_profile *profile)
 			ratbag_resolution_set_dpi_list_from_range(res,
 								  r0->dpi_min,
 								  r0->dpi_max);
+
+		for (size_t r = 0; r < ARRAY_LENGTH(r0->report_rates); r++) {
+			if (r0->report_rates[r] > 0)
+				nrates++;
+		}
+
+		if (nrates > 0)
+			ratbag_resolution_set_report_rate_list(res,
+							       r0->report_rates,
+							       nrates);
+
 		res->is_active = r->active;
 		if (r->active)
 			active_set = true;

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -1318,6 +1318,40 @@ int hidpp20_adjustable_dpi_set_sensor_dpi(struct hidpp20_device *device,
 }
 
 /* -------------------------------------------------------------------------- */
+/* 0x8060 - Adjustable Report Rate                                            */
+/* -------------------------------------------------------------------------- */
+
+#define CMD_ADJUSTABLE_REPORT_RATE_GET_REPORT_RATE_LIST 0x00
+
+int hidpp20_adjustable_report_rate_get_report_rate_list(struct hidpp20_device *device,
+							uint8_t *bitflags_ms)
+{
+	uint8_t feature_index;
+	int rc;
+	union hidpp20_message msg = {
+		.msg.report_id = REPORT_ID_LONG,
+		.msg.device_idx = device->index,
+		.msg.address = CMD_ADJUSTABLE_REPORT_RATE_GET_REPORT_RATE_LIST,
+		.msg.parameters[0] = 0,
+	};
+
+	feature_index = hidpp_root_get_feature_idx(device,
+						   HIDPP_PAGE_ADJUSTABLE_REPORT_RATE);
+	if (feature_index == 0)
+		return -ENOTSUP;
+
+	msg.msg.sub_id = feature_index;
+
+	rc = hidpp20_request_command(device, &msg);
+	if (rc)
+		return rc;
+
+	*bitflags_ms = msg.msg.parameters[0];
+
+	return 0;
+}
+
+/* -------------------------------------------------------------------------- */
 /* 0x8100 - Onboard Profiles                                                  */
 /* -------------------------------------------------------------------------- */
 

--- a/src/hidpp20.h
+++ b/src/hidpp20.h
@@ -376,6 +376,13 @@ int hidpp20_adjustable_dpi_set_sensor_dpi(struct hidpp20_device *device,
 
 #define HIDPP_PAGE_ADJUSTABLE_REPORT_RATE		0x8060
 
+/**
+ * set the bitmap_ms to the supported report rates. Bits enabled reflect a
+ * supported report rate, where bit 0 equals 1ms, bit 1 2ms, bit 2 3ms, etc.
+ */
+int hidpp20_adjustable_report_rate_get_report_rate_list(struct hidpp20_device *device,
+							uint8_t *bitflags_ms);
+
 /* -------------------------------------------------------------------------- */
 /* 0x8070v4 - Color LED effects                                               */
 /* -------------------------------------------------------------------------- */

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -525,6 +525,7 @@ ratbag_resolution_set_dpi_list(struct ratbag_resolution *res,
 		if (i > 0)
 			assert(dpis[i] > dpis[i - 1]);
 	}
+	res->ndpis = ndpis;
 }
 
 static inline void

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -261,6 +261,10 @@ struct ratbag_resolution {
 	unsigned int dpi_x;	/**< x resolution in dpi */
 	unsigned int dpi_y;	/**< y resolution in dpi */
 	unsigned int hz;	/**< report rate in Hz */
+
+	unsigned int rates[5];
+	size_t nrates;
+
 	bool is_active;
 	bool is_default;
 	uint32_t capabilities;
@@ -526,6 +530,22 @@ ratbag_resolution_set_dpi_list(struct ratbag_resolution *res,
 			assert(dpis[i] > dpis[i - 1]);
 	}
 	res->ndpis = ndpis;
+}
+
+static inline void
+ratbag_resolution_set_report_rate_list(struct ratbag_resolution *res,
+				       unsigned int *rates,
+				       size_t nrates)
+{
+	assert(nrates <= ARRAY_LENGTH(res->rates));
+	_Static_assert(sizeof(*rates) == sizeof(*res->rates), "Mismatching size");
+
+	for (size_t i = 0; i < nrates; i++) {
+		res->rates[i] = rates[i];
+		if (i > 0)
+			assert(rates[i] > rates[i - 1]);
+	}
+	res->nrates = nrates;
 }
 
 static inline void

--- a/src/libratbag-test.h
+++ b/src/libratbag-test.h
@@ -57,6 +57,7 @@ struct ratbag_test_resolution {
 	uint32_t caps;
 
 	int dpi_min, dpi_max;
+	unsigned int report_rates[5];
 };
 
 struct ratbag_test_color {

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -1158,6 +1158,24 @@ ratbag_resolution_get_report_rate(struct ratbag_resolution *resolution)
 	return resolution->hz;
 }
 
+LIBRATBAG_EXPORT size_t
+ratbag_resolution_get_report_rate_list(struct ratbag_resolution *resolution,
+				       unsigned int *rates,
+				       size_t nrates)
+{
+	_Static_assert(sizeof(*rates) == sizeof(*resolution->rates), "type mismatch");
+
+	assert(nrates > 0);
+
+	if (resolution->nrates == 0)
+		return 0;
+
+	memcpy(rates, resolution->rates,
+	       sizeof(unsigned int) * min(nrates, resolution->nrates));
+
+	return resolution->nrates;
+}
+
 LIBRATBAG_EXPORT int
 ratbag_resolution_is_active(const struct ratbag_resolution *resolution)
 {

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -1131,6 +1131,9 @@ ratbag_resolution_get_dpi_list(struct ratbag_resolution *resolution,
 
 	assert(nres > 0);
 
+	if (resolution->ndpis == 0)
+		return 0;
+
 	memcpy(resolutions, resolution->dpis,
 	       sizeof(unsigned int) * min(nres, resolution->ndpis));
 

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -247,6 +247,8 @@ ratbag_sanity_check_device(struct ratbag_device *device)
 	}
 
 	ratbag_device_for_each_profile(device, profile) {
+		struct ratbag_resolution *resolution;
+
 		/* Allow max 1 active profile */
 		if (profile->is_active) {
 			if (has_active) {
@@ -265,6 +267,30 @@ ratbag_sanity_check_device(struct ratbag_device *device)
 						  device->name,
 						  nres);
 				goto out;
+		}
+
+		ratbag_profile_for_each_resolution(profile, resolution) {
+			unsigned int vals[300];
+			unsigned int nvals = ARRAY_LENGTH(vals);
+
+			if (!ratbag_device_has_capability(device, RATBAG_DEVICE_CAP_RESOLUTION))
+				break;
+
+			nvals = ratbag_resolution_get_dpi_list(resolution, vals, nvals);
+			if (nvals == 0) {
+				log_bug_libratbag(ratbag,
+						  "%s: invalid dpi list\n",
+						  device->name);
+				goto out;
+			}
+
+			nvals = ratbag_resolution_get_report_rate_list(resolution, vals, nvals);
+			if (nvals == 0) {
+				log_bug_libratbag(ratbag,
+						  "%s: invalid report rate list\n",
+						  device->name);
+				goto out;
+			}
 		}
 	}
 

--- a/src/libratbag.h
+++ b/src/libratbag.h
@@ -939,6 +939,29 @@ ratbag_resolution_get_report_rate(struct ratbag_resolution *resolution);
 /**
  * @ingroup resolution
  *
+ * Get the number of report rates in Hz available for this resolution.
+ * The list of report rates is sorted in ascending order but may be filtered
+ * by libratbag and does not necessarily reflect all report rates supported by
+ * the physical device.
+ *
+ * This function writes at most nrates values but returns the number of
+ * report rates available on this resolution. In other words, if it returns a
+ * number larger than nrates, call it again with an array the size of the
+ * return value.
+ *
+ * @param[out] rates Set to the supported report rates in ascending order
+ * @param[in] nrates The number of elements in resolutions
+ *
+ * @return The number of valid items in rates. If the returned value
+ * is larger than nrates, the list was truncated.
+ */
+size_t
+ratbag_resolution_get_report_rate_list(struct ratbag_resolution *resolution,
+				       unsigned int *rates,
+				       size_t nrates);
+/**
+ * @ingroup resolution
+ *
  * Activate the given resolution mode. If the mode is not configured, this
  * function returns an error and the result is undefined.
  *

--- a/src/libratbag.i
+++ b/src/libratbag.i
@@ -10,7 +10,7 @@
 %}
 #define __attribute__(x)
 
-/* custom typemap for handling ratbag_resolution_get_dpi */
+/* custom typemap for handling ratbag_resolution_get_dpi_list */
 %typemap(in) (unsigned int *resolutions, size_t nres) {
   unsigned int i;
   if (!PyList_Check($input)) {
@@ -42,7 +42,7 @@
   if ($1)
     free($1);
 }
-/* END OF custom typemap for handling ratbag_resolution_get_dpi */
+/* END OF custom typemap for handling ratbag_resolution_get_dpi_list */
 
 /*  Parse the header file to generate wrappers */
 %include "libratbag.h"

--- a/src/libratbag.i
+++ b/src/libratbag.i
@@ -44,6 +44,14 @@
 }
 /* END OF custom typemap for handling ratbag_resolution_get_dpi_list */
 
+
+/* custom typemap for handling ratbag_resolution_get_report_rate_list */
+/* We re-use the ratbag_resolution_get_dpi_list typemap */
+%typemap(in) (unsigned int *rates, size_t nrates) = (unsigned int *resolutions, size_t nres);
+%typemap(argout) (unsigned int *rates, size_t nrates) = (unsigned int *resolutions, size_t nres);
+%typemap(freearg) (unsigned int *rates, size_t nrates) = (unsigned int *resolutions, size_t nres);
+/* END OF custom typemap for handling ratbag_resolution_get_report_rate_list */
+
 /*  Parse the header file to generate wrappers */
 %include "libratbag.h"
 %include "libratbag-enums.h"

--- a/test/test-device.c
+++ b/test/test-device.c
@@ -59,7 +59,9 @@ const struct ratbag_test_device sane_device = {
 	.profiles = {
 		{
 		.resolutions = {
-			{ .xres = 100, .yres = 200, .hz = 1000 },
+			{ .xres = 100, .yres = 200, .hz = 1000,
+				.dpi_min = 100, .dpi_max = 5000,
+				.report_rates = { 500, 1000 } },
 			{ .xres = 200, .yres = 300, .hz = 1000 },
 			{ .xres = 300, .yres = 400, .hz = 1000 },
 		},
@@ -354,7 +356,9 @@ START_TEST(device_resolutions)
 		.profiles = {
 			{
 			.resolutions = {
-				{ .xres = 100, .yres = 200, .hz = 1000, .dpi_min = 50, .dpi_max = 5000},
+				{ .xres = 100, .yres = 200, .hz = 1000,
+					.dpi_min = 50, .dpi_max = 5000,
+					.report_rates = { 500, 1000 } },
 				{ .xres = 200, .yres = 300, .hz = 1000, .active = true },
 				{ .xres = 300, .yres = 400, .hz = 1000 },
 			},

--- a/tools/ratbagc.py
+++ b/tools/ratbagc.py
@@ -485,6 +485,13 @@ class RatbagdResolution(metaclass=MetaRatbag):
         return dpis[:n]
 
     @property
+    def report_rates(self):
+        """The list of supported report rates"""
+        rates = [0 for i in range(300)]
+        n = libratbag.ratbag_resolution_get_report_rate_list(self._res, rates)
+        return rates[:n]
+
+    @property
     def is_active(self):
         """True if this is the currently active resolution, False
         otherwise"""

--- a/tools/ratbagctl.1
+++ b/tools/ratbagctl.1
@@ -100,6 +100,9 @@ resolution of the active profile if none are given.
 .B dpi get
 Print the dpi value
 .TP 8
+.B dpi get-all
+Print the supported dpi values
+.TP 8
 .B dpi set N
 Set the dpi value to N
 .SH Rate Commands

--- a/tools/ratbagctl.1
+++ b/tools/ratbagctl.1
@@ -112,6 +112,9 @@ resolution of the active profile if none are given.
 .B rate get
 Print the report rate in ms
 .TP 8
+.B rate get-all
+Print the supported report rates in ms
+.TP 8
 .B rate set N
 Set the report rate in N ms
 .SH Button Commands

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -450,6 +450,12 @@ def func_report_rate_get(r, args):
     print(r.report_rate)
 
 
+def func_report_rate_get_all(r, args):
+    r, p, d = find_resolution(r, args)
+    rates = r.report_rates
+    print(" ".join([str(x) for x in rates]))
+
+
 def func_report_rate_set(r, args):
     r, p, d = find_resolution(r, args)
     r.report_rate = args.rate_n
@@ -914,6 +920,12 @@ active resolution of the active profile if none are given.""",
                 name: 'get',
                 help_str: 'Show current report rate',
                 func: func_report_rate_get,
+            },
+            {
+                of_type: command,
+                name: 'get-all',
+                help_str: 'Show all available report rates',
+                func: func_report_rate_get_all,
             },
             {
                 of_type: command,

--- a/tools/ratbagctl.test.in
+++ b/tools/ratbagctl.test.in
@@ -353,6 +353,15 @@ class TestRatbagCtlReportRate(TestRatbagCtl):
         self.launch_fail_test(command + " 1 test_device")
         self.launch_fail_test(command + " test_device X")
 
+    def test_rate_get_all(self):
+        rate_list = "500 1000"
+        command = "rate get-all"
+        r = self.launch_good_test(command + " test_device")
+        self.assertEqual(r, rate_list)
+        self.setProfile(1)
+        r = self.launch_good_test(command + " test_device")
+        self.assertEqual(r, rate_list)
+
     def test_rate_set(self):
         command = "rate set"
         r = self.launch_good_test("rate get test_device")

--- a/tools/ratbagctl.test.in
+++ b/tools/ratbagctl.test.in
@@ -286,7 +286,7 @@ class TestRatbagCtlDPI(TestRatbagCtl):
         self.launch_fail_test(command + " 1 test_device")
         self.launch_fail_test(command + " test_device X")
 
-    def test_dpi_get_all_self(self):
+    def test_dpi_get_all(self):
         dpi_list = "50 100 150 200 250 300 350 400 450 500 550 600 650 700 750 800 850 900 950 1000 1100 1200 1300 1400 1500 1600 1700 1800 1900 2000 2100 2200 2300 2400 2500 2600 2800 3000 3200 3400 3600 3800 4000 4200 4400 4600 4800 5000"
         command = "DPI get-all"
         r = self.launch_good_test(command + " test_device")

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -599,6 +599,11 @@ class RatbagdResolution(_RatbagdDBus):
         return self._get_dbus_property("Resolutions")
 
     @GObject.Property
+    def report_rates(self):
+        """The list of supported report rates"""
+        return self._get_dbus_property("ReportRates")
+
+    @GObject.Property
     def is_active(self):
         """True if this is the currently active resolution, False
         otherwise"""


### PR DESCRIPTION
Basically the same approach as for the dpi list we already have. Some of the rates are hardcoded, but we can fill those in later.

And a bunch of cleanup patches. 