### PR TITLE
meson: bump min version to 0.40.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project('libratbag', 'c', 'cpp',
 	version : '0.9.902',
 	license : 'MIT/Expat',
 	default_options : [ 'c_std=gnu99', 'warning_level=2' ],
-	meson_version : '>= 0.38.0')
+	meson_version : '>= 0.40.0')
 
 libratbag_version = meson.project_version().split('.')
 


### PR DESCRIPTION
Needed for build_by_default

The logs of configuring current meson warns about this:
```
The Meson build system
Version: 0.47.1
Source dir: /home/phomes/libratbag
Build dir: /home/phomes/libratbag/builddir
Build type: native build
Project name: libratbag
Project version: 0.9.902
Native C compiler: cc (gcc 8.1.1 "cc (GCC) 8.1.1 20180712 (Red Hat 8.1.1-5)")
Native C++ compiler: c++ (gcc 8.1.1 "c++ (GCC) 8.1.1 20180712 (Red Hat 8.1.1-5)")
Build machine cpu family: x86_64
Build machine cpu: x86_64
Program git found: YES (/usr/bin/git)
Found pkg-config: /usr/bin/pkg-config (1.4.2)
Native dependency libudev found: YES 238
Native dependency libevdev found: YES 1.5.9
Native dependency libsystemd found: YES 238
Native dependency systemd found: YES 238
Native dependency glib-2.0 found: YES 2.56.1
Library m found: YES
Configuring libratbag-version.h using configuration
Configuring lur-command.1 using configuration
Program /home/phomes/libratbag/data/devices/data-parse-test.py found: YES (/home/phomes/libratbag/data/devices/data-parse-test.py)
Program data/gnome/check-svg.py found: YES (/home/phomes/libratbag/data/gnome/check-svg.py)
Native dependency check found: YES 0.12.0
Program valgrind found: YES (/usr/bin/valgrind)
Configuring org.freedesktop.ratbag_devel1.conf using configuration
Configuring ratbagd.service using configuration
Configuring org.freedesktop.ratbag1.service using configuration
Configuring org.freedesktop.ratbag1.conf using configuration
WARNING: Project targetting '>= 0.38.0' but tried to use feature introduced in '0.40.0': build_by_default arg in custom_target
Configuring ratbagctl.1 using configuration
Configuring ratbagctl.devel using configuration
Configuring ratbagctl.test using configuration
Program /home/phomes/libratbag/builddir/ratbagctl.test found: YES (/home/phomes/libratbag/builddir/ratbagctl.test)
Configuring toolbox.py using configuration
Configuring config.h using configuration
Program swig found: YES (/usr/bin/swig)
Native dependency python3 found: YES 3.6
Build targets in project: 22
WARNING: Project specifies a minimum meson_version '>= 0.38.0' which conflicts with:
 * 0.40.0: {'build_by_default arg in custom_target'}

```