### PR TITLE
Merge Logitech G403 devices files.

### DIFF
--- a/data/devices/logitech-g403-wireless.device
+++ b/data/devices/logitech-g403-wireless.device
@@ -1,6 +1,0 @@
-# Logitech G403 Wireless
-[Device]
-Name=Logitech G403
-DeviceMatch=usb:046d:c082
-Driver=hidpp20
-Svg=logitech-g403.svg

--- a/data/devices/logitech-g403.device
+++ b/data/devices/logitech-g403.device
@@ -1,6 +1,6 @@
-# Logitech G403 over USB
+# Logitech G403
 [Device]
 Name=Logitech G403
-DeviceMatch=usb:046d:c083
+DeviceMatch=usb:046d:c082;usb:046d:c083
 Driver=hidpp20
 Svg=logitech-g403.svg


### PR DESCRIPTION
This is in response to a comment on PR #385 suggesting that G403 device files be merged and just use multiple IDs on DeviceMatch.

Confirmed to work, built against git and checked with my G403 `usb:046d:c083`