### PR TITLE
ratbagd: map the default theme to the gnome theme

### DIFF
--- a/ratbagd/ratbagd-device.c
+++ b/ratbagd/ratbagd-device.c
@@ -152,6 +152,9 @@ static int ratbagd_device_get_theme_svg_fd(sd_bus_message *m,
 
 	CHECK_CALL(sd_bus_message_read(m, "s", &theme));
 
+	if (streq(theme, "default"))
+		theme = "gnome";
+
 	svg = ratbag_device_get_svg_name(device->lib_device);
 	if (!svg) {
 		log_error("%s: failed to fetch SVG, using fallback\n",


### PR DESCRIPTION
We don't install the default SVGs anymore and all the effort for new mice goes
into the gnome theme.
