### PR TITLE
hidpp20 keybindings support (again)

### DIFF
--- a/src/driver-etekcity.c
+++ b/src/driver-etekcity.c
@@ -366,10 +366,20 @@ etekcity_read_button(struct ratbag_button *button)
 	unsigned j;
 	int rc;
 
+	device = button->profile->device;
 	action = etekcity_button_to_action(button->profile, button->index);
 	if (action)
 		ratbag_button_set_action(button, action);
 	button->type = etekcity_raw_to_button_type(button->index);
+
+	if (action->type == RATBAG_BUTTON_ACTION_TYPE_KEY) {
+		if (ratbag_button_macro_new_from_key(button)) {
+			log_error(device->ratbag,
+				  "Error while reading button %d\n",
+				  button->index);
+			button->action.type = RATBAG_BUTTON_ACTION_TYPE_NONE;
+		}
+	}
 
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_BUTTON);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_KEY);
@@ -377,7 +387,6 @@ etekcity_read_button(struct ratbag_button *button)
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_MACRO);
 
 	if (action && action->type == RATBAG_BUTTON_ACTION_TYPE_MACRO) {
-		device = button->profile->device;
 		drv_data = ratbag_get_drv_data(device);
 
 		etekcity_set_config_profile(device,

--- a/src/driver-gskill.c
+++ b/src/driver-gskill.c
@@ -1216,12 +1216,24 @@ gskill_read_button(struct ratbag_button *button)
 		act->action.key.key =
 			ratbag_hidraw_get_keycode_from_keyboard_usage(
 			    device, bcfg->params.kbd.hid_code);
+		if (ratbag_button_macro_new_from_key(button)) {
+			log_error(device->ratbag,
+				  "Error while reading button %d\n",
+				  button->index);
+			button->action.type = RATBAG_BUTTON_ACTION_TYPE_NONE;
+		}
 		break;
 	case GSKILL_BUTTON_FUNCTION_CONSUMER:
 		act->type = RATBAG_BUTTON_ACTION_TYPE_KEY;
 		act->action.key.key =
 			ratbag_hidraw_get_keycode_from_consumer_usage(
 			    device, bcfg->params.consumer.code);
+		if (ratbag_button_macro_new_from_key(button)) {
+			log_error(device->ratbag,
+				  "Error while reading button %d\n",
+				  button->index);
+			button->action.type = RATBAG_BUTTON_ACTION_TYPE_NONE;
+		}
 		break;
 	case GSKILL_BUTTON_FUNCTION_DPI_UP:
 	case GSKILL_BUTTON_FUNCTION_DPI_DOWN:

--- a/src/driver-hidpp10.c
+++ b/src/driver-hidpp10.c
@@ -178,11 +178,23 @@ hidpp10drv_map_button(struct ratbag_device *device,
 		button->action.type = RATBAG_BUTTON_ACTION_TYPE_KEY;
 		button->action.action.key.key = ratbag_hidraw_get_keycode_from_keyboard_usage(device,
 							profile.buttons[button->index].keys.key);
+		if (ratbag_button_macro_new_from_key(button)) {
+			log_error(device->ratbag,
+				  "Error while reading button %d\n",
+				  button->index);
+			button->action.type = RATBAG_BUTTON_ACTION_TYPE_NONE;
+		}
 		break;
 	case PROFILE_BUTTON_TYPE_CONSUMER_CONTROL:
 		button->action.type = RATBAG_BUTTON_ACTION_TYPE_KEY;
 		button->action.action.key.key = ratbag_hidraw_get_keycode_from_consumer_usage(device,
 							profile.buttons[button->index].consumer_control.consumer_control);
+		if (ratbag_button_macro_new_from_key(button)) {
+			log_error(device->ratbag,
+				  "Error while reading button %d\n",
+				  button->index);
+			button->action.type = RATBAG_BUTTON_ACTION_TYPE_NONE;
+		}
 		break;
 	case PROFILE_BUTTON_TYPE_SPECIAL:
 		button->action.type = RATBAG_BUTTON_ACTION_TYPE_SPECIAL;

--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -215,11 +215,23 @@ hidpp20drv_read_button_8100(struct ratbag_button *button)
 			button->action.type = RATBAG_BUTTON_ACTION_TYPE_KEY;
 			button->action.action.key.key = ratbag_hidraw_get_keycode_from_keyboard_usage(device,
 								profile->buttons[button->index].keyboard_keys.key);
+			if (ratbag_button_macro_new_from_key(button)) {
+				log_error(device->ratbag,
+					  "Error while reading button %d\n",
+					  button->index);
+				button->action.type = RATBAG_BUTTON_ACTION_TYPE_NONE;
+			}
 			break;
 		case HIDPP20_BUTTON_HID_TYPE_CONSUMER_CONTROL:
 			button->action.type = RATBAG_BUTTON_ACTION_TYPE_KEY;
 			button->action.action.key.key = ratbag_hidraw_get_keycode_from_consumer_usage(device,
 								profile->buttons[button->index].consumer_control.consumer_control);
+			if (ratbag_button_macro_new_from_key(button)) {
+				log_error(device->ratbag,
+					  "Error while reading button %d\n",
+					  button->index);
+				button->action.type = RATBAG_BUTTON_ACTION_TYPE_NONE;
+			}
 			break;
 		}
 		break;

--- a/src/driver-logitech-g300.c
+++ b/src/driver-logitech-g300.c
@@ -321,6 +321,12 @@ logitech_g300_read_button(struct ratbag_button *button)
 		key_action->type = RATBAG_BUTTON_ACTION_TYPE_KEY;
 		key_action->action.key.key = ratbag_hidraw_get_keycode_from_keyboard_usage(
 			device, button_report->key);
+		if (ratbag_button_macro_new_from_key(button)) {
+			log_error(device->ratbag,
+				  "Error while reading button %d\n",
+				  button->index);
+			button->action.type = RATBAG_BUTTON_ACTION_TYPE_NONE;
+		}
 	}
 }
 

