### PR TITLE
hidraw: use cleanup for udev enumerate

### DIFF
--- a/src/libratbag-hidraw.c
+++ b/src/libratbag-hidraw.c
@@ -1375,7 +1375,7 @@ ratbag_find_hidraw_node(struct ratbag_device *device,
 			int use_usb_parent)
 {
 	struct ratbag *ratbag = device->ratbag;
-	struct udev_enumerate *e;
+	_cleanup_(udev_enumerate_unrefp) struct udev_enumerate *e = NULL;
 	struct udev_list_entry *entry;
 	const char *path;
 	struct udev_device *hid_udev;
@@ -1421,14 +1421,11 @@ ratbag_find_hidraw_node(struct ratbag_device *device,
 		matched = match(device);
 		rc = matched ? 0 : -ENODEV;
 		if (matched == 1)
-			goto out;
+			return rc;
 
 skip:
 		ratbag_close_hidraw(device);
 	}
-
-out:
-	udev_enumerate_unref(e);
 
 	return rc;
 }

--- a/src/shared-macro.h
+++ b/src/shared-macro.h
@@ -135,6 +135,7 @@ static inline void reset_errno(int *saved_errno)
 
 DEFINE_TRIVIAL_CLEANUP_FUNC(struct udev*, udev_unref);
 DEFINE_TRIVIAL_CLEANUP_FUNC(struct udev_device*, udev_device_unref);
+DEFINE_TRIVIAL_CLEANUP_FUNC(struct udev_enumerate*, udev_enumerate_unref);
 
 /*
  * ELEMENTSOF() - number of array elements


### PR DESCRIPTION
This is just a small cleanup that I had in my tree. 