### PR TITLE
ratbagd: update all properties before sending out Resync

### DIFF
--- a/ratbagd/ratbagd-button.c
+++ b/ratbagd/ratbagd-button.c
@@ -433,3 +433,15 @@ struct ratbagd_button *ratbagd_button_free(struct ratbagd_button *button)
 	return mfree(button);
 }
 
+int ratbagd_button_resync(sd_bus *bus,
+			      struct ratbagd_button *button)
+{
+	return sd_bus_emit_properties_changed(bus,
+					      button->path,
+					      RATBAGD_NAME_ROOT ".Button",
+					      "ButtonMapping",
+					      "SpecialMapping",
+					      "Macro",
+					      "ActionType",
+					      NULL);
+}

--- a/ratbagd/ratbagd-device.c
+++ b/ratbagd/ratbagd-device.c
@@ -438,6 +438,10 @@ int ratbagd_device_resync(struct ratbagd_device *device, sd_bus *bus)
 {
 	assert(device);
 	assert(bus);
+
+	ratbagd_for_each_profile_signal(bus, device,
+					ratbagd_profile_resync);
+
 	return sd_bus_emit_signal(bus,
 				  device->path,
 				  RATBAGD_NAME_ROOT ".Device",

--- a/ratbagd/ratbagd-led.c
+++ b/ratbagd/ratbagd-led.c
@@ -360,3 +360,15 @@ struct ratbagd_led *ratbagd_led_free(struct ratbagd_led *led)
 	return mfree(led);
 }
 
+int ratbagd_led_resync(sd_bus *bus,
+		       struct ratbagd_led *led)
+{
+	return sd_bus_emit_properties_changed(bus,
+					      led->path,
+					      RATBAGD_NAME_ROOT ".Led",
+					      "Mode",
+					      "Color",
+					      "EffectDuration",
+					      "Brightness",
+					      NULL);
+}

--- a/ratbagd/ratbagd-profile.c
+++ b/ratbagd/ratbagd-profile.c
@@ -788,3 +788,47 @@ int ratbagd_for_each_resolution_signal(sd_bus *bus,
 
 	return rc;
 }
+
+int ratbagd_for_each_button_signal(sd_bus *bus,
+				       struct ratbagd_profile *profile,
+				       int (*func)(sd_bus *bus,
+						   struct ratbagd_button *button))
+{
+	int rc = 0;
+
+	for (size_t i = 0; rc == 0 && i < profile->n_buttons; i++)
+		rc = func(bus, profile->buttons[i]);
+
+	return rc;
+}
+
+int ratbagd_for_each_led_signal(sd_bus *bus,
+				       struct ratbagd_profile *profile,
+				       int (*func)(sd_bus *bus,
+						   struct ratbagd_led *button))
+{
+	int rc = 0;
+
+	for (size_t i = 0; rc == 0 && i < profile->n_leds; i++)
+		rc = func(bus, profile->leds[i]);
+
+	return rc;
+}
+
+
+int ratbagd_profile_resync(sd_bus *bus,
+			    struct ratbagd_profile *profile)
+{
+	ratbagd_for_each_resolution_signal(bus, profile, ratbagd_resolution_resync);
+	ratbagd_for_each_button_signal(bus, profile, ratbagd_button_resync);
+	ratbagd_for_each_led_signal(bus, profile, ratbagd_led_resync);
+
+	return sd_bus_emit_properties_changed(bus,
+					      profile->path,
+					      RATBAGD_NAME_ROOT ".Profile",
+					      "Resolutions",
+					      "Buttons",
+					      "Leds",
+					      "IsActive",
+					      NULL);
+}

--- a/ratbagd/ratbagd-resolution.c
+++ b/ratbagd/ratbagd-resolution.c
@@ -45,6 +45,19 @@ struct ratbagd_resolution {
 	char *path;
 };
 
+int ratbagd_resolution_resync(sd_bus *bus,
+			      struct ratbagd_resolution *resolution)
+{
+	return sd_bus_emit_properties_changed(bus,
+					      resolution->path,
+					      RATBAGD_NAME_ROOT ".Resolution",
+					      "IsDefault",
+					      "Resolution",
+					      "ReportRate",
+					      "IsActive",
+					      NULL);
+}
+
 static int ratbagd_resolution_active_signal_cb(sd_bus *bus,
 						struct ratbagd_resolution *resolution)
 {

--- a/ratbagd/ratbagd.h
+++ b/ratbagd/ratbagd.h
@@ -100,6 +100,15 @@ int ratbagd_for_each_resolution_signal(sd_bus *bus,
 				       struct ratbagd_profile *profile,
 				       int (*func)(sd_bus *bus,
 						   struct ratbagd_resolution *resolution));
+int ratbagd_for_each_button_signal(sd_bus *bus,
+				   struct ratbagd_profile *profile,
+				   int (*func)(sd_bus *bus,
+					       struct ratbagd_button *button));
+int ratbagd_for_each_led_signal(sd_bus *bus,
+				struct ratbagd_profile *profile,
+				int (*func)(sd_bus *bus,
+					    struct ratbagd_led *led));
+int ratbagd_profile_resync(sd_bus *bus, struct ratbagd_profile *profile);
 
 DEFINE_TRIVIAL_CLEANUP_FUNC(struct ratbagd_profile *, ratbagd_profile_free);
 
@@ -115,6 +124,7 @@ int ratbagd_resolution_new(struct ratbagd_resolution **out,
 			   unsigned int index);
 struct ratbagd_resolution *ratbagd_resolution_free(struct ratbagd_resolution *resolution);
 const char *ratbagd_resolution_get_path(struct ratbagd_resolution *resolution);
+int ratbagd_resolution_resync(sd_bus *bus, struct ratbagd_resolution *resolution);
 
 DEFINE_TRIVIAL_CLEANUP_FUNC(struct ratbagd_resolution *, ratbagd_resolution_free);
 
@@ -130,6 +140,7 @@ int ratbagd_button_new(struct ratbagd_button **out,
 		       unsigned int index);
 struct ratbagd_button *ratbagd_button_free(struct ratbagd_button *button);
 const char *ratbagd_button_get_path(struct ratbagd_button *button);
+int ratbagd_button_resync(sd_bus *bus, struct ratbagd_button *button);
 
 DEFINE_TRIVIAL_CLEANUP_FUNC(struct ratbagd_button *, ratbagd_button_free);
 
@@ -145,6 +156,7 @@ int ratbagd_led_new(struct ratbagd_led **out,
 		    unsigned int index);
 struct ratbagd_led *ratbagd_led_free(struct ratbagd_led *led);
 const char *ratbagd_led_get_path(struct ratbagd_led *led);
+int ratbagd_led_resync(sd_bus *bus, struct ratbagd_led *led);
 
 DEFINE_TRIVIAL_CLEANUP_FUNC(struct ratbagd_led *, ratbagd_led_free);
 


### PR DESCRIPTION
Fixes #528

I can see the signals float past on dbus-monitor, but piper doesn't seem to update itself correctly (yet). I think this is an issue with piper rather than ratbagd though.