### PR TITLE
use SVGs from the source dir in .devel

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -41,7 +41,7 @@ config_h.set_quoted('FALLBACK_SVG_NAME', 'fallback.svg')
 libratbag_data_dir = join_paths(get_option('prefix'),
 				get_option('datadir'),
 				'libratbag')
-libratbag_data_dir_devel = join_paths(meson.source_root(), 'data', 'devices')
+libratbag_data_dir_devel = join_paths(meson.source_root(), 'data')
 config_h.set_quoted('LIBRATBAG_DATA_DIR', libratbag_data_dir)
 
 # dependencies
@@ -276,7 +276,7 @@ data_files = files(
 )
 
 install_data(data_files,
-	     install_dir : join_paths(get_option('datadir'), 'libratbag'))
+	     install_dir : join_paths(get_option('datadir'), 'libratbag', 'devices'))
 
 data_parse_test = find_program(join_paths(meson.source_root(), 'data/devices/data-parse-test.py'))
 test('data-parse-test', data_parse_test,

--- a/ratbagd/ratbagd-device.c
+++ b/ratbagd/ratbagd-device.c
@@ -163,6 +163,11 @@ static int ratbagd_device_get_theme_svg(sd_bus_message *m,
 	const char *theme;
 	const char *svg;
 	int r;
+	const char *datadir;
+
+	datadir = getenv("LIBRATBAG_DATA_DIR");
+	if (!datadir)
+		datadir = LIBRATBAG_DATA_DIR;
 
 	r = sd_bus_message_read(m, "s", &theme);
 	if (r < 0)
@@ -176,7 +181,7 @@ static int ratbagd_device_get_theme_svg(sd_bus_message *m,
 		svg = FALLBACK_SVG_NAME;
 	}
 
-	sprintf(svg_path, "%s/%s/%s", LIBRATBAG_DATA_DIR, theme, svg);
+	snprintf(svg_path, sizeof(svg_path), "%s/%s/%s", datadir, theme, svg);
 
 	return sd_bus_reply_method_return(m, "s", svg_path);
 }

--- a/src/libratbag-data.c
+++ b/src/libratbag-data.c
@@ -446,15 +446,18 @@ ratbag_device_data_new_for_id(struct ratbag *ratbag, const struct input_id *id)
 	struct dirent **files;
 	int n, nfiles;
 	const char *datadir;
+	char devicedir[PATH_MAX] = {0};
 
 	datadir = getenv("LIBRATBAG_DATA_DIR");
 	if (!datadir)
 		datadir = LIBRATBAG_DATA_DIR;
 
-	n = scandir(datadir, &files, filter_device_files, alphasort);
+	snprintf(devicedir, sizeof(devicedir), "%s/devices", datadir);
+
+	n = scandir(devicedir, &files, filter_device_files, alphasort);
 	if (n <= 0) {
 		log_error(ratbag, "Unable to locate device files in %s: %s\n",
-			  datadir, n == 0 ? "No files found" : strerror(errno));
+			  devicedir, n == 0 ? "No files found" : strerror(errno));
 		return NULL;
 	}
 
@@ -463,7 +466,7 @@ ratbag_device_data_new_for_id(struct ratbag *ratbag, const struct input_id *id)
 		_cleanup_(freep) char *file = NULL;
 		int rc;
 
-		rc = xasprintf(&file, "%s/%s", datadir, files[n]->d_name);
+		rc = xasprintf(&file, "%s/%s", devicedir, files[n]->d_name);
 		if (rc == -1)
 			goto out;
 		if (file_data_matches(ratbag, file, id, &data))


### PR DESCRIPTION
When using ratbagctl.devel we would use the .device files
from the source dir. This patch also makes it use the .svg
files from the source dir. This makes it easier to edit the
svg and less surprising now that it follows the .devices files.

We need to treat the .device and .svg file a bit different. The
reason is that in soure the device files are in a separate dir
'data/devices' but we do not use the 'devices' dir when installed.