### PR TITLE
It seems the driver is for Etekcity Scroll Alpha

### DIFF
--- a/data/devices/etekcity-scroll-alpha.device
+++ b/data/devices/etekcity-scroll-alpha.device
@@ -1,6 +1,5 @@
-# FIXME: which device is this exactly?
 [Device]
-Name=Etekcity FIXME
+Name=Etekcity Scroll Alpha
 DeviceMatch=usb:1ea7:4011
 Driver=etekcity
 Svg=etekcity.svg


### PR DESCRIPTION
Based on the [etekcity.svg](https://github.com/libratbag/libratbag/blob/master/data/default/etekcity.svg) and https://www.phoronix.com/scan.php?page=news_item&px=Libratbag-Announced
Need confirmation from @dvdhrm and @bentiss based on http://libratbag.github.io/device-notes/ to check IDs, unless it's for both both.