### PR TITLE
meson: conditional check to avoid use of depricated features after Meson v0.48.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -533,8 +533,13 @@ configure_file(input : 'dbus/org.freedesktop.ratbag1.conf.in',
 
 #### tools ####
 
-python = import('python3')
-py3 = python.find_python()
+if meson.version().version_compare('<0.48.0')
+  python = import('python3')
+  py3 = python.find_python()
+else
+  pymod = import('python')
+  py3 = pymod.find_installation()
+endif
 
 # ratbagctl calls ratbagd over DBus
 custom_target('ratbagctl',


### PR DESCRIPTION
When building the package in Archlinux I got the following:
```
DEPRECATION: Project targetting '>= 0.40.0' but tried to use feature deprecated since '0.48.0': python3 module
<snip>
WARNING: Deprecated features used:
 * 0.48.0: {'python3 module'}
```

``import(python3)`` was [depreciated in 0.48](https://github.com/mesonbuild/meson/blob/master/docs/markdown/Release-notes-for-0.48.0.md#python3-module-is-deprecated).