### PR TITLE
Logitech G502 button 10 fix

### DIFF
--- a/data/gnome/check-svg.py
+++ b/data/gnome/check-svg.py
@@ -66,13 +66,14 @@ def check_elements(root, prefix, required=0):
     highest = -1
     for idx in range(0, 20):
         e = '{}{}'.format(prefix, idx)
+        previous = '{}{}'.format(prefix, idx - 1)
+        leader = '{}{}-leader'.format(prefix, idx)
+        path = '{}{}-path'.format(prefix, idx)
         if e in element_ids:
             highest = idx
-            previous = '{}{}'.format(prefix, idx - 1)
             if idx > 0 and previous not in element_ids:
                 logger.warning("Non-consecutive {}: {}".format(prefix, e))
 
-            leader = '{}{}-leader'.format(prefix, idx)
             if leader not in element_ids:
                 logger.error("Missing {} for {}".format(leader, e))
             else:
@@ -80,9 +81,12 @@ def check_elements(root, prefix, required=0):
                 if element is None or len(element) != 1 or element[0] is None:
                     logger.error("Missing style property for {}".format(leader))
 
-            path = '{}{}-path'.format(prefix, idx)
             if path not in element_ids:
                 logger.error("Missing {} for {}".format(path, e))
+        elif leader in element_ids:
+            logger.error("Have {} but not {}".format(leader, e))
+        elif path in element_ids:
+            logger.error("Have {} but not {}".format(path, e))
         elif idx < required:
             logger.error("Missing {}: {}".format(prefix, e))
 

--- a/data/gnome/logitech-g502.svg
+++ b/data/gnome/logitech-g502.svg
@@ -213,7 +213,7 @@
       <path
          style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
          d="m 608.6358,526.99557 v 7.97553 l -3.83318,-3.83321 z"
-         id="path1148"
+         id="button10"
          inkscape:connector-curvature="0" />
     </g>
   </g>


### PR DESCRIPTION
Fixes https://github.com/libratbag/piper/issues/240

The button was simply mislabeled in the SVG, new test case added for that now.