### PR TITLE
dbus service: use the actual ratbagd service name and not the alias

### DIFF
--- a/dbus/org.freedesktop.ratbag1.service.in
+++ b/dbus/org.freedesktop.ratbag1.service.in
@@ -2,4 +2,4 @@
 Name=org.freedesktop.ratbag1
 Exec=@bindir@/ratbagd
 User=root
-SystemdService=dbus-org.freedesktop.ratbag1.service
+SystemdService=ratbagd.service


### PR DESCRIPTION
The alias can be used only when the service is enabled