### PR TITLE
hidpp10: fix finding the closest dpi

### DIFF
--- a/src/hidpp10.c
+++ b/src/hidpp10.c
@@ -643,7 +643,7 @@ hidpp10_get_dpi_mapping(struct hidpp10_device *dev, unsigned int value)
 	min_delta = INT_MAX;
 
 	for (i = 0; i < dev->dpi_count; i++) {
-		delta = abs(value - m[i].dpi);
+		delta = abs((int)value - (int)m[i].dpi);
 		if (delta < min_delta) {
 			result = m[i].raw_value;
 			min_delta = delta;


### PR DESCRIPTION
value and dpi are unsigned so the delta calculations was wrong when
dpi is larger than than value. Casting to int should be fine for the
expected range of values in those variables.