### PR TITLE
Fix the Logitech G Pro GNOME SVG

### DIFF
--- a/data/gnome/logitech-g-pro.svg
+++ b/data/gnome/logitech-g-pro.svg
@@ -37,11 +37,11 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1.9881757"
-     inkscape:cx="204.03959"
-     inkscape:cy="203.08966"
+     inkscape:zoom="0.99408785"
+     inkscape:cx="119.04209"
+     inkscape:cy="99.169501"
      inkscape:document-units="px"
-     inkscape:current-layer="LEDs"
+     inkscape:current-layer="Buttons"
      inkscape:document-rotation="0"
      showgrid="false"
      units="px"
@@ -308,7 +308,8 @@
     </g>
     <g
        id="button1-path"
-       inkscape:label="#g1002">
+       inkscape:label="#g1002"
+       transform="translate(0,-11.999703)">
       <rect
          inkscape:label="#rect867"
          style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"

--- a/data/gnome/logitech-g-pro.svg
+++ b/data/gnome/logitech-g-pro.svg
@@ -38,8 +38,8 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="1.9881757"
-     inkscape:cx="89.311243"
-     inkscape:cy="190.59507"
+     inkscape:cx="204.03959"
+     inkscape:cy="203.08966"
      inkscape:document-units="px"
      inkscape:current-layer="LEDs"
      inkscape:document-rotation="0"
@@ -49,11 +49,11 @@
      inkscape:showpageshadow="false"
      inkscape:pagecheckerboard="false"
      showguides="true"
-     inkscape:window-width="2560"
-     inkscape:window-height="1381"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
+     inkscape:window-width="960"
+     inkscape:window-height="1016"
+     inkscape:window-x="960"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0"
      fit-margin-top="20"
      fit-margin-left="20"
      fit-margin-bottom="20"
@@ -78,7 +78,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -87,25 +87,76 @@
      id="Device"
      inkscape:label="Device"
      transform="translate(-68.791597,-394.02675)"
-     style="display:inline" />
-  <g
-     inkscape:groupmode="layer"
-     id="Buttons"
-     inkscape:label="Buttons"
-     style="display:inline"
-     transform="translate(-68.791597,5.973336)">
+     style="display:inline">
     <path
+       transform="translate(0,400.00009)"
        inkscape:connector-curvature="0"
        style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
        d="m 266.16642,15.04496 c -22.92467,4.66104 -61.30054,24.9861 -69.63884,36.00461 -12.61957,47.68515 -14.80528,106.34213 -15.92423,155.87459 -2.00552,88.77814 32.07323,172.95939 100.58708,173.36506 46.62862,0.10701 67.422,-29.01299 84.50986,-68.69579 14.62944,-39.36304 14.98472,-73.16931 15.71414,-103.07446 0.40991,-66.33641 -5.20115,-105.262 -13.70975,-157.25734 C 354.76319,35.15715 299.72236,14.28047 297.61469,15.04496 v 5.05311 h -3.45953 v -5.05311 l -25.2862,3.5e-4 v 5.05276 l -2.70254,-10e-6 z"
        id="path870"
        sodipodi:nodetypes="ccscccccccccccc" />
     <path
-       style="display:inline;fill:#989896;stroke:#babdb6;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
-       d="M 229.17383 21.009766 C 229.00748 20.992194 228.88813 20.993688 228.82227 21.017578 L 228.82227 26.072266 L 225.36328 26.072266 L 225.36328 21.017578 L 200.07812 21.019531 L 200.07812 26.072266 L 197.375 26.072266 L 197.375 21.017578 C 174.45033 25.678618 136.07463 46.004927 127.73633 57.023438 C 116.35922 100.01374 113.47533 151.86101 112.19531 197.96094 L 112.19727 197.96289 L 194.28711 159.88281 C 194.19011 159.92441 192.73412 179.58139 211.27148 179.11133 C 229.80884 178.64127 228.7988 160.0586 228.82227 160.05078 L 312.53125 197.98242 L 312.58008 197.88281 C 312.02168 141.36823 306.68242 104.71806 298.91211 57.234375 C 286.37504 41.63316 234.33067 21.554483 229.17383 21.009766 z "
+       style="display:inline;fill:#989896;fill-opacity:1;stroke:#babdb6;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 229.17383,21.009766 c -0.16635,-0.01757 -0.2857,-0.01608 -0.35156,0.0078 v 5.054688 h -3.45899 v -5.054688 l -25.28516,0.002 v 5.052735 H 197.375 v -5.054688 c -22.92467,4.66104 -61.30037,24.987349 -69.63867,36.00586 -11.37711,42.990297 -14.261,94.837567 -15.54102,140.937497 l 0.002,0.002 82.08984,-38.08008 c -0.097,0.0416 -1.55299,19.69858 16.98437,19.22852 18.53736,-0.47006 17.52732,-19.05273 17.55079,-19.06055 l 83.70898,37.93164 0.0488,-0.0996 C 312.02168,141.36823 306.68242,104.71806 298.91211,57.234375 286.37504,41.63316 234.33067,21.554483 229.17383,21.009766 Z"
        id="path1006"
