### PR TITLE
meson.build meson_options.txt: Add systemd switch

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -50,9 +50,13 @@ pkgconfig = import('pkgconfig')
 dep_udev = dependency('libudev')
 dep_libevdev = dependency('libevdev')
 dep_libsystemd = dependency('libsystemd', version : '>=227')
-dep_systemd = dependency('systemd')
 dep_glib = dependency('glib-2.0')
 dep_lm = cc.find_library('m')
+
+enable_systemd = get_option('systemd')
+if enable_systemd
+	dep_systemd = dependency('systemd')
+endif
 
 #### libutil.a ####
 src_libutil = [
@@ -437,35 +441,39 @@ configure_file(input : 'dbus/org.freedesktop.ratbag_devel1.conf.in',
 	       configuration : config_ratbagd_devel)
 
 #### unit file ####
-unitdir = get_option('systemd-unit-dir')
-if unitdir == ''
-	libdir = get_option('libdir')
-	default_unitdir = dep_systemd.get_pkgconfig_variable('systemdsystemunitdir')
-	# Fedora uses lib64 but systemd is in lib. Hack around this so it
-	# works out of the box.
-	intended_unitdir = join_paths(get_option('prefix'), get_option('libdir'), 'systemd')
-	if get_option('prefix') == '/usr' and intended_unitdir != default_unitdir
-		message('''
-		systemd unitdir libdir mismatch detected, changing unitdir to
-			@0@
-		or specify with
-			mesonconf -Dsystemd-unit-dir=<path>
+if enable_systemd
+	unitdir = get_option('systemd-unit-dir')
+	if unitdir == ''
+		libdir = get_option('libdir')
+		default_unitdir = dep_systemd.get_pkgconfig_variable('systemdsystemunitdir')
+		# Fedora uses lib64 but systemd is in lib. Hack around this so it
+		# works out of the box.
+		intended_unitdir = join_paths(get_option('prefix'), get_option('libdir'), 'systemd')
+		if get_option('prefix') == '/usr' and intended_unitdir != default_unitdir
+			message('''
+			systemd unitdir libdir mismatch detected, changing unitdir to
+				@0@
+			or specify with
+				mesonconf -Dsystemd-unit-dir=<path>
 
-		See https://github.com/libratbag/libratbag/issues/188
-		'''.format(default_unitdir))
-		unitdir = default_unitdir
-	else
-		unitdir = intended_unitdir
+			See https://github.com/libratbag/libratbag/issues/188
+			'''.format(default_unitdir))
+			unitdir = default_unitdir
+		else
+			unitdir = intended_unitdir
+		endif
 	endif
 endif
 
 config_bindir = configuration_data()
 config_bindir.set('bindir', join_paths(get_option('prefix'), get_option('bindir')))
 
-configure_file(input : 'ratbagd/ratbagd.service.in',
-	       output : 'ratbagd.service',
-	       configuration : config_bindir,
-	       install_dir : unitdir)
+if enable_systemd
+	configure_file(input : 'ratbagd/ratbagd.service.in',
+			output : 'ratbagd.service',
+			configuration : config_bindir,
+			install_dir : unitdir)
+endif
 
 dbusdir = get_option('dbus-root-dir')
 if dbusdir == ''

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -27,3 +27,9 @@ option('dbus-group',
 	type: 'string',
 	value : '',
 	description : 'The UNIX group that is granted access to the ratbagd D-Bus service. By default all users may access it.')
+
+option('systemd',
+  type : 'boolean',
+  value : true,
+  description : 'Build systemd unit files'
+)


### PR DESCRIPTION
Allows systems that provide libelogind (which provides a portion of
libsystemd that libratbag uses) to also compile without having to patch
out the rest of the build to remove the full systemd dependency.

This commit:

- Adds a systemd swith on meson_options.txt, a boolean set to true as
default to keep expected behaivour
- Adds a check on meson.build for the systemd switch and adds
dep_systemd
- Guards sections meant to generate systemd service units under the
systemd switch