### PR TITLE
Add Logitech G PowerPlay wireless configuration

### DIFF
--- a/data/devices/logitech-gpowerplay-wireless.device
+++ b/data/devices/logitech-gpowerplay-wireless.device
@@ -1,0 +1,9 @@
+# Logitech G PowerPlay mouse pad + wireless USB receiver.
+[Device]
+Name=Logitech G PowerPlay mouse pad.
+DeviceMatch=usb:046d:c53a
+Driver=hidpp20
+Svg=logitech-g900.svg
+
+[Driver/hidpp20]
+DeviceIndex=1


### PR DESCRIPTION
Tested with a Logitech G903, should also work with a Logitech G703.
May also work with other Logitech mice that work with a G900 receiver.