### PR TITLE
src/libratbag-data.c tools/lur-command.c: add missing limits.h includes

### DIFF
--- a/src/libratbag-data.c
+++ b/src/libratbag-data.c
@@ -28,6 +28,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <glib.h>
+#include <limits.h>
 
 #include "libratbag.h"
 #include "libratbag-private.h"

--- a/tools/lur-command.c
+++ b/tools/lur-command.c
@@ -31,6 +31,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <limits.h>
 
 #include <liblur.h>
 #include <libratbag-util.h>


### PR DESCRIPTION
Those are required to compile libratbag under musl libc systems which are stricter

Error log
```
FAILED: lur-command@exe/tools_lur-command.c.o 
x86_64-linux-musl-gcc -Ilur-command@exe -I. -I.. -I../src -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -std=gnu99 -Wno-unused-parameter -fvisibility=hidden -Wmissing-prototypes -Wstrict-prototypes -D_FORTIFY_SOURCE=2 -O2 -pipe -mtune=generic -lelogind -I/usr/x86_64-linux-musl/usr/include -MD -MQ 'lur-command@exe/tools_lur-command.c.o' -MF 'lur-command@exe/tools_lur-command.c.o.d' -o 'lur-command@exe/tools_lur-command.c.o' -c ../tools/lur-command.c
../tools/lur-command.c: In function ‘find_receiver’:
../tools/lur-command.c:145:12: error: ‘PATH_MAX’ undeclared (first use in this function); did you mean ‘INT8_MAX’?
  char path[PATH_MAX] = {0};
            ^~~~~~~~
            INT8_MAX
../tools/lur-command.c:145:12: note: each undeclared identifier is reported only once for each function it appears in
[32/57] Compiling C object 'ratbagd@exe/src_shared-rbtree.c.o'.
[33/57] Compiling C object 'ratbagd@exe/ratbagd_ratbagd.c.o'.
ninja: build stopped: subcommand failed.
```