### PR TITLE
Change G102/203's symlink to G-Pro

### DIFF
--- a/data/gnome/logitech-g102-g203.svg
+++ b/data/gnome/logitech-g102-g203.svg
@@ -1,1 +1,1 @@
-logitech-g303.svg
+logitech-g-pro.svg


### PR DESCRIPTION
The three mouses have the same design, so I changed G102's symlink to the G-Pro's SVG.