### PR TITLE
Read input reports from different endpoint

### DIFF
--- a/src/driver-hidpp10.c
+++ b/src/driver-hidpp10.c
@@ -612,7 +612,7 @@ hidpp10drv_probe(struct ratbag_device *device)
 		goto err;
 
 	drv_data = zalloc(sizeof(*drv_data));
-	hidpp_device_init(&base, device->hidraw.fd);
+	hidpp_device_init(&base, device->hidraw[0].fd);
 	hidpp_device_set_log_handler(&base, hidpp10_log, HIDPP_LOG_PRIORITY_RAW, device);
 
 	typestr = ratbag_device_data_hidpp10_get_profile_type(device->data);

--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -1310,7 +1310,7 @@ hidpp20drv_probe(struct ratbag_device *device)
 
 	drv_data = zalloc(sizeof(*drv_data));
 	ratbag_set_drv_data(device, drv_data);
-	hidpp_device_init(&base, device->hidraw.fd);
+	hidpp_device_init(&base, device->hidraw[0].fd);
 	hidpp_device_set_log_handler(&base, hidpp20_log, HIDPP_LOG_PRIORITY_RAW, device);
 
 	device_idx = ratbag_device_data_hidpp20_get_index(device->data);

--- a/src/libratbag-hidraw.h
+++ b/src/libratbag-hidraw.h
@@ -32,6 +32,7 @@
 #define HID_INPUT_REPORT	0
 #define HID_OUTPUT_REPORT	1
 #define HID_FEATURE_REPORT	2
+#define MAX_HIDRAW 2
 
 struct ratbag_hid_report {
 	unsigned int report_id;
@@ -56,6 +57,18 @@ struct ratbag_hidraw {
 int ratbag_open_hidraw(struct ratbag_device *device);
 
 /**
+ * Open a hidraw device associated with the device by its enumeration order to
+ * a specific internal hidraw index.
+ *
+ * @param device the ratbag device
+ * @param enumeration index of the endpoint
+ * @param interal index of hidraw array
+ *
+ * @return 0 on success or a negative errno on error
+ */
+int ratbag_open_hidraw_index(struct ratbag_device *device, int endpoint_index, int hidraw_index);
+
+/**
  * Find and open the hidraw device associated with the device by using the
  * given matching function.
  *
@@ -74,6 +87,14 @@ ratbag_find_hidraw(struct ratbag_device *device,
  * @param device the ratbag device
  */
 void ratbag_close_hidraw(struct ratbag_device *device);
+
+/**
+ * Close a hidraw device associated with the device by the internal index.
+ *
+ * @param device the ratbag device
+ * @param interal index of hidraw array
+ */
+void ratbag_close_hidraw_index(struct ratbag_device *device, int idx);
 
 /**
  * Send report request to device
@@ -114,6 +135,19 @@ int ratbag_hidraw_output_report(struct ratbag_device *device, uint8_t *buf, size
  * @return count of data transfered, or a negative errno on error
  */
 int ratbag_hidraw_read_input_report(struct ratbag_device *device, uint8_t *buf, size_t len);
+
+/**
+ * Read an input report from the device from a specific hidraw index
+ *
+ * @param device the ratbag device
+ * @param[out] buf resulting raw data
+ * @param len length of buf
+ * @param interal index of hidraw array
+ *
+ * @return count of data transfered, or a negative errno on error
+ */
+int ratbag_hidraw_read_input_report_index(struct ratbag_device *device, uint8_t *buf, size_t len, int hidrawno);
+
 
 /**
  * Tells if a given device has the specified report ID.

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -129,7 +129,7 @@ struct ratbag_device {
 	void *userdata;
 
 	struct udev_device *udev_device;
-	struct ratbag_hidraw hidraw;
+	struct ratbag_hidraw hidraw[MAX_HIDRAW];
 	int refcount;
 	struct input_id ids;
 	struct ratbag_driver *driver;


### PR DESCRIPTION
This is a bit of work in progress, but is still usable as is. The motivation for pushing this now is the plans for changing from udev for flatpak support in ratbagd which would require changes in the same code.

This PR will add support in libratbag for those devices that receive reports on one endpoint but send the response on another. This is done by mice from both steelseries and cooler master. In this PR we added the functionality needed in libratbag itself and starts to make use of it from the steelseries driver.

More work is needed to read a full profile from the steelseries mice, but @FFY00 has already understood a good part of the protocol needed. I would love to see followup patches with additional data read, and more testing of device/firmware differences.