### PR TITLE
hidpp20: if the button is remapped, use that

### DIFF
--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -90,7 +90,7 @@ hidpp20drv_read_button_1b04(struct ratbag_button *button)
 
 	control = &drv_data->controls[button->index];
 	mapping = control->control_id;
-	if (control->reporting.divert || control->reporting.persist)
+	if (control->reporting.remapped)
 		mapping = control->reporting.remapped;
 	log_raw(device->ratbag,
 		  " - button%d: %s (%02x) %s%s:%d\n",


### PR DESCRIPTION
A non-zero value for the remapped field means the button is mapped to that
button.

"diverted" means to decouple it from normal HID reports and report it via
HID++ only. In our case here, we "map" it, which is different.

Fixes `button set`/`button get` mismatch listed in #587 