### PR TITLE
meson/dbus: support build time option to restrict D-Bus access

### DIFF
--- a/dbus/org.freedesktop.ratbag1.conf.in
+++ b/dbus/org.freedesktop.ratbag1.conf.in
@@ -11,8 +11,7 @@
                 <allow receive_sender="org.freedesktop.ratbag1"/>
         </policy>
 
-	<!-- allow everyone to talk to the daemon -->
-        <policy context="default">
+        <policy @access@>
                 <allow send_destination="org.freedesktop.ratbag1"/>
                 <allow receive_sender="org.freedesktop.ratbag1"/>
         </policy>

--- a/meson.build
+++ b/meson.build
@@ -467,8 +467,23 @@ configure_file(input : 'dbus/org.freedesktop.ratbag1.service.in',
 	       output : 'org.freedesktop.ratbag1.service',
 	       configuration : config_bindir,
 	       install_dir : join_paths(dbusdir, 'system-services'))
-install_data('dbus/org.freedesktop.ratbag1.conf',
-	     install_dir : join_paths(dbusdir, 'system.d'))
+
+dbusgroup = get_option('dbus-group')
+if dbusgroup == ''
+	# grant everybody access by default
+	access = 'context="default"'
+else
+	# grant access to members of the specified group only
+	access = 'group="@0@"'.format(dbusgroup)
+endif
+
+config_dbusaccess = configuration_data()
+config_dbusaccess.set('access', access)
+
+configure_file(input : 'dbus/org.freedesktop.ratbag1.conf.in',
+	       output : 'org.freedesktop.ratbag1.conf',
+	       configuration : config_dbusaccess,
+	       install_dir : join_paths(dbusdir, 'system.d'))
 
 #### tools ####
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -22,3 +22,8 @@ option('documentation',
 	type: 'boolean',
 	value: false,
 	description: 'Enable documentation build (default=no)')
+
+option('dbus-group',
+	type: 'string',
+	value : '',
+	description : 'The UNIX group that is granted access to the ratbagd D-Bus service. By default all users may access it.')


### PR DESCRIPTION
This change makes it possible to pass '-Ddbus-group=<group>' to limit
the access to the ratbagd D-Bus service. The default remains to allow
everyone access to the service.

This allows integrators to choose more conservative security settings
e.g. only allowing users in the 'games' group to talk to the ratbagd
daemon.