### PR TITLE
Fix coverity

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -46,6 +46,25 @@ libratbag_data_dir = join_paths(get_option('prefix'),
 libratbag_data_dir_devel = join_paths(meson.source_root(), 'data')
 config_h.set_quoted('LIBRATBAG_DATA_DIR', libratbag_data_dir)
 
+# Coverity breaks because it doesn't define _Float128 correctly, you'll end
+# up with a bunch of messages in the form:
+# "/usr/include/stdlib.h", line 133: error #20: identifier "_Float128" is
+#           undefined
+#   extern _Float128 strtof128 (const char *__restrict __nptr,
+#          ^
+# We don't use float128 ourselves, it gets pulled in from math.h or
+# something, so let's just define it as uint128 and move on.
+# Unfortunately we can't detect the coverity build at meson configure
+# time, we only know it fails at runtime. So make this an option instead, to
+# be removed when coverity fixes this again.
+if get_option('coverity')
+        config_h.set('_Float128', '__uint128_t')
+        config_h.set('_Float32', 'int')
+        config_h.set('_Float32x', 'int')
+        config_h.set('_Float64', 'long')
+        config_h.set('_Float64x', 'long')
+endif
+
 # dependencies
 pkgconfig = import('pkgconfig')
 dep_udev = dependency('libudev')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -38,3 +38,8 @@ option('logind-provider',
   choices: [ 'elogind', 'systemd'],
   value : 'systemd',
   description : 'Which logind provider to use')
+
+option('coverity',
+       type: 'boolean',
+       value: false,
+       description: 'Enable coverity build fixes, see meson.build for details [default=false]')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -31,12 +31,10 @@ option('dbus-group',
 option('systemd',
 	type : 'boolean',
 	value : true,
-	description : 'Build systemd unit files'
-)
+	description : 'Build systemd unit files')
 
 option('logind-provider',
   type : 'combo',
   choices: [ 'elogind', 'systemd'],
   value : 'systemd',
-  description : 'Which logind provider to use'
-)
+  description : 'Which logind provider to use')


### PR DESCRIPTION
no, not coverity fixes, but really "fix coverity". It doesn't like gcc7 and spews things like undefined type _Float128 by the millions (you can never have enough of those errors, I guess).

So let's give libratbag a special "be nice to coverity" option and let meson define all the types coverity is really unhappy about. 