### PR TITLE
hidpp20: if a command returns with error, return a neg errno

### DIFF
--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -189,7 +189,9 @@ out_err:
 int
 hidpp20_request_command(struct hidpp20_device *device, union hidpp20_message *msg)
 {
-	return hidpp20_request_command_allow_error(device, msg, false);
+	int ret = hidpp20_request_command_allow_error(device, msg, false);
+
+	return ret > 0 ? -EPROTO : ret;
 }
 
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
I'm pretty sure all callers rely on this command to return either 0 or a
negative errno. There's a quirky occasion where if we get a HID error (a
positive number) during hidpp20_special_keys_buttons_get_reporting, that
number eventually ends up as the 'num_controls' value in
hidpp20_special_key_mouse_get_controls().

Since the only time we care about HID++ errors is during
hidpp20_root_get_protocol_version, let's just always return -EPROTO on HID++
errors.

Fixes #558