### PR TITLE
roccat: set the dpi list

### DIFF
--- a/src/driver-roccat.c
+++ b/src/driver-roccat.c
@@ -748,6 +748,7 @@ roccat_read_profile(struct ratbag_profile *profile)
 
 		ratbag_resolution_set_report_rate_list(resolution, report_rates,
 						       ARRAY_LENGTH(report_rates));
+		ratbag_resolution_set_dpi_list_from_range(resolution, 200, 8200);
 	}
 
 	ratbag_profile_for_each_button(profile, button)


### PR DESCRIPTION
Turns out this driver never got updated for the 'new' DPI list provided by
libratbag and thus broke with bacdab259653512e06631075216f090eadc435dc when we
enforced that DPI list.

Set a fixed DPI list based on the hardcoded values we use elsewhere in this
driver.
