### PR TITLE
Convert LED effect rate in Hz to effect duration in ms

### DIFF
--- a/doc/dbus.rst
+++ b/doc/dbus.rst
@@ -426,12 +426,12 @@ org.freedesktop.ratbag1.Led
 
         The color depth of this LED as one of the constants in libratbag-enums.h
 
-    .. js:attribute:: EffectRate
+    .. js:attribute:: EffectDuration
 
         :type: u
         :flags: read-write, mutable
 
-        The effect rate in Hz, possible values are in the range 100 - 20000
+        The effect duration in ms, possible values are in the range 0 - 10000
 
     .. js:attribute:: Brightness
 

--- a/ratbagd/ratbagd-led.c
+++ b/ratbagd/ratbagd-led.c
@@ -179,28 +179,28 @@ static int ratbagd_led_set_color(sd_bus *bus,
 	return 0;
 }
 
-static int ratbagd_led_get_effect_rate(sd_bus *bus,
-				       const char *path,
-				       const char *interface,
-				       const char *property,
-				       sd_bus_message *reply,
-				       void *userdata,
-				       sd_bus_error *error)
+static int ratbagd_led_get_effect_duration(sd_bus *bus,
+					   const char *path,
+					   const char *interface,
+					   const char *property,
+					   sd_bus_message *reply,
+					   void *userdata,
+					   sd_bus_error *error)
 {
 	struct ratbagd_led *led = userdata;
 	int rate;
 
-	rate = ratbag_led_get_effect_rate(led->lib_led);
+	rate = ratbag_led_get_effect_duration(led->lib_led);
 	return sd_bus_message_append(reply, "u", rate);
 }
 
