### PR TITLE
meson: change to use "-Dtests=true" instead of "enable-tests"

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -315,7 +315,7 @@ test_svg_files = find_program('data/gnome/check-svg.py')
 test('check-svg', test_svg_files, args : gnome_svg_files)
 
 #### tests ####
-enable_tests = get_option('enable-tests')
+enable_tests = get_option('tests')
 if enable_tests
 	dep_check = dependency('check', version: '>= 0.9.10')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,7 +3,7 @@ option('udev-dir',
        value: '',
        description: 'udev base directory [default=$prefix/lib/udev]')
 
-option('enable-tests',
+option('tests',
 	type: 'boolean',
 	value: true,
 	description: 'Build the tests (default=yes)')


### PR DESCRIPTION
This is more meson-like, the "enable-foo" is a autotools leftover.