### PR TITLE
ratbagd: do not warn when converting invalid special action

### DIFF
--- a/ratbagd/ratbagd-button.c
+++ b/ratbagd/ratbagd-button.c
@@ -132,11 +132,8 @@ static int ratbagd_button_get_special(sd_bus *bus,
 	enum ratbag_button_action_special special;
 
 	special = ratbag_button_get_special(button->lib_button);
-	if (special == RATBAG_BUTTON_ACTION_SPECIAL_INVALID) {
-		log_error("%s: changing button special action from INVALID to UNKNOWN\n",
-			  ratbagd_device_get_sysname(button->device));
+	if (special == RATBAG_BUTTON_ACTION_SPECIAL_INVALID)
 		special = RATBAG_BUTTON_ACTION_SPECIAL_UNKNOWN;
-	}
 
 	verify_unsigned_int(special);
 


### PR DESCRIPTION
In the review of #516 I requested error logging when we converted an invalid special action to an unknown. That turned out to be a mistake.  Clients e.g. ratbagctl ask for all properties, so this getter function gets called often even if the button is not a special action. I only thought that we would call the getter of the actual button type, and that each conversion from invalid to unknown would thus be due to an internal confusion of the type. I was wrong.

We do not want to send the value for an invalid special action as
that is negative 1. Converting to unknown is good enough here so
let's just remove the error logging and convert in silence.