### PR TITLE
ratbagd: provide a decent error message when the bus name is taken

### DIFF
--- a/ratbagd/ratbagd.c
+++ b/ratbagd/ratbagd.c
@@ -568,8 +568,12 @@ exit:
 	ratbagd_free(ctx);
 
 	if (r < 0) {
-		errno = -r;
-		log_error("Failed to start ratbagd: %m\n");
+		if (r == -EEXIST) {
+			log_error("Bus name is taken, another instance of ratbagd is already running.\n");
+		} else {
+			errno = -r;
+			log_error("Failed to start ratbagd: %m\n");
+		}
 		return EXIT_FAILURE;
 	}
 


### PR DESCRIPTION
sd-bus returns EEXISTS which is "File exists" and way too confusing. Let's
print out a decent error message for that case.

Relater #535