### PR TITLE
Add MacroLength to .device files

### DIFF
--- a/data/devices/steelseries-kinzu-v2.device
+++ b/data/devices/steelseries-kinzu-v2.device
@@ -9,3 +9,4 @@ DeviceVersion=1
 Buttons=3
 Leds=0
 DpiList=400;800;1600;3200
+MacroLength=0

--- a/data/devices/steelseries-rival-310.device
+++ b/data/devices/steelseries-rival-310.device
@@ -9,3 +9,4 @@ DeviceVersion=2
 Buttons=6
 Leds=2
 DpiRange=100:12000@100
+MacroLength=1

--- a/data/devices/steelseries-rival.device
+++ b/data/devices/steelseries-rival.device
@@ -9,3 +9,4 @@ DeviceVersion=1
 Buttons=6
 Leds=2
 DpiRange=50:6500@50
+MacroLength=1

--- a/data/devices/steelseries-sensei-310.device
+++ b/data/devices/steelseries-sensei-310.device
@@ -9,3 +9,4 @@ DeviceVersion=2
 Buttons=8
 Leds=2
 DpiRange=100:12000@100
+MacroLength=1

--- a/src/driver-steelseries.c
+++ b/src/driver-steelseries.c
@@ -150,7 +150,7 @@ steelseries_probe(struct ratbag_device *device)
 				    led_count);
 
 	/* only later models allow setting buttons on the device */
-	if (device_version > 1) {
+	if (ratbag_device_data_steelseries_get_macro_length(device->data) > 0) {
 		/* set these caps manually as they are not assumed with only 1 profile */
 		ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_BUTTON);
 		ratbag_device_set_capability(device, RATBAG_DEVICE_CAP_BUTTON_KEY);
@@ -286,12 +286,11 @@ static int
 steelseries_write_buttons(struct ratbag_profile *profile)
 {
 	struct ratbag_device *device = profile->device;
-	int device_version = ratbag_device_data_steelseries_get_device_version(device->data);
 	uint8_t buf[STEELSERIES_REPORT_LONG_SIZE] = {0};
 	struct ratbag_button *button;
 	int ret;
 
-	if (device_version < 2)
+	if (ratbag_device_data_steelseries_get_macro_length(device->data) == 0)
 		return 0;
 
 	buf[0] = STEELSERIES_ID_BUTTONS;

--- a/src/libratbag-data.c
+++ b/src/libratbag-data.c
@@ -70,6 +70,7 @@ struct data_steelseries {
 	int led_count;
 	struct dpi_list *dpi_list;
 	struct dpi_range *dpi_range;
+	int macro_length;
 };
 
 struct ratbag_device_data {
@@ -202,6 +203,13 @@ init_data_steelseries(struct ratbag *ratbag,
 		if (str)
 			data->steelseries.dpi_list = dpi_list_from_string(str);
 	}
+
+	error = NULL;
+	num = g_key_file_get_integer(keyfile, group, "MacroLength", &error);
+	if (num > 0 || !error)
+		data->steelseries.macro_length = num;
+	if (error)
+		g_error_free(error);
 }
 
 static const struct driver_map {
@@ -584,3 +592,10 @@ ratbag_device_data_steelseries_get_dpi_range(const struct ratbag_device_data *da
 	return data->steelseries.dpi_range;
 }
 
+int
+ratbag_device_data_steelseries_get_macro_length(const struct ratbag_device_data *data)
+{
+	assert(data->drivertype == STEELSERIES);
+
+	return data->steelseries.macro_length;
+}

--- a/src/libratbag-data.h
+++ b/src/libratbag-data.h
@@ -108,3 +108,5 @@ ratbag_device_data_steelseries_get_dpi_list(const struct ratbag_device_data *dat
 struct dpi_range *
 ratbag_device_data_steelseries_get_dpi_range(const struct ratbag_device_data *data);
 
+int
+ratbag_device_data_steelseries_get_macro_length(const struct ratbag_device_data *data);


### PR DESCRIPTION
I need to store in the .device file for the steelseries mice whether they support mapping buttons to keys or not. I cannot query it and it the feature does not follow any of the other settings, like DeviceVersion.

The steelseries mice do not support storing real macros on the device itself, only key+modifiers. This can be seen as a single-step macro. Since it seems we will need a global option for macro length anyway I thought that using a macro length of 0 could be used to indicate that no keys can be set.

I have only updated the .device files for the steelseries mice in this PR.

Is it a reasonable option? And is there a better name than MacroLength?