### PR TITLE
ratbagd: send enums as signed int

### DIFF
--- a/ratbagd/ratbagd-button.c
+++ b/ratbagd/ratbagd-button.c
@@ -129,7 +129,7 @@ static int ratbagd_button_get_special(sd_bus *bus,
 
 	special = ratbag_button_get_special(button->lib_button);
 
-	return sd_bus_message_append(reply, "u", special);
+	return sd_bus_message_append(reply, "i", special);
 }
 
 static int ratbagd_button_set_special(sd_bus *bus,
@@ -144,7 +144,7 @@ static int ratbagd_button_set_special(sd_bus *bus,
 	enum ratbag_button_action_special special;
 	int r;
 
-	r = sd_bus_message_read(m, "u", &special);
+	r = sd_bus_message_read(m, "i", &special);
 	if (r < 0)
 		return r;
 
@@ -183,7 +183,7 @@ static int ratbagd_button_get_macro(sd_bus *bus,
 	int r;
 	unsigned int idx;
 
-	r = sd_bus_message_open_container(reply, 'a', "(uu)");
+	r = sd_bus_message_open_container(reply, 'a', "(iu)");
 	if (r < 0)
 		return r;
 
@@ -213,7 +213,7 @@ static int ratbagd_button_get_macro(sd_bus *bus,
 			abort();
 		}
 
-		r = sd_bus_message_append(reply, "(uu)", type, value);
+		r = sd_bus_message_append(reply, "(iu)", type, value);
 		if (r < 0)
 			return r;
 	}
@@ -235,12 +235,12 @@ static int ratbagd_button_set_macro(sd_bus *bus,
 	int r, idx = 0;
 	_cleanup_(ratbag_button_macro_unrefp) struct ratbag_button_macro *macro = NULL;
 
-	r = sd_bus_message_enter_container(m, 'a', "(uu)");
+	r = sd_bus_message_enter_container(m, 'a', "(iu)");
 	if (r < 0)
 		return r;
 
 	macro = ratbag_button_macro_new("macro");
-	while ((r = sd_bus_message_read(m, "(uu)", &type, &value)) > 0) {
+	while ((r = sd_bus_message_read(m, "(iu)", &type, &value)) > 0) {
 		r = ratbag_button_macro_set_event(macro, idx++, type, value);
 		if (r < 0) {
 			r = ratbagd_device_resync(button->device, bus);
@@ -295,7 +295,7 @@ static int ratbagd_button_get_action_type(sd_bus *bus,
 	if (type == RATBAG_BUTTON_ACTION_TYPE_KEY)
 		type = RATBAG_BUTTON_ACTION_TYPE_UNKNOWN;
 
-	return sd_bus_message_append(reply, "u", type);
+	return sd_bus_message_append(reply, "i", type);
 }
 
 static int ratbagd_button_get_action_types(sd_bus *bus,
@@ -316,7 +316,7 @@ static int ratbagd_button_get_action_types(sd_bus *bus,
 	enum ratbag_button_action_type *t;
 
 
-	r = sd_bus_message_open_container(reply, 'a', "u");
+	r = sd_bus_message_open_container(reply, 'a', "i");
 	if (r < 0)
 		return r;
 
@@ -324,7 +324,7 @@ static int ratbagd_button_get_action_types(sd_bus *bus,
 		if (!ratbag_button_has_action_type(button->lib_button, *t))
 			continue;
 
-		r = sd_bus_message_append(reply, "u", *t);
+		r = sd_bus_message_append(reply, "i", *t);
 		if (r < 0)
 			return r;
 	}
@@ -362,16 +362,16 @@ const sd_bus_vtable ratbagd_button_vtable[] = {
 				 ratbagd_button_get_button,
 				 ratbagd_button_set_button,
 				 0, SD_BUS_VTABLE_UNPRIVILEGED | SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
-	SD_BUS_WRITABLE_PROPERTY("SpecialMapping", "u",
+	SD_BUS_WRITABLE_PROPERTY("SpecialMapping", "i",
 				 ratbagd_button_get_special,
 				 ratbagd_button_set_special,
 				 0, SD_BUS_VTABLE_UNPRIVILEGED | SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
-	SD_BUS_WRITABLE_PROPERTY("Macro", "a(uu)",
+	SD_BUS_WRITABLE_PROPERTY("Macro", "a(iu)",
 				 ratbagd_button_get_macro,
 				 ratbagd_button_set_macro,
 				 0, SD_BUS_VTABLE_UNPRIVILEGED | SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
-	SD_BUS_PROPERTY("ActionType", "u", ratbagd_button_get_action_type, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
-	SD_BUS_PROPERTY("ActionTypes", "au", ratbagd_button_get_action_types, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+	SD_BUS_PROPERTY("ActionType", "i", ratbagd_button_get_action_type, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
+	SD_BUS_PROPERTY("ActionTypes", "ai", ratbagd_button_get_action_types, 0, SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_METHOD("Disable", "", "u", ratbagd_button_disable, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_VTABLE_END,
 };

--- a/ratbagd/ratbagd-device.c
+++ b/ratbagd/ratbagd-device.c
@@ -264,14 +264,14 @@ ratbagd_device_get_capabilities(sd_bus *bus,
 	int r;
 	size_t i;
 
-	r = sd_bus_message_open_container(reply, 'a', "u");
+	r = sd_bus_message_open_container(reply, 'a', "i");
 	if (r < 0)
 		return r;
 
 	for (i = 0; i < ELEMENTSOF(caps); i++) {
 		cap = caps[i];
 		if (ratbag_device_has_capability(lib_device, cap)) {
-			r = sd_bus_message_append(reply, "u", cap);
+			r = sd_bus_message_append(reply, "i", cap);
 			if (r < 0)
 				return r;
 		}
@@ -283,7 +283,7 @@ ratbagd_device_get_capabilities(sd_bus *bus,
 const sd_bus_vtable ratbagd_device_vtable[] = {
 	SD_BUS_VTABLE_START(0),
 	SD_BUS_PROPERTY("Id", "s", NULL, offsetof(struct ratbagd_device, sysname), SD_BUS_VTABLE_PROPERTY_CONST),
-	SD_BUS_PROPERTY("Capabilities", "au", ratbagd_device_get_capabilities, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+	SD_BUS_PROPERTY("Capabilities", "ai", ratbagd_device_get_capabilities, 0, SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_PROPERTY("Name", "s", ratbagd_device_get_device_name, 0, SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_PROPERTY("Svg", "s", ratbagd_device_get_svg, 0, SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_PROPERTY("Profiles", "ao", ratbagd_device_get_profiles, 0, SD_BUS_VTABLE_PROPERTY_CONST),

--- a/ratbagd/ratbagd-led.c
+++ b/ratbagd/ratbagd-led.c
@@ -52,14 +52,14 @@ static int ratbagd_led_get_modes(sd_bus *bus,
 	enum ratbag_led_mode mode = 0;
 	int r;
 
-	r = sd_bus_message_open_container(reply, 'a', "u");
+	r = sd_bus_message_open_container(reply, 'a', "i");
 	if (r < 0)
 		return r;
 
 
 	while (mode <= RATBAG_LED_BREATHING) {
 		if (ratbag_led_has_mode(led->lib_led, mode))
-			sd_bus_message_append(reply, "u", mode);
+			sd_bus_message_append(reply, "i", mode);
 		mode++;
 	}
 
@@ -78,7 +78,7 @@ static int ratbagd_led_get_mode(sd_bus *bus,
 	enum ratbag_led_mode mode;
 
 	mode = ratbag_led_get_mode(led->lib_led);
-	return sd_bus_message_append(reply, "u", mode);
+	return sd_bus_message_append(reply, "i", mode);
 }
 
 static int ratbagd_led_set_mode(sd_bus *bus,
@@ -93,7 +93,7 @@ static int ratbagd_led_set_mode(sd_bus *bus,
 	enum ratbag_led_mode mode;
 	int r;
 
-	r = sd_bus_message_read(m, "u", &mode);
+	r = sd_bus_message_read(m, "i", &mode);
 	if (r < 0)
 		return r;
 
@@ -124,7 +124,7 @@ static int ratbagd_led_get_type(sd_bus *bus,
 
 	type = ratbag_led_get_type(led->lib_led);
 
-	return sd_bus_message_append(reply, "u", type);
+	return sd_bus_message_append(reply, "i", type);
 }
 
 static int ratbagd_led_get_color(sd_bus *bus,
@@ -278,16 +278,16 @@ static int ratbagd_led_set_brightness(sd_bus *bus,
 const sd_bus_vtable ratbagd_led_vtable[] = {
 	SD_BUS_VTABLE_START(0),
 	SD_BUS_PROPERTY("Index", "u", NULL, offsetof(struct ratbagd_led, index), SD_BUS_VTABLE_PROPERTY_CONST),
-	SD_BUS_PROPERTY("Modes", "au", ratbagd_led_get_modes, 0, SD_BUS_VTABLE_PROPERTY_CONST),
-	SD_BUS_WRITABLE_PROPERTY("Mode", "u",
+	SD_BUS_PROPERTY("Modes", "ai", ratbagd_led_get_modes, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+	SD_BUS_WRITABLE_PROPERTY("Mode", "i",
 				 ratbagd_led_get_mode,
 				 ratbagd_led_set_mode, 0,
 				 SD_BUS_VTABLE_UNPRIVILEGED|SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
-	SD_BUS_PROPERTY("Type", "u", ratbagd_led_get_type, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+	SD_BUS_PROPERTY("Type", "i", ratbagd_led_get_type, 0, SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_WRITABLE_PROPERTY("Color", "(uuu)",
 				 ratbagd_led_get_color, ratbagd_led_set_color, 0,
 				 SD_BUS_VTABLE_UNPRIVILEGED|SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
-	SD_BUS_PROPERTY("ColorDepth", "u", NULL, offsetof(struct ratbagd_led, colordepth), SD_BUS_VTABLE_PROPERTY_CONST),
+	SD_BUS_PROPERTY("ColorDepth", "i", NULL, offsetof(struct ratbagd_led, colordepth), SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_WRITABLE_PROPERTY("EffectDuration", "u",
 				 ratbagd_led_get_effect_duration, ratbagd_led_set_effect_duration, 0,
 				 SD_BUS_VTABLE_UNPRIVILEGED|SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),

--- a/ratbagd/ratbagd-profile.c
+++ b/ratbagd/ratbagd-profile.c
@@ -413,14 +413,14 @@ ratbagd_profile_get_capabilities(sd_bus *bus,
 	int r;
 	size_t i;
 
-	r = sd_bus_message_open_container(reply, 'a', "u");
+	r = sd_bus_message_open_container(reply, 'a', "i");
 	if (r < 0)
 		return r;
 
 	for (i = 0; i < ELEMENTSOF(caps); i++) {
 		cap = caps[i];
 		if (ratbag_profile_has_capability(lib_profile, cap)) {
-			r = sd_bus_message_append(reply, "u", cap);
+			r = sd_bus_message_append(reply, "i", cap);
 			if (r < 0)
 				return r;
 		}
@@ -440,7 +440,7 @@ const sd_bus_vtable ratbagd_profile_vtable[] = {
 				 ratbagd_profile_set_enabled, 0,
 				 SD_BUS_VTABLE_UNPRIVILEGED|SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_PROPERTY("Index", "u", NULL, offsetof(struct ratbagd_profile, index), SD_BUS_VTABLE_PROPERTY_CONST),
-	SD_BUS_PROPERTY("Capabilities", "au", ratbagd_profile_get_capabilities, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+	SD_BUS_PROPERTY("Capabilities", "ai", ratbagd_profile_get_capabilities, 0, SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_PROPERTY("Resolutions", "ao", ratbagd_profile_get_resolutions, 0, 0),
 	SD_BUS_PROPERTY("Buttons", "ao", ratbagd_profile_get_buttons, 0, 0),
 	SD_BUS_PROPERTY("Leds", "ao", ratbagd_profile_get_leds, 0, 0),

--- a/ratbagd/ratbagd-resolution.c
+++ b/ratbagd/ratbagd-resolution.c
@@ -133,20 +133,20 @@ ratbagd_resolution_get_capabilities(sd_bus *bus,
 	enum ratbag_resolution_capability cap;
 	int r;
 
-	r = sd_bus_message_open_container(reply, 'a', "u");
+	r = sd_bus_message_open_container(reply, 'a', "i");
 	if (r < 0)
 		return r;
 
 	cap = RATBAG_RESOLUTION_CAP_INDIVIDUAL_REPORT_RATE;
 	if (ratbag_resolution_has_capability(lib_resolution, cap)) {
-		r = sd_bus_message_append(reply, "u", cap);
+		r = sd_bus_message_append(reply, "i", cap);
 		if (r < 0)
 			return r;
 	}
 
 	cap = RATBAG_RESOLUTION_CAP_SEPARATE_XY_RESOLUTION;
 	if (ratbag_resolution_has_capability(lib_resolution, cap)) {
-		r = sd_bus_message_append(reply, "u", cap);
+		r = sd_bus_message_append(reply, "i", cap);
 		if (r < 0)
 			return r;
 	}
@@ -369,7 +369,7 @@ ratbagd_resolution_set_report_rate(sd_bus *bus,
 const sd_bus_vtable ratbagd_resolution_vtable[] = {
 	SD_BUS_VTABLE_START(0),
 	SD_BUS_PROPERTY("Index", "u", NULL, offsetof(struct ratbagd_resolution, index), SD_BUS_VTABLE_PROPERTY_CONST),
-	SD_BUS_PROPERTY("Capabilities", "au", ratbagd_resolution_get_capabilities, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+	SD_BUS_PROPERTY("Capabilities", "ai", ratbagd_resolution_get_capabilities, 0, SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_PROPERTY("IsActive", "b", ratbagd_resolution_is_active, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_PROPERTY("IsDefault", "b", ratbagd_resolution_is_default, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_WRITABLE_PROPERTY("Resolution", "(uu)",

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -763,7 +763,7 @@ class RatbagdButton(_RatbagdDBus):
         @param macro A RatbagdMacro object representing the macro to apply to
                      the button, as RatbagdMacro.
         """
-        self._set_dbus_property("Macro", "a(uu)", macro.keys)
+        self._set_dbus_property("Macro", "a(iu)", macro.keys)
 
     @GObject.Property
     def special(self):
@@ -776,7 +776,7 @@ class RatbagdButton(_RatbagdDBus):
 
         @param special The special entry, as one of RatbagdButton.ACTION_SPECIAL_*
         """
-        self._set_dbus_property("SpecialMapping", "u", special)
+        self._set_dbus_property("SpecialMapping", "i", special)
 
     @GObject.Property
     def action_type(self):
@@ -941,7 +941,7 @@ class RatbagdLed(_RatbagdDBus):
         @param mode The new mode, as one of MODE_OFF, MODE_ON, MODE_CYCLE and
                     MODE_BREATHING.
         """
-        self._set_dbus_property("Mode", "u", mode)
+        self._set_dbus_property("Mode", "i", mode)
 
     @GObject.Property
     def modes(self):


### PR DESCRIPTION
Some of our enums use negative values for an invalid
setting. E.g. RATBAG_BUTTON_ACTION_SPECIAL_INVALID = -1

To allow using the same values in piper we should send the
enum values as signed ints.

Fixes #281