### PR TITLE
docs: Ensure we also check for python3 sphinx build exec suffixed without a hyphen

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -1,6 +1,6 @@
 if get_option('documentation')
 
-cmd_sphinx = find_program('sphinx-build-3')
+cmd_sphinx = find_program('sphinx-build-3', 'sphinx-build3')
 cmd_doxygen = find_program('doxygen')
 cmd_xsltproc = find_program('xsltproc')
 


### PR DESCRIPTION
Some vendors (*such as Solus*) ship python3 sphinx binaries without a `-`, so let's check for both.