--- a/src/driver-roccat.c
+++ b/src/driver-roccat.c
@@ -451,6 +451,15 @@ roccat_read_button(struct ratbag_button *button)
 //			button->index, drv_data->profiles[button->profile->index][3 + button->index * 3],
 //			__FILE__, __LINE__);
 
+	if (action->type == RATBAG_BUTTON_ACTION_TYPE_KEY) {
+		if (ratbag_button_macro_new_from_key(button)) {
+			log_error(device->ratbag,
+				  "Error while reading button %d\n",
+				  button->index);
+			button->action.type = RATBAG_BUTTON_ACTION_TYPE_NONE;
+		}
+	}
+
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_BUTTON);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_KEY);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_SPECIAL);

--- a/src/driver-test.c
+++ b/src/driver-test.c
@@ -70,6 +70,12 @@ test_read_button(struct ratbag_button *button)
 	case RATBAG_BUTTON_ACTION_TYPE_KEY:
 		button->action.type = RATBAG_BUTTON_ACTION_TYPE_KEY;
 		button->action.action.key.key = p->buttons[button->index].key;
+		if (ratbag_button_macro_new_from_key(button)) {
+			log_error(device->ratbag,
+				  "Error while reading button %d\n",
+				  button->index);
+			button->action.type = RATBAG_BUTTON_ACTION_TYPE_NONE;
+		}
 		break;
 	case RATBAG_BUTTON_ACTION_TYPE_MACRO:
 		button->action.type = RATBAG_BUTTON_ACTION_TYPE_MACRO;

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -478,6 +478,9 @@ ratbag_button_action_match(const struct ratbag_button_action *action,
 	return 0;
 }
 
+int
+ratbag_button_macro_new_from_key(struct ratbag_button *button);
+
 static inline void
 ratbag_resolution_set_resolution(struct ratbag_resolution *res,
 				 int dpi_x, int dpi_y, int hz)

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -481,6 +481,9 @@ ratbag_button_action_match(const struct ratbag_button_action *action,
 int
 ratbag_button_macro_new_from_key(struct ratbag_button *button);
 
+bool
+ratbag_action_keybinding_from_macro(struct ratbag_button_action *action);
+
 static inline void
 ratbag_resolution_set_resolution(struct ratbag_resolution *res,
 				 int dpi_x, int dpi_y, int hz)

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -1905,3 +1905,31 @@ ratbag_button_macro_new(const char *name)
 
 	return macro;
 }
