### PR TITLE
Add --version and --quiet to ratbagd

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -161,15 +161,6 @@ deps_libratbag = [
 	dep_libhidpp,
 ]
 
-libratbag_version_h_config = configuration_data()
-libratbag_version_h_config.set_quoted('LIBRATBAG_VERSION', meson.project_version())
-
-libratbag_version_h = configure_file(
-	output : 'libratbag-version.h',
-	configuration : libratbag_version_h_config,
-	install: false,
-)
-
 lib_libratbag = static_library('ratbag',
 	src_libratbag,
 	include_directories : include_directories('.'),

--- a/meson.build
+++ b/meson.build
@@ -38,6 +38,7 @@ add_project_arguments(cppflags, language: 'cpp')
 # is generated at the end of this file
 config_h = configuration_data()
 config_h.set('_GNU_SOURCE', '1')
+config_h.set_quoted('RATBAG_VERSION', meson.project_version())
 config_h.set_quoted('FALLBACK_SVG_NAME', 'fallback.svg')
 libratbag_data_dir = join_paths(get_option('prefix'),
 				get_option('datadir'),

--- a/ratbagd/ratbagd-device.c
+++ b/ratbagd/ratbagd-device.c
@@ -323,10 +323,10 @@ int ratbagd_device_new(struct ratbagd_device **out,
 	device->n_profiles = ratbag_device_get_num_profiles(device->lib_device);
 	device->profiles = zalloc(device->n_profiles * sizeof(*device->profiles));
 
-	log_verbose("%s: \"%s\", %d profiles\n",
-		    sysname,
-		    ratbag_device_get_name(lib_device),
-		    device->n_profiles);
+	log_info("%s: \"%s\", %d profiles\n",
+		 sysname,
+		 ratbag_device_get_name(lib_device),
+		 device->n_profiles);
 
 	for (i = 0; i < device->n_profiles; ++i) {
 		profile = ratbag_device_get_profile(device->lib_device, i);

--- a/ratbagd/ratbagd.c
+++ b/ratbagd/ratbagd.c
@@ -539,14 +539,17 @@ int main(int argc, char *argv[])
 #endif
 
 	if (argc > 1) {
-		if (streq(argv[1], "--quiet")) {
+		if (streq(argv[1], "--version")) {
+			printf("%s\n", RATBAG_VERSION);
+			return 0;
+		} else if (streq(argv[1], "--quiet")) {
 			log_level = LL_QUIET;
 		} else if (streq(argv[1], "--verbose=raw")) {
 			log_level = LL_RAW;
 		} else if (streq(argv[1], "--verbose")) {
 			log_level = LL_VERBOSE;
 		} else {
-			fprintf(stderr, "Usage: %s [--quiet | --verbose[=raw]]\n",
+			fprintf(stderr, "Usage: %s [--version | --quiet | --verbose[=raw]]\n",
 				program_invocation_short_name);
 			r = -EINVAL;
 			goto exit;

--- a/ratbagd/ratbagd.h
+++ b/ratbagd/ratbagd.h
@@ -54,6 +54,7 @@ struct ratbagd_resolution;
 struct ratbagd_button;
 struct ratbagd_led;
 
+void log_info(const char *fmt, ...) _printf_(1, 2);
 void log_verbose(const char *fmt, ...) _printf_(1, 2);
 void log_error(const char *fmt, ...) _printf_(1, 2);
 

--- a/tools/toolbox.py
+++ b/tools/toolbox.py
@@ -75,6 +75,8 @@ def start_ratbagd(verbosity=0):
         args.append('--verbose=raw')
     elif verbosity >= 2:
         args.append('--verbose')
+    elif verbosity == 0:
+        args.append('--quiet')
 
     ratbagd_process = subprocess.Popen(args, shell=False, stdout=sys.stdout, stderr=sys.stderr)
 


### PR DESCRIPTION
We don't have an easy way to query the version of ratbagd itself (`ratbag-command --version` works though), so let's add `--version`.

And the default `ratbagd` process doesn't print anything so we hope it just works rather than hanging. Add a `--quiet` argument for that mode and in the default startup at least print the devices as we find them.