### PR TITLE
gskill: don't break after finding the active index

### DIFF
--- a/src/driver-gskill.c
+++ b/src/driver-gskill.c
@@ -1425,10 +1425,8 @@ gskill_probe(struct ratbag_device *device)
 		ratbag_profile_for_each_button(profile, button)
 			gskill_read_button(button);
 
-		if (profile->index == active_idx) {
+		if (profile->index == active_idx)
 			profile->is_active = true;
-			break;
-		}
 	}
 
 	return 0;


### PR DESCRIPTION
We still need to read the data of all other profiles. This broke in f26de4bb,
the previous loop only did the is-active modification

cc @Lyude 