### PR TITLE
Initialize a few _cleanup_ pointers to NULL

### DIFF
--- a/src/driver-gskill.c
+++ b/src/driver-gskill.c
@@ -987,7 +987,7 @@ gskill_read_resolutions(struct ratbag_profile *profile,
 	hz = GSKILL_MAX_POLLING_RATE / (report->polling_rate + 1);
 
 	for (i = 0; i < report->dpi_num; i++) {
-		_cleanup_resolution_ struct ratbag_resolution *resolution;
+		_cleanup_resolution_ struct ratbag_resolution *resolution = NULL;
 		unsigned int rates[] = { 500, 1000 }; /* let's assume that is true */
 
 		dpi_x = report->dpi_levels[i].x * GSKILL_DPI_UNIT;
@@ -1108,7 +1108,7 @@ gskill_update_resolutions(struct ratbag_profile *profile)
 	 * lost on exit
 	 */
 	for (i = 0; i < GSKILL_NUM_DPI; i++) {
-		_cleanup_resolution_ struct ratbag_resolution *res;
+		_cleanup_resolution_ struct ratbag_resolution *res = NULL;
 		struct gskill_raw_dpi_level *level =
 			&report->dpi_levels[report->dpi_num];
 

--- a/src/driver-test.c
+++ b/src/driver-test.c
@@ -190,7 +190,7 @@ test_read_profile(struct ratbag_profile *profile)
 	r0 = &p0->resolutions[0];
 
 	for (i = 0; i < d->num_resolutions; i++) {
-		_cleanup_resolution_ struct ratbag_resolution *res;
+		_cleanup_resolution_ struct ratbag_resolution *res = NULL;
 		size_t nrates = 0;
 
 		r = &p->resolutions[i];
@@ -225,7 +225,7 @@ test_read_profile(struct ratbag_profile *profile)
 
 	/* special case triggered by the test suite when num_resolutions is 0 */
 	if (d->num_resolutions) {
-		_cleanup_resolution_ struct ratbag_resolution *res;
+		_cleanup_resolution_ struct ratbag_resolution *res = NULL;
 
 		res = ratbag_profile_get_resolution(profile, 0);
 		assert(res);

--- a/src/liblur.c
+++ b/src/liblur.c
@@ -195,7 +195,7 @@ lur_receiver_enumerate(struct lur_receiver *lur,
 		dev->present = false;
 
 	for (i = 0; i < MAX_DEVICES; i++) {
-		_cleanup_hidpp10_device_destroy_ struct hidpp10_device *d;
+		_cleanup_hidpp10_device_destroy_ struct hidpp10_device *d = NULL;
 		size_t name_size = 64;
 		char name[name_size];
 		uint8_t interval, type;


### PR DESCRIPTION
../src/liblur.c:46:3: warning: 'd' may be used uninitialized in this function [-Wmaybe-uninitialized]
   hidpp10_device_destroy(*hidpp10_device);
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/liblur.c:198:59: note: 'd' was declared here
   _cleanup_hidpp10_device_destroy_ struct hidpp10_device *d;

And similar messages
