### PR TITLE
tools: add a noop notify() function to all our classes

### DIFF
--- a/tools/ratbagc.py.in
+++ b/tools/ratbagc.py.in
@@ -51,6 +51,10 @@ class MetaRatbag(type):
         c = type.__new__(cls, name, bases, dct)
         if "__late_init__" in dct:
             c.__late_init__()
+
+        # Add a noop self.notify() so we're compatible with GObjects
+        c.notify = lambda *args : None
+
         return c
 
 


### PR DESCRIPTION
ratbagd uses GObjects and properties so we also make use of notify() a
fair bit. Make sure we don't crash out in ratbagc for that, just add an empty
noop function named notify().

```
 File "./build/ratbag-command", line 621, in macro
    return RatbagdMacro.from_ratbag(libratbag.ratbag_button_get_macro(self._button))
  File "./build/ratbag-command", line 741, in from_ratbag
    ratbagd_macro.append(type, value)
  File "./build/ratbag-command", line 760, in append
    self.notify("keys")
AttributeError: 'RatbagdMacro' object has no attribute 'notify'
```

This is a hack, I think we should review how we're using gobjects and normal objects but for now it fixes the crash at least.