### PR TITLE
Hidpp10 profile name

### DIFF
--- a/src/driver-hidpp10.c
+++ b/src/driver-hidpp10.c
@@ -407,7 +407,13 @@ hidpp10drv_read_profile(struct ratbag_profile *profile)
 	if (rc)
 		return;
 
+	ratbag_profile_set_cap(profile, RATBAG_PROFILE_CAP_WRITABLE_NAME);
+
 	profile->is_enabled = p.enabled;
+
+	if (profile->name)
+		free(profile->name);
+	profile->name = strdup_safe((char*)p.name);
 
 	rc = hidpp10_get_current_profile(hidpp10, &idx);
 	if (rc == 0 && (unsigned int)idx == profile->index)
@@ -543,6 +549,7 @@ hidpp10drv_commit(struct ratbag_device *device)
 			return rc;
 
 		p.enabled = profile->is_enabled;
+		strncpy_safe((char*)p.name, profile->name, 24);
 
 		ratbag_profile_for_each_resolution(profile, resolution) {
 			p.dpi_modes[resolution->index].xres = resolution->dpi_x;

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -1682,6 +1682,7 @@ ratbag_profile_set_name(struct ratbag_profile *profile,
 		free(profile->name);
 
 	profile->name = name_copy;
+	profile->dirty = true;
 
 	return 0;
 }


### PR DESCRIPTION
HID++1.0 devices store the profile name. Update the name used by libratbag.

The name will be used in the output from ratbagctl. Piper does not yet make used of the name.