-static int ratbagd_led_set_effect_rate(sd_bus *bus,
-				       const char *path,
-				       const char *interface,
-				       const char *property,
-				       sd_bus_message *m,
-				       void *userdata,
-				       sd_bus_error *error)
+static int ratbagd_led_set_effect_duration(sd_bus *bus,
+					   const char *path,
+					   const char *interface,
+					   const char *property,
+					   sd_bus_message *m,
+					   void *userdata,
+					   sd_bus_error *error)
 {
 	struct ratbagd_led *led = userdata;
 	unsigned int rate;
@@ -210,12 +210,10 @@ static int ratbagd_led_set_effect_rate(sd_bus *bus,
 	if (r < 0)
 		return r;
 
-	if (rate < 100)
-		rate = 100;
-	else if (rate > 20000)
-		rate = 20000;
+	if (rate > 10000)
+		rate = 10000;
 
-	r = ratbag_led_set_effect_rate(led->lib_led, rate);
+	r = ratbag_led_set_effect_duration(led->lib_led, rate);
 
 	if (r == 0) {
 		sd_bus *bus = sd_bus_message_get_bus(m);
@@ -290,8 +288,8 @@ const sd_bus_vtable ratbagd_led_vtable[] = {
 				 ratbagd_led_get_color, ratbagd_led_set_color, 0,
 				 SD_BUS_VTABLE_UNPRIVILEGED|SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_PROPERTY("ColorDepth", "u", NULL, offsetof(struct ratbagd_led, colordepth), SD_BUS_VTABLE_PROPERTY_CONST),
-	SD_BUS_WRITABLE_PROPERTY("EffectRate", "u",
-				 ratbagd_led_get_effect_rate, ratbagd_led_set_effect_rate, 0,
+	SD_BUS_WRITABLE_PROPERTY("EffectDuration", "u",
+				 ratbagd_led_get_effect_duration, ratbagd_led_set_effect_duration, 0,
 				 SD_BUS_VTABLE_UNPRIVILEGED|SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_WRITABLE_PROPERTY("Brightness", "u",
 				 ratbagd_led_get_brightness, ratbagd_led_set_brightness, 0,

--- a/ratbagd/ratbagd-test.c
+++ b/ratbagd/ratbagd-test.c
@@ -76,21 +76,21 @@ static const struct ratbag_test_device ratbagd_test_device_descr = {
 				{
 					.mode = RATBAG_LED_OFF,
 					.color = { .red = 255, .green = 0, .blue = 0 },
-					.hz = 1,
+					.ms = 1000,
 					.brightness = 20,
 					.type = RATBAG_LED_TYPE_LOGO,
 				},
 				{
 					.mode = RATBAG_LED_ON,
 					.color = { .red = 255, .green = 0, .blue = 0 },
-					.hz = 1,
+					.ms = 1000,
 					.brightness = 20,
 					.type = RATBAG_LED_TYPE_SIDE,
 				},
 				{
 					.mode = RATBAG_LED_CYCLE,
 					.color = { .red = 255, .green = 255, .blue = 0 },
-					.hz = 3,
+					.ms = 333,
 					.brightness = 40,
 					.type = RATBAG_LED_TYPE_SIDE,
 				}
@@ -145,13 +145,13 @@ static const struct ratbag_test_device ratbagd_test_device_descr = {
 				{
 					.mode = RATBAG_LED_ON,
 					.color = { .red = 255, .green = 0, .blue = 0 },
-					.hz = 1,
+					.ms = 1000,
 					.brightness = 20
 				},
 				{
 					.mode = RATBAG_LED_CYCLE,
 					.color = { .red = 255, .green = 255, .blue = 0 },
-					.hz = 3,
+					.ms = 333,
 					.brightness = 40
 				}
 			},

--- a/src/driver-test.c
+++ b/src/driver-test.c
@@ -127,7 +127,7 @@ test_read_led(struct ratbag_led *led)
 	led->color.red = t_led.color.red;
 	led->color.green = t_led.color.green;
 	led->color.blue = t_led.color.blue;
-	led->hz = t_led.hz;
+	led->ms = t_led.ms;
 	led->brightness = t_led.brightness;
 
 	/* The led type has to be the same anyway so make writing test
@@ -148,7 +148,7 @@ test_write_button(struct ratbag_button *button,
 static int
 test_write_led(struct ratbag_led *led,
 	       enum ratbag_led_mode mode,
-	       struct ratbag_color color, unsigned int hz,
+	       struct ratbag_color color, unsigned int ms,
 	       unsigned int brightness)
 {
 	/* check if the device is still valid */

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -239,7 +239,7 @@ struct ratbag_driver {
 	 * it. Look at commit() instead.
 	 */
 	int (*write_led)(struct ratbag_led *led, enum ratbag_led_mode mode,
-			 struct ratbag_color color, unsigned int hz,
+			 struct ratbag_color color, unsigned int ms,
 			 unsigned int brightness);
 
 	/* private */
@@ -281,7 +281,7 @@ struct ratbag_led {
 	uint32_t modes;		      /**< supported modes */
 	struct ratbag_color color;
 	enum ratbag_led_colordepth colordepth;
-	unsigned int hz;              /**< rate of action in hz */
+	unsigned int ms;              /**< duration of action in ms */
 	unsigned int brightness;      /**< brightness of the LED */
 	bool dirty;
 };

--- a/src/libratbag-test.h
+++ b/src/libratbag-test.h
@@ -70,7 +70,7 @@ struct ratbag_test_led {
 	enum ratbag_led_type type;
 	enum ratbag_led_mode mode;
 	struct ratbag_test_color color;
-	unsigned int hz;
+	unsigned int ms;
 	unsigned int brightness;
 };
 

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -905,7 +905,7 @@ ratbag_device_has_capability(const struct ratbag_device *device,
 static inline enum ratbag_error_code
 write_led_helper(struct ratbag_device *device, struct ratbag_led *led)
 {
-	return device->driver->write_led(led, led->mode, led->color, led->hz, led->brightness);
+	return device->driver->write_led(led, led->mode, led->color, led->ms, led->brightness);
 }
 
 /* FIXME: This is a temporary fix for all of the drivers that have yet to be
@@ -1547,9 +1547,9 @@ ratbag_led_get_color(struct ratbag_led *led)
 }
 
 LIBRATBAG_EXPORT int
-ratbag_led_get_effect_rate(struct ratbag_led *led)
+ratbag_led_get_effect_duration(struct ratbag_led *led)
 {
-	return led->hz;
+	return led->ms;
 }
 
 LIBRATBAG_EXPORT unsigned int
@@ -1596,13 +1596,13 @@ ratbag_led_get_colordepth(struct ratbag_led *led)
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_led_set_effect_rate(struct ratbag_led *led, unsigned int hz)
+ratbag_led_set_effect_duration(struct ratbag_led *led, unsigned int ms)
 {
 	if (!ratbag_device_has_capability(led->profile->device,
 					  RATBAG_DEVICE_CAP_LED))
 		return RATBAG_ERROR_CAPABILITY;
 
-	led->hz = hz;
+	led->ms = ms;
 	led->dirty = true;
 	led->profile->dirty = true;
 	return RATBAG_SUCCESS;

--- a/src/libratbag.h
+++ b/src/libratbag.h
@@ -1268,15 +1268,15 @@ ratbag_led_get_colordepth(struct ratbag_led *led);
 /**
  * @ingroup led
  *
- * This function returns the LED effect rate.
+ * This function returns the LED effect duration.
  *
  * @param led A previously initialized ratbag LED
- * @return The LED rate in Hz, can be 100 - 20000
+ * @return The LED duration in ms, can be 0 - 10000
  *
- * @see ratbag_led_set_effect_rate
+ * @see ratbag_led_set_effect_duration
  */
 int
-ratbag_led_get_effect_rate(struct ratbag_led *led);
+ratbag_led_get_effect_duration(struct ratbag_led *led);
 /**
  * @ingroup led
  *
@@ -1329,16 +1329,16 @@ ratbag_led_set_color(struct ratbag_led *led, struct ratbag_color color);
  * @ingroup led
  *
  * If the LED's mode is @ref RATBAG_LED_CYCLE or @ref RATBAG_LED_BREATHING
- * then this function sets the LED rate in Hz
+ * then this function sets the LED duration in ms
  *
  * @param led A previously initialized ratbag LED
- * @param rate Effect rate in hz, 100 - 20000
+ * @param rate Effect duration in ms, 0 - 10000
  * @return 0 on success or an error code otherwise.
  *
- * @see ratbag_led_get_effect_rate
+ * @see ratbag_led_get_effect_duration
  */
 enum ratbag_error_code
-ratbag_led_set_effect_rate(struct ratbag_led *led, unsigned int rate);
+ratbag_led_set_effect_duration(struct ratbag_led *led, unsigned int rate);
 
 /**
  * @ingroup led

--- a/test/test-device.c
+++ b/test/test-device.c
@@ -91,13 +91,13 @@ const struct ratbag_test_device sane_device = {
 			{
 				.mode = RATBAG_LED_ON,
 				.color = { .red = 255, .green = 0,	.blue = 0 },
-				.hz = 1,
+				.ms = 1000,
 				.brightness = 20,
 			},
 			{
 				.mode = RATBAG_LED_CYCLE,
 				.color = { .red = 255, .green = 255, .blue = 0 },
-				.hz = 3,
+				.ms = 333,
 				.brightness = 40,
 			}
 		},
@@ -793,18 +793,18 @@ assert_led_equals(struct ratbag_led *l, struct ratbag_test_led e_l)
 {
 	enum ratbag_led_mode mode;
 	struct ratbag_color color;
-	int brightness, hz;
+	int brightness, ms;
 
 	ck_assert(l != NULL);
 	mode = ratbag_led_get_mode(l);
 	color = ratbag_led_get_color(l);
-	hz = ratbag_led_get_effect_rate(l);
+	ms = ratbag_led_get_effect_duration(l);
 	brightness = ratbag_led_get_brightness(l);
 	ck_assert_int_eq(mode, e_l.mode);
 	ck_assert_int_eq(color.red, e_l.color.red);
 	ck_assert_int_eq(color.green, e_l.color.green);
 	ck_assert_int_eq(color.blue, e_l.color.blue);
-	ck_assert_int_eq(hz, e_l.hz);
+	ck_assert_int_eq(ms, e_l.ms);
 	ck_assert_int_eq(brightness, e_l.brightness);
 }
 
@@ -876,7 +876,7 @@ START_TEST(device_leds_set)
 
 	ratbag_led_set_mode(l, RATBAG_LED_BREATHING);
 	ratbag_led_set_color(l, c);
-	ratbag_led_set_effect_rate(l, 11);
+	ratbag_led_set_effect_duration(l, 90);
 	ratbag_led_set_brightness(l, 22);
 
 	l = ratbag_profile_get_led(p, 0);
@@ -887,7 +887,7 @@ START_TEST(device_leds_set)
 			.green = c.green,
 			.blue = c.blue
 		},
-		.hz = 11,
+		.ms = 90,
 		.brightness = 22
 	};
 	assert_led_equals(l, e_l);

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -147,22 +147,22 @@ def print_led(d, p, l, level):
                                                                                                       l.color[1],
                                                                                                       l.color[2]))
     elif l.mode == RatbagdLed.MODE_CYCLE:
-        print(" " * level + "LED: {} type: {}, depth: {}, mode: {}, rate: {}, brightness: {}".format(l.index,
-                                                                                                     types[l.type],
-                                                                                                     depths[l.colordepth],
-                                                                                                     leds[l.mode],
-                                                                                                     l.effect_rate,
-                                                                                                     l.brightness))
+        print(" " * level + "LED: {} type: {}, depth: {}, mode: {}, duration: {}, brightness: {}".format(l.index,
+                                                                                                         types[l.type],
+                                                                                                         depths[l.colordepth],
+                                                                                                         leds[l.mode],
+                                                                                                         l.effect_duration,
+                                                                                                         l.brightness))
     elif l.mode == RatbagdLed.MODE_BREATHING:
-        print(" " * level + "LED: {} type: {}, depth: {}, mode: {}, color: {:02x}{:02x}{:02x}, rate: {}, brightness: {}".format(l.index,
-                                                                                                                                types[l.type],
-                                                                                                                                depths[l.colordepth],
-                                                                                                                                leds[l.mode],
-                                                                                                                                l.color[0],
-                                                                                                                                l.color[1],
-                                                                                                                                l.color[2],
-                                                                                                                                l.effect_rate,
-                                                                                                                                l.brightness))
+        print(" " * level + "LED: {} type: {}, depth: {}, mode: {}, color: {:02x}{:02x}{:02x}, duration: {}, brightness: {}".format(l.index,
+                                                                                                                                    types[l.type],
+                                                                                                                                    depths[l.colordepth],
+                                                                                                                                    leds[l.mode],
+                                                                                                                                    l.color[0],
+                                                                                                                                    l.color[1],
+                                                                                                                                    l.color[2],
+                                                                                                                                    l.effect_duration,
+                                                                                                                                    l.brightness))
 
 
 def print_led_caps(d, p, l, level):
@@ -340,11 +340,11 @@ def func_led_set(r, args):
     else:
         l.color = color
     try:
-        rate = args.rate
+        duration = args.duration
     except AttributeError:
         pass
     else:
-        l.effect_rate = rate
+        l.effect_duration = duration
     try:
         brightness = args.brightness
     except AttributeError:
@@ -1146,14 +1146,14 @@ active profile if none is given.""",
                         },
                         {
                             of_type: command,
-                            name: 'rate',
-                            help_str: 'The rate to set as current',
+                            name: 'duration',
+                            help_str: 'The duration to set as current',
                             pos_args: [
                                 {
                                     of_type: argument,
-                                    name: 'rate',
+                                    name: 'duration',
                                     metavar: 'R',
-                                    help_str: 'The rate in Hz to set as current',
+                                    help_str: 'The duration in ms to set as current',
                                     arg_type: int,
                                 },
                             ],
@@ -1488,7 +1488,7 @@ Examples:
   {0} dpi set 800
   {0} profile 0 led 0 set mode on
   {0} profile 0 led 0 set color ff00ff
-  {0} profile 0 led 0 set rate 20
+  {0} profile 0 led 0 set duration 50
 
 Exit codes:
   0     Success

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -974,17 +974,17 @@ class RatbagdLed(_RatbagdDBus):
         return self._get_dbus_property("ColorDepth")
 
     @GObject.Property
-    def effect_rate(self):
-        """The LED's effect rate in Hz, values range from 100 to 20000."""
+    def effect_duration(self):
+        """The LED's effect duration in ms, values range from 0 to 10000."""
         return self._get_dbus_property("EffectRate")
 
-    @effect_rate.setter
-    def effect_rate(self, effect_rate):
-        """Set the effect rate in Hz. Allowed values range from 100 to 20000.
+    @effect_duration.setter
+    def effect_duration(self, effect_duration):
+        """Set the effect duration in ms. Allowed values range from 0 to 10000.
 
-        @param effect_rate The new effect rate, as int
+        @param effect_duration The new effect duration, as int
         """
-        self._set_dbus_property("EffectRate", "u", effect_rate)
+        self._set_dbus_property("EffectRate", "u", effect_duration)
 
     @GObject.Property
     def brightness(self):


### PR DESCRIPTION
This is a start to convert an LED's effect rate in Hz to effect duration in ms, as discussed in https://github.com/libratbag/piper/issues/175. This commit isn't working because I do not trust myself to change the drivers. I did peek at them and only driver-hidpp20.c needs changing. Feel free to take this work and squash in the changes required to the driver.