### PR TITLE
Add Logitech G302 device

### DIFF
--- a/data/devices/logitech-g302.device
+++ b/data/devices/logitech-g302.device
@@ -1,0 +1,7 @@
+# G302 over USB
+[Device]
+Name=Logitech Gaming Mouse G302
+DeviceMatch=usb:046d:c07f
+Svg=logitech-g303.svg
+Driver=hidpp20
+LedTypes=logo;side;


### PR DESCRIPTION
This short-lived rgb-less edition of the G303 was a bit sad and left out. 

Simply adding its usb ID makes it work.

Thanks a lot for this project!