### PR TITLE
Include Logitech G102/G203 device files

### DIFF
--- a/data/devices/logitech-g102-g203.device
+++ b/data/devices/logitech-g102-g203.device
@@ -1,0 +1,7 @@
+# G102 and G203 (USB)
+[Device]
+Name=Logitech Gaming Mouse G102/G103
+DeviceMatch=usb:046d:c084
+Svg=logitech-g102-g203.svg
+Driver=hidpp20
+LedTypes=logo;side;

--- a/data/gnome/logitech-g102-g203.svg
+++ b/data/gnome/logitech-g102-g203.svg
@@ -1,0 +1,1 @@
+logitech-g303.svg

--- a/meson.build
+++ b/meson.build
@@ -244,6 +244,7 @@ man_lur_command = configure_file (
 data_files = files(
 	'data/devices/etekcity-scroll-alpha.device',
 	'data/devices/gskill-MX-780.device',
+	'data/devices/logitech-g102-g203.device',
 	'data/devices/logitech-g300.device',
 	'data/devices/logitech-g303.device',
 	'data/devices/logitech-g403.device',
@@ -290,6 +291,7 @@ test('data-parse-test', data_parse_test,
 
 gnome_svg_files = files(
 	'data/gnome/fallback.svg',
+	'data/gnome/logitech-g102-g203.svg',
 	'data/gnome/logitech-g300.svg',
 	'data/gnome/logitech-g303.svg',
 	'data/gnome/logitech-g403.svg',


### PR DESCRIPTION
Just a quick change to add support for the G102 and G203 mice.

These mice are functionally identical and share a device ID, they only differ in marketing materials and which countries sell each mouse.