### PR TITLE
ratbagd: set up a simple exit-on-idle

### DIFF
--- a/ratbagd/ratbagd.h
+++ b/ratbagd/ratbagd.h
@@ -208,6 +208,7 @@ struct ratbagd {
 	sd_event *event;
 	struct ratbag *lib_ctx;
 	struct udev_monitor *monitor;
+	sd_event_source *timeout_source;
 	sd_event_source *monitor_source;
 	sd_bus *bus;
 


### PR DESCRIPTION
ratbagd is not something that needs stay around forever just because we
configured a mouse once. We have DBus activation and we don't store anything
anyway, so we might as well exit after a period of inactivity (20 min).

There's a slight race condition where if something comes in at exactly the
20min mark, we may shut down anyway and the messages get lost. This is too
narrow to worry about.