+
+LIBRATBAG_EXPORT int
+ratbag_button_macro_new_from_key(struct ratbag_button *button)
+{
+	struct ratbag_button_macro *macro;
+	int i;
+
+	if (button->action.type != RATBAG_BUTTON_ACTION_TYPE_KEY)
+		return -EINVAL;
+
+	macro = ratbag_button_macro_new("key");
+	i = 0;
+
+	/* FIXME: handle modifiers */
+	ratbag_button_macro_set_event(macro,
+				      i++,
+				      RATBAG_MACRO_EVENT_KEY_PRESSED,
+				      button->action.action.key.key);
+	ratbag_button_macro_set_event(macro,
+				      i++,
+				      RATBAG_MACRO_EVENT_KEY_RELEASED,
+				      button->action.action.key.key);
+
+	ratbag_button_copy_macro(button, macro);
+	ratbag_button_macro_unref(macro);
+
+	return 0;
+}

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -1933,3 +1933,32 @@ ratbag_button_macro_new_from_key(struct ratbag_button *button)
 
 	return 0;
 }
+
+bool
+ratbag_action_keybinding_from_macro(struct ratbag_button_action *action)
+{
+	unsigned int key;
+	struct ratbag_macro *macro = action->macro;
+
+	if (!macro || action->type != RATBAG_BUTTON_ACTION_TYPE_MACRO)
+		return false;
+
+	if (macro->events[0].type != RATBAG_MACRO_EVENT_KEY_PRESSED)
+		return false;
+
+	key = macro->events[0].event.key;
+
+	if (macro->events[1].type != RATBAG_MACRO_EVENT_KEY_RELEASED)
+		return false;
+
+	if (key != macro->events[1].event.key)
+		return false;
+
+	if (macro->events[2].type != RATBAG_MACRO_EVENT_NONE)
+		return false;
+
+	action->type = RATBAG_BUTTON_ACTION_TYPE_KEY;
+	action->action.key.key = key;
+
+	return true;
+}

--- a/tools/ratbagc.py
+++ b/tools/ratbagc.py
@@ -676,6 +676,9 @@ class RatbagdMacro(metaclass=MetaRatbag):
         idx = 0
         while idx < len(self._macro):
             t, v = self._macro[idx]
+            if t == libratbag.RATBAG_MACRO_EVENT_NONE:
+                # macro are null terminated
+                break
             try:
                 if t == RatbagdButton.MACRO_KEY_PRESS:
                     # Check for a paired press/release event
@@ -731,7 +734,6 @@ class RatbagdMacro(metaclass=MetaRatbag):
         # e.g. have two identical key presses in a row.
         if len(self._macro) == 0 or (type, value) != self._macro[-1]:
             self._macro.append((type, value))
-            self.notify("keys")
 
 
 class RatbagdLed(metaclass=MetaRatbag):

--- a/tools/ratbagctl.test.in
+++ b/tools/ratbagctl.test.in
@@ -404,7 +404,7 @@ class TestRatbagCtlButton(TestRatbagCtl):
         r = self.launch_good_test("button 0 get test_device")
         self.assertEqual(r, "Button: 0 type left is mapped to 'button 0'")
         r = self.launch_good_test("button 1 get test_device")
-        self.assertEqual(r, "Button: 1 type middle is mapped to UNKNOWN")
+        self.assertEqual(r, "Button: 1 type middle is mapped to macro '↕3'")
         r = self.launch_good_test("button 2 get test_device")
         self.assertEqual(r, "Button: 2 type right is mapped to 'profile-cycle-up'")
         r = self.launch_good_test("button 3 get test_device")


### PR DESCRIPTION
Next step before supporting full macro write, allow to detect keybindings and translate them as macro.

Currently only onboard profiles in HID++2.0 support writing back them, so we might want to convert everyone before actually merging this (given that we will change the state of the profiles for the other drivers).

Anyway, reading works OK for HID++ 1.0 and 2.0, it would be cool if the other maintainers could give a try at their drivers so we merge it safely.

This goes on top of #401, so only the last 2 patches matter.