### PR TITLE
DBus: drop the Svg and GetSvg() APIs

### DIFF
--- a/doc/dbus.rst
+++ b/doc/dbus.rst
@@ -137,14 +137,6 @@ known to ratbagd.
         ratbag_device_capability` in libratbag-enums.h for the list of permissible
         capabilities.
 
-
-.. attribute:: Svg
-
-        :type: s
-        :flags: read-only, constant
-
-        The device's SVG file name, without path.
-
 .. attribute:: Profiles
 
         :type: ao
@@ -160,20 +152,6 @@ known to ratbagd.
 
         Commits the changes to the device. Changes to the device are batched; they
         are not written to the hardware until :func:`Commit` is invoked.
-
-.. function:: GetSvg(s) → (s)
-
-        :param s: the theme name
-        :returns: A full path to the SVG for the given theme
-
-        Returns the full path to the SVG for the given theme or an
-        empty string if none is available.  The theme must be one of
-	:func:`org.freedesktop.ratbag1.Manager.Themes <Themes>`.
-
-        The theme **'default'** is guaranteed to be available.
-        ratbagd may return the path to a file that doesn't exist.
-        This is the case if the device has SVGs available but not
-        for the given theme.
 
 .. function:: GetSvgFd(s) → (h)
 

--- a/ratbagd/ratbagd-device.c
+++ b/ratbagd/ratbagd-device.c
@@ -135,59 +135,6 @@ static int ratbagd_device_get_device_name(sd_bus *bus,
 	return 0;
 }
 
-static int ratbagd_device_get_svg(sd_bus *bus,
-				  const char *path,
-				  const char *interface,
-				  const char *property,
-				  sd_bus_message *reply,
-				  void *userdata,
-				  sd_bus_error *error)
-{
-	struct ratbagd_device *device = userdata;
-	const char *svg;
-
-	svg = ratbag_device_get_svg_name(device->lib_device);
-	if (!svg) {
-		log_error("%s: failed to fetch SVG\n",
-			  ratbagd_device_get_sysname(device));
-		svg = "";
-	}
-
-	CHECK_CALL(sd_bus_message_append(reply, "s", svg));
-
-	return 0;
-}
-
-static int ratbagd_device_get_theme_svg(sd_bus_message *m,
-					void *userdata,
-					sd_bus_error *error)
-{
-	struct ratbagd_device *device = userdata;
-	char svg_path[PATH_MAX] = {0};
-	const char *theme;
-	const char *svg;
-	const char *datadir;
-
-	datadir = getenv("LIBRATBAG_DATA_DIR");
-	if (!datadir)
-		datadir = LIBRATBAG_DATA_DIR;
-
-	CHECK_CALL(sd_bus_message_read(m, "s", &theme));
-
-	svg = ratbag_device_get_svg_name(device->lib_device);
-	if (!svg) {
-		log_error("%s: failed to fetch SVG, using fallback\n",
-			  ratbagd_device_get_sysname(device));
-		svg = FALLBACK_SVG_NAME;
-	}
-
-	snprintf(svg_path, sizeof(svg_path), "%s/%s/%s", datadir, theme, svg);
-
-	CHECK_CALL(sd_bus_reply_method_return(m, "s", svg_path));
-
-	return 0;
-}
-
 static int ratbagd_device_get_theme_svg_fd(sd_bus_message *m,
 					   void *userdata,
 					   sd_bus_error *error)
@@ -327,9 +274,7 @@ const sd_bus_vtable ratbagd_device_vtable[] = {
 	SD_BUS_PROPERTY("Id", "s", NULL, offsetof(struct ratbagd_device, sysname), SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_PROPERTY("Capabilities", "au", ratbagd_device_get_capabilities, 0, SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_PROPERTY("Name", "s", ratbagd_device_get_device_name, 0, SD_BUS_VTABLE_PROPERTY_CONST),
-	SD_BUS_PROPERTY("Svg", "s", ratbagd_device_get_svg, 0, SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_PROPERTY("Profiles", "ao", ratbagd_device_get_profiles, 0, SD_BUS_VTABLE_PROPERTY_CONST),
-	SD_BUS_METHOD("GetSvg", "s", "s", ratbagd_device_get_theme_svg, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("GetSvgFd", "s", "h", ratbagd_device_get_theme_svg_fd, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("Commit", "", "u", ratbagd_device_commit, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_SIGNAL("Resync", "", 0),

--- a/tools/ratbagc.py.in
+++ b/tools/ratbagc.py.in
@@ -283,21 +283,6 @@ class RatbagdDevice(metaclass=MetaRatbag):
         print("No active profile. Please report this bug to the libratbag developers", file=sys.stderr)
         return self._profiles[0]
 
-    def get_svg(self, theme):
-        """Gets the full path to the SVG for the given theme, or the empty
-        string if none is available.
-
-        The theme must be one of org.freedesktop.ratbag1.Manager.Themes. The
-        theme 'default' is guaranteed to be available.
-
-        @param theme The theme from which to retrieve the SVG, as str
-        """
-        svg = libratbag.ratbag_device_get_svg_name(self._device)
-        if svg is None:
-            return ''
-
-        return os.path.join(LIBRATBAG_DATA_DIR, theme, svg)
-
     def get_svg_fd(self, theme):
         """Returns a File-like object to the SVG for the given theme, or
         raises FileNotFoundError if the file is not available.

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -394,17 +394,6 @@ class RatbagdDevice(_RatbagdDBus):
         fd = self._dbus_call_return_one_fd("GetSvgFd", "s", theme)
         return os.fdopen(fd)
 
-    def get_svg(self, theme):
-        """Gets the full path to the SVG for the given theme, or the empty
-        string if none is available.
-
-        The theme must be one of org.freedesktop.ratbag1.Manager.Themes. The
-        theme 'default' is guaranteed to be available.
-
-        @param theme The theme from which to retrieve the SVG, as str
-        """
-        return self._dbus_call("GetSvg", "s", theme)
-
     def commit(self):
         """Commits all changes made to the device.
 


### PR DESCRIPTION
This is prep work for libratbag 1.0.

These APIs are now legacy, we assume that we're running sandboxed because that's the future. So let's drop them before we commit to maintain these forever.