### PR TITLE
Don't install the default theme svgs

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -283,19 +283,6 @@ test('data-parse-test', data_parse_test,
 	      '--svg-dir', join_paths(meson.source_root(), 'data/gnome') ] + data_files)
 
 #### svg files ####
-default_svg_files = [
-	'data/default/etekcity.svg',
-	'data/default/logitech-g300.svg',
-	'data/default/logitech-g303.svg',
-	'data/default/logitech-g500s.svg',
-	'data/default/logitech-g502.svg',
-	'data/default/logitech-g700.svg',
-	'data/default/logitech-g900.svg',
-	'data/default/logitech-mx_master.svg',
-	'data/default/roccat-kone-xtd.svg'
-]
-install_data(default_svg_files,
-	     install_dir : join_paths(get_option('datadir'), 'libratbag', 'default'))
 
 gnome_svg_files = files(
 	'data/gnome/fallback.svg',


### PR DESCRIPTION
No-one appears to be using these and the efforts to create SVGs
go into the GNOME ones (used by piper). Leave them in the git tree in case
someone wants to pick them up but until we have a consumer it's not worth it
installing them.

Note: this kinda bears the question now whether we should even bother claiming to have a 'default' theme...