### PR TITLE
ASCII-only profile name hack

### DIFF
--- a/ratbagd/ratbagd-profile.c
+++ b/ratbagd/ratbagd-profile.c
@@ -382,8 +382,15 @@ ratbagd_profile_get_name(sd_bus *bus,
 {
 	struct ratbagd_profile *profile = userdata;
 	const char *name = ratbag_profile_get_name(profile->lib_profile);
+	_cleanup_free_ char *asciiname;
 
-	CHECK_CALL(sd_bus_message_append(reply, "s", name));
+	/* This should really be a UTF8 check and it should really be in
+	 * libratbag, but for now this will do to at least not kick us off
+	 * the bus. https://github.com/libratbag/libratbag/issues/617
+	 */
+	asciiname = strdup_ascii_only(name);
+
+	CHECK_CALL(sd_bus_message_append(reply, "s", asciiname));
 
 	return 0;
 }

--- a/ratbagd/ratbagd-test.c
+++ b/ratbagd/ratbagd-test.c
@@ -42,6 +42,7 @@ static const struct ratbag_test_device ratbagd_test_device_descr = {
 	.svg = "fallback.svg",
 	.profiles = {
 		{
+			.name = "test profile 1",
 			.buttons = {
 				{ .button_type = RATBAG_BUTTON_TYPE_LEFT,
 				  .action_type = RATBAG_BUTTON_ACTION_TYPE_BUTTON,

--- a/src/driver-test.c
+++ b/src/driver-test.c
@@ -243,6 +243,10 @@ test_read_profile(struct ratbag_profile *profile)
 
 	profile->is_active = p->active;
 	profile->is_enabled = !p->disabled;
+	if (p->name) {
+		free(profile->name);
+		profile->name = strdup(p->name);
+	}
 
 	for (i = 0; i < ARRAY_LENGTH(p->caps) && p->caps[i]; i++) {
 		ratbag_profile_set_cap(profile, p->caps[i]);

--- a/src/libratbag-test.h
+++ b/src/libratbag-test.h
@@ -75,6 +75,7 @@ struct ratbag_test_led {
 };
 
 struct ratbag_test_profile {
+	const char *name;
 	struct ratbag_test_button buttons[RATBAG_TEST_MAX_BUTTONS];
 	struct ratbag_test_resolution resolutions[RATBAG_TEST_MAX_RESOLUTIONS];
 	struct ratbag_test_led leds[RATBAG_TEST_MAX_LEDS];

--- a/src/libratbag-util.h
+++ b/src/libratbag-util.h
@@ -116,6 +116,27 @@ snprintf_safe(char *buf, size_t n, const char *fmt, ...)
 	return rc;
 }
 
+/**
+ * Returns a strdup'd string with all non-ascii characters replaced with a
+ * space.
+ */
+static inline char *
+strdup_ascii_only(const char *str_in)
+{
+	char *str, *ascii_only;
+
+	ascii_only = strdup_safe(str_in);
+	str = ascii_only;
+	while (str && *str) {
+		unsigned char c = *str;
+		if (c > 127)
+			*str = ' ';
+
+		str++;
+	}
+	return ascii_only;
+}
+
 #define sprintf_safe(buf, fmt, ...) \
 	snprintf_safe(buf, ARRAY_LENGTH(buf), fmt, __VA_ARGS__)
 

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -522,7 +522,11 @@ def func_profile_get(r, args):
 
 def func_profile_name_get(r, args):
     p, d = find_profile(r, args)
-    print(p.name)
+    # See https://github.com/libratbag/libratbag/issues/617
+    # ratbag converts to ascii, so this has no real effect there, but
+    # ratbag-command may still have a non-ascii string.
+    string = bytes(p.name, 'utf-8', 'ignore')
+    print(string.decode('utf-8'))
 
 
 def func_profile_name_set(r, args):

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -1523,8 +1523,8 @@ def open_ratbagd(ratbagd_process=None, verbose=0):
     try:
         r = Ratbagd()
         r.verbose = verbose
-    except RatbagdUnavailable:
-        print("Unable to connect to ratbagd")
+    except RatbagdUnavailable as e:
+        print("Unable to connect to ratbagd: {}".format(e))
         return None
 
     if ratbagd_process is not None:

--- a/tools/ratbagctl.test.in
+++ b/tools/ratbagctl.test.in
@@ -141,7 +141,7 @@ class TestRatbagCtlProfile(TestRatbagCtl):
     def test_profile_name_get(self):
         command = "profile 0 name get"
         r = self.launch_good_test(command + " test_device")
-        self.assertEqual(r, 'Profile 1')
+        self.assertEqual(r, 'test profile 1')
         self.launch_fail_test(command)
         self.launch_fail_test(command + " X test_device")
         self.launch_fail_test("profile name get test_device")


### PR DESCRIPTION
cc @YoyPa

Add a hack to strip non-ascii symbols from the profile names. Our API promises that the strings we send are UTF-8 (because otherwise we'd get kicked off DBus anyway) but a latin-1 encoded string can be invalid UTF-8, see #617.

Until we have proper encoding/decoding in place, let's hack around this by just dropping anything non-ascii from the profile name. Ideally we should do this in libratbag, but adding it in libratbag is a few LOC, libratbag would require some significant rework.

Fixes #617 