### PR TITLE
Scramble user visible ids for ratbagctl

### DIFF
--- a/ratbagd/ratbagd-test.c
+++ b/ratbagd/ratbagd-test.c
@@ -190,7 +190,7 @@ int ratbagd_reset_test_device(sd_bus_message *m,
 
 	device = ratbag_device_new_test_device(ctx->lib_ctx, &ratbagd_test_device_descr);
 
-	r = ratbagd_device_new(&ratbagd_test_device, ctx, "test_device", device);
+	r = ratbagd_device_new(&ratbagd_test_device, ctx, "test_device", "test_device", device);
 
 	/* the ratbagd_device takes its own reference, drop ours */
 	ratbag_device_unref(device);

--- a/ratbagd/ratbagd.c
+++ b/ratbagd/ratbagd.c
@@ -209,7 +209,7 @@ static void ratbagd_process_device(struct ratbagd *ctx,
 {
 	struct ratbag_device *lib_device;
 	struct ratbagd_device *device;
-	const char *name;
+	const char *sysname;
 	int r;
 
 	/*
@@ -217,15 +217,15 @@ static void ratbagd_process_device(struct ratbagd *ctx,
 	 *       device-grouping, just like libinput does. If multiple input
 	 *       devices belong to the same virtual device, we should not add
 	 *       it multiple times. Instead, libratbag should group them and
-	 *       provide *us* a unique name that identifies the group, rather
+	 *       provide *us* a unique sysname that identifies the group, rather
 	 *       than taking a random input-device as tag.
 	 */
 
-	name = udev_device_get_sysname(udevice);
-	if (!name || !startswith(name, "hidraw"))
+	sysname = udev_device_get_sysname(udevice);
+	if (!sysname || !startswith(sysname, "hidraw"))
 		return;
 
-	device = ratbagd_device_lookup(ctx, name);
+	device = ratbagd_device_lookup(ctx, sysname);
 
 	if (streq_ptr("remove", udev_device_get_action(udevice))) {
 		/* device was removed, unlink it and destroy our context */
@@ -251,13 +251,13 @@ static void ratbagd_process_device(struct ratbagd *ctx,
 		if (error != RATBAG_SUCCESS)
 			return; /* unsupported device */
 
-		r = ratbagd_device_new(&device, ctx, name, lib_device);
+		r = ratbagd_device_new(&device, ctx, sysname, lib_device);
 
 		/* the ratbagd_device takes its own reference, drop ours */
 		ratbag_device_unref(lib_device);
 
 		if (r < 0) {
-			log_error("%s: cannot track device\n", name);
+			log_error("%s: cannot track device\n", sysname);
 			return;
 		}
 

--- a/ratbagd/ratbagd.h
+++ b/ratbagd/ratbagd.h
@@ -169,8 +169,10 @@ extern const sd_bus_vtable ratbagd_device_vtable[];
 int ratbagd_device_new(struct ratbagd_device **out,
 		       struct ratbagd *ctx,
 		       const char *sysname,
+		       const char *id,
 		       struct ratbag_device *lib_device);
 struct ratbagd_device *ratbagd_device_free(struct ratbagd_device *device);
+const char *ratbagd_device_get_id(struct ratbagd_device *device);
 const char *ratbagd_device_get_sysname(struct ratbagd_device *device);
 const char *ratbagd_device_get_path(struct ratbagd_device *device);
 unsigned int ratbagd_device_get_num_buttons(struct ratbagd_device *device);

--- a/ratbagd/ratbagd.h
+++ b/ratbagd/ratbagd.h
@@ -168,7 +168,7 @@ extern const sd_bus_vtable ratbagd_device_vtable[];
 
 int ratbagd_device_new(struct ratbagd_device **out,
 		       struct ratbagd *ctx,
-		       const char *name,
+		       const char *sysname,
 		       struct ratbag_device *lib_device);
 struct ratbagd_device *ratbagd_device_free(struct ratbagd_device *device);
 const char *ratbagd_device_get_sysname(struct ratbagd_device *device);


### PR DESCRIPTION
Right now:

```
$ ratbagctl list
event3: Logitech MX Anywhere 2S         
event5:   Logitech Gaming Mouse G303      
event6:   Logitech G500s Laser Gaming Mouse
```
This is bad because it encourages users to hardcode the event node in their scripts.  And we don't actually care about the event node anyway. With the patch set from #634:

```
hidraw0: Logitech MX Anywhere 2S         
hidraw2:   Logitech Gaming Mouse G303      
hidraw4:   Logitech G500s Laser Gaming Mouse
````

Which is better but still encourages users to hardcode the event node in their scripts. With this glorious patchset:

```
chinchilla: Logitech MX Anywhere 2S         
hamster:   Logitech Gaming Mouse G303      
woodrat:   Logitech G500s Laser Gaming Mouse
```
Boom! No more hardcoding because it should be fairly obvious that none of those refer to a specfic syspath. Plus it may encourage people to learn a bit more about rodents, because hands up if you knew that a tuco-tuco existed.

No-one? 

See, we like to be educational here too.

FTR: the name assigned is actually static while the hidraw node doesn't change but we could shuffle the array of names.

`ratbag-command` still uses the device nodes, Piper doesn't display the ID anyway.