-       transform="translate(68.791597,-5.973336)" />
+       inkscape:connector-curvature="0"
+       transform="translate(68.791597,394.02675)" />
+    <path
+       transform="translate(0,400.00009)"
+       style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#d3d3ce;fill-opacity:1;stroke:#bfc2bb;stroke-width:1.5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="m 266.16185,15.045758 c -18.53203,3.769004 -47.15067,17.769904 -61.84571,28.81836 -11.15926,49.01809 -14.18353,94.599442 -16.57028,140.693352 l 75.52927,-35.0039 2.89062,-129.455077 h -0.004 z"
+       id="button0"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc"
+       inkscape:label="#button0" />
+    <path
+       style="display:inline;fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 132.05273,52.619141 c -1.82879,1.575925 -3.29915,3.06006 -4.3164,4.404297 -11.02439,41.657485 -14.08583,91.685452 -15.42969,136.691402 l 0.0527,-0.0137 3.71874,-1.73242 c 1.00541,-44.43893 6.38155,-97.490788 15.99415,-139.328125 0.001,-0.0054 -0.0176,-0.01533 -0.0195,-0.02148 z"
+       id="path1008"
+       inkscape:connector-curvature="0"
+       transform="translate(68.791597,394.02675)" />
     <rect
+       transform="translate(0,400.00009)"
+       style="display:inline;opacity:1;fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:1.5;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect985"
+       width="25.286205"
+       height="35.886375"
+       x="268.86896"
+       y="15.044975"
+       rx="0"
+       ry="0" />
+    <path
+       transform="translate(0,400.00009)"
+       style="display:inline;opacity:1;fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:1.5;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 267.69435,112.88968 25.82029,0.0837 0.40098,45.62246 c -3.09214,13.17174 -23.47755,15.50099 -27.35134,0 z"
+       id="rect1003"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <rect
+       transform="translate(0,400.00009)"
+       inkscape:label="#button5"
+       ry="5.2884812"
+       rx="6.152226"
+       y="132.22084"
+       x="273.28256"
+       height="31.288317"
+       width="13.468106"
+       id="button5"
+       style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:0.99999988;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+    <path
+       style="display:inline;fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 294.34961,52.697266 c 7.67404,38.319455 12.12064,93.009104 13.58789,139.437504 l 4.29102,2.33203 0.31445,0.13867 c -0.72941,-54.66832 -6.01154,-90.81008 -13.63086,-137.371095 -1.18866,-1.479179 -2.73716,-2.997879 -4.5625,-4.537109 z"
+       id="path1010"
+       inkscape:connector-curvature="0"
+       transform="translate(68.791597,394.02675)" />
+    <path
+       transform="translate(0,400.00009)"
+       inkscape:connector-curvature="0"
+       style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#d3d3ce;fill-opacity:1;stroke:#bfc2bb;stroke-width:1.5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="m 297.61497,15.045758 v 5.052735 h -0.004 c -0.072,38.851502 0.17641,91.903097 0.004,129.455077 l 76.24024,35.0039 C 371.4683,138.46428 370.62141,92.883297 359.46263,43.866071 348.69198,36.04897 332.00497,28.07624 318.64622,22.491071 307.62271,18.054789 298.7509,15.065752 297.61497,15.045758 Z"
+       id="button1" />
+    <rect
+       transform="translate(0,400.00009)"
        style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:0.99999982;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
        id="button2"
        width="21.314863"
@@ -115,6 +166,12 @@
        rx="10.657432"
        ry="11.054664"
        inkscape:label="#button2" />
+    <path
+       transform="translate(0,400.00009)"
+       inkscape:connector-curvature="0"
+       style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="m 183.47044,134.90318 -3.23828,3.46679 -2.36328,40.83203 3.375,2.76368 c 0.0158,-0.0318 0.0292,-0.0639 0.0449,-0.0957 0.4971,-15.01188 1.2161,-30.49256 2.37305,-45.99218 -0.0654,-0.32133 -0.12562,-0.6554 -0.19141,-0.97461 z"
+       id="button4" />
     <path
        style="color:#000000;display:inline;overflow:visible;fill:none;fill-opacity:1;stroke:#babdb6;stroke-width:10;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="led0"
@@ -128,66 +185,30 @@
        sodipodi:arc-type="arc"
        d="m -319.14844,290.54175 a 13.376111,13.525835 0 0 1 -18.91668,0 13.376111,13.525835 0 0 1 0,-19.12842 13.376111,13.525835 0 0 1 18.91668,0"
        sodipodi:open="true"
-       transform="rotate(-90)"
+       transform="rotate(-90,200.00004,200.00004)"
        inkscape:label="#led0" />
     <path
-       inkscape:connector-curvature="0"
-       style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#d3d3ce;fill-opacity:1;stroke:#bfc2bb;stroke-width:1.5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
-       d="m 297.61497,15.045758 v 5.052735 h -0.004 c -0.072,38.851502 0.17641,91.903097 0.004,129.455077 l 76.24024,35.0039 C 371.4683,138.46428 370.62141,92.883297 359.46263,43.866071 348.69198,36.04897 332.00497,28.07624 318.64622,22.491071 307.62271,18.054789 298.7509,15.065752 297.61497,15.045758 Z"
-       id="button1" />
-    <path
-       inkscape:connector-curvature="0"
-       style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
-       d="m 183.47044,134.90318 -3.23828,3.46679 -2.36328,40.83203 3.375,2.76368 c 0.0158,-0.0318 0.0292,-0.0639 0.0449,-0.0957 0.4971,-15.01188 1.2161,-30.49256 2.37305,-45.99218 -0.0654,-0.32133 -0.12562,-0.6554 -0.19141,-0.97461 z"
-       id="button4" />
-    <path
+       transform="translate(0,400.00009)"
        style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
        d="m 180.98802,191.98911 -3.65625,3.90235 0.70171,41.21448 3.55024,4.1781 c -0.0255,-0.32903 -0.0218,-0.78636 -0.0254,-1.21094 -0.88777,-10.87151 -1.20752,-21.97334 -0.95508,-33.14844 0.11017,-4.87659 0.24499,-9.90124 0.38477,-14.93555 z"
        id="button3"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cccccsc" />
     <path
-       style="display:inline;opacity:1;fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:1.5;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 267.69435,112.88968 25.82029,0.0837 0.40098,45.62246 c -3.09214,13.17174 -23.47755,15.50099 -27.35134,0 z"
-       id="rect1003"
+       transform="translate(0,400.00009)"
+       sodipodi:nodetypes="ccccsccsccccc"
+       id="led1"
+       d="m 381.38813,191.93864 c 0.0522,5.34015 0.0617,10.85826 0.0263,16.58033 -0.72942,29.90515 -1.0847,63.71142 -15.71414,103.07446 -17.08786,39.6828 -37.88124,68.8028 -84.50986,68.69579 -68.51385,-0.40567 -102.5926,-84.58692 -100.58708,-173.36506 0.11095,-4.91156 0.2425,-9.86517 0.38356,-14.93656 l 2.19839,0.0215 c -0.13796,4.95985 -0.26661,11.86142 -0.37513,16.66495 -1.96142,86.82554 31.36807,166.8792 98.37558,167.27594 45.60344,0.10466 65.93966,-26.09877 82.65183,-64.90878 14.30779,-38.49728 14.65526,-71.56001 15.36865,-100.80742 0.0346,-5.59622 0.0253,-13.00199 -0.0257,-18.22469 z"
+       style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#babdb6;fill-opacity:1;stroke:#babdb6;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
        inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccc" />
-    <rect
-       inkscape:label="#button5"
-       ry="5.2884812"
-       rx="6.152226"
-       y="132.22084"
-       x="273.28256"
-       height="31.288317"
-       width="13.468106"
-       id="button5"
-       style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:0.99999988;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
-    <rect
-       style="display:inline;opacity:1;fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:1.5;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect985"
-       width="25.286205"
-       height="35.886375"
-       x="268.86896"
-       y="15.044975"
-       rx="0"
-       ry="0" />
-    <path
-       style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#d3d3ce;fill-opacity:1;stroke:#bfc2bb;stroke-width:1.5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
-       d="m 266.16185,15.045758 c -18.53203,3.769004 -47.15067,17.769904 -61.84571,28.81836 -11.15926,49.01809 -14.18353,94.599442 -16.57028,140.693352 l 75.52927,-35.0039 2.89062,-129.455077 h -0.004 z"
-       id="button0"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccccc"
-       inkscape:label="#button0" />
-    <path
-       style="display:inline;fill:#d3d3ce;stroke:#babdb6;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
-       d="M 132.05273 52.619141 C 130.22394 54.195066 128.75358 55.679201 127.73633 57.023438 C 116.71194 98.680923 113.6505 148.70889 112.30664 193.71484 L 112.35938 193.70117 L 116.07812 191.96875 C 117.08353 147.52982 122.45967 94.477962 132.07227 52.640625 C 132.0735 52.635269 132.0547 52.625295 132.05273 52.619141 z "
-       transform="translate(68.791597,-5.973336)"
-       id="path1008" />
-    <path
-       style="display:inline;fill:#d3d3ce;stroke:#babdb6;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
-       d="M 294.34961 52.697266 C 302.02365 91.016721 306.47025 145.70637 307.9375 192.13477 L 312.22852 194.4668 L 312.54297 194.60547 C 311.81356 139.93715 306.53143 103.79539 298.91211 57.234375 C 297.72345 55.755196 296.17495 54.236496 294.34961 52.697266 z "
-       id="path1010"
-       transform="translate(68.791597,-5.973336)" />
+       inkscape:label="#led1" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="Buttons"
+     inkscape:label="Buttons"
+     style="display:inline"
+     transform="translate(-68.791597,5.973336)">
     <g
        id="button4-path">
       <path
@@ -335,13 +356,6 @@
          id="rect970"
          style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
     </g>
-    <path
-       sodipodi:nodetypes="ccccsccsccccc"
-       id="led1"
-       d="m 381.38813,191.93864 c 0.0522,5.34015 0.0617,10.85826 0.0263,16.58033 -0.72942,29.90515 -1.0847,63.71142 -15.71414,103.07446 -17.08786,39.6828 -37.88124,68.8028 -84.50986,68.69579 -68.51385,-0.40567 -102.5926,-84.58692 -100.58708,-173.36506 0.11095,-4.91156 0.2425,-9.86517 0.38356,-14.93656 l 2.19839,0.0215 c -0.13796,4.95985 -0.26661,11.86142 -0.37513,16.66495 -1.96142,86.82554 31.36807,166.8792 98.37558,167.27594 45.60344,0.10466 65.93966,-26.09877 82.65183,-64.90878 14.30779,-38.49728 14.65526,-71.56001 15.36865,-100.80742 0.0346,-5.59622 0.0253,-13.00199 -0.0257,-18.22469 z"
-       style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#babdb6;fill-opacity:1;stroke:#babdb6;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
-       inkscape:connector-curvature="0"
-       inkscape:label="#led1" />
   </g>
   <g
      inkscape:groupmode="layer"
@@ -354,7 +368,7 @@
       <path
          inkscape:connector-curvature="0"
          id="path877"
-         d="m 485,329.52026 -203.94584,0"
+         d="M 485,329.52026 H 281.05416"
          style="color:#000000;display:inline;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
          sodipodi:nodetypes="cc" />
       <rect
@@ -378,7 +392,7 @@
       <path
          sodipodi:nodetypes="cc"
          style="color:#000000;display:inline;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
-         d="m 484.99745,272.95285 -105.75862,0"
+         d="M 484.99745,272.95285 H 379.23883"
          id="path4525"
          inkscape:connector-curvature="0" />
       <rect


### PR DESCRIPTION
This fixes two issues, both visible in #607:

1. Ensure that Piper renders the device
2. Fix the vertical spacing between two leader lines.