### PR TITLE
tools: switch time.clock() to time.perf_counter()

### DIFF
--- a/tools/toolbox.py
+++ b/tools/toolbox.py
@@ -83,8 +83,8 @@ def start_ratbagd(verbosity=0):
     dbus = Gio.bus_get_sync(Gio.BusType.SYSTEM, None)
 
     name_owner = None
-    start_time = time.clock()
-    while name_owner is None and time.clock() - start_time < 30:
+    start_time = time.perf_counter()
+    while name_owner is None and time.perf_counter() - start_time < 30:
         proxy = Gio.DBusProxy.new_sync(dbus,
                                        Gio.DBusProxyFlags.NONE,
                                        None,


### PR DESCRIPTION
toolbox.py:86: DeprecationWarning: time.clock has been deprecated in Python
3.3 and will be removed from Python 3.8: use time.perf_counter or
time.process_time instead