### PR TITLE
ratbagd: ensure boolean passed to sd_* are 4 bytes wide

### DIFF
--- a/ratbagd/ratbagd-profile.c
+++ b/ratbagd/ratbagd-profile.c
@@ -196,7 +196,7 @@ static int ratbagd_profile_is_active(sd_bus *bus,
 				     sd_bus_error *error)
 {
 	struct ratbagd_profile *profile = userdata;
-	bool is_active;
+	int is_active;
 
 	is_active = !!ratbag_profile_is_active(profile->lib_profile);
 
@@ -315,7 +315,7 @@ ratbagd_profile_set_enabled(sd_bus *bus,
 			    sd_bus_error *error)
 {
 	struct ratbagd_profile *profile = userdata;
-	bool enabled;
+	int enabled;
 	int r;
 
 	r = sd_bus_message_read(m, "b", &enabled);
@@ -345,7 +345,7 @@ ratbagd_profile_is_enabled(sd_bus *bus,
 			   sd_bus_error *error)
 {
 	struct ratbagd_profile *profile = userdata;
-	bool enabled = ratbag_profile_is_enabled(profile->lib_profile) != 0;
+	int enabled = ratbag_profile_is_enabled(profile->lib_profile) != 0;
 
 	return sd_bus_message_append(reply, "b", enabled);
 }

--- a/ratbagd/ratbagd-resolution.c
+++ b/ratbagd/ratbagd-resolution.c
@@ -165,7 +165,7 @@ ratbagd_resolution_is_active(sd_bus *bus,
 {
 	struct ratbagd_resolution *resolution = userdata;
 	struct ratbag_resolution *lib_resolution = resolution->lib_resolution;
-	bool is_active;
+	int is_active;
 
 	is_active = !!ratbag_resolution_is_active(lib_resolution);
 
@@ -183,7 +183,7 @@ ratbagd_resolution_is_default(sd_bus *bus,
 {
 	struct ratbagd_resolution *resolution = userdata;
 	struct ratbag_resolution *lib_resolution = resolution->lib_resolution;
-	bool is_default;
+	int is_default;
 
 	is_default = !!ratbag_resolution_is_default(lib_resolution);
 


### PR DESCRIPTION
This makes sure that every boolean passed to sd_* functions is 4 bytes long as required by the dbus specification

Signed-off-by: Ogier Bouvier <obouvier@logitech.com>