### PR TITLE
Allow for basic name matching in ratbagctl

### DIFF
--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -1365,11 +1365,6 @@ class RatbagParserRoot(object):
         self.want_keepalive = False
 
     def parse(self, input_string):
-        # we do not care about case, use lower case for the input string
-        for i, string in enumerate(input_string):
-            if not string.startswith('-'):
-                input_string[i] = string.lower()
-
         self.parser = argparse.ArgumentParser(description="Inspect and modify a configurable device",
                                               add_help=False)
         self.parser.add_argument("-V", "--version", action="version", version="@version@")

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -67,6 +67,9 @@ def list_devices(r, args):
 def find_device(r, args):
     dev = r[args.device]
     if dev is None:
+        for d in r.devices:
+            if args.device in d.name:
+                return d
         print("Unable to find device {}".format(args.device))
         sys.exit(1)
     return dev

--- a/tools/ratbagctl.test.in
+++ b/tools/ratbagctl.test.in
@@ -124,7 +124,7 @@ class TestRatbagCtl(unittest.TestCase):
 
     @classmethod
     def setProfile(cls, profile):
-        cls.run_ratbagctl("test_device Profile active set {}".format(profile))
+        cls.run_ratbagctl("test_device profile active set {}".format(profile))
 
 
 class TestRatbagCtlList(TestRatbagCtl):
@@ -199,13 +199,13 @@ class TestRatbagCtlProfile(TestRatbagCtl):
         self.launch_fail_test("test_device " + command + " 1 X")
 
     def test_profile_n(self):
-        r0 = self.launch_good_test("test_device Profile 0 get")
-        r1 = self.launch_good_test("test_device Profile 1 get")
+        r0 = self.launch_good_test("test_device profile 0 get")
+        r1 = self.launch_good_test("test_device profile 1 get")
         self.assertNotEqual(r0, r1)
-        self.launch_fail_test("Profile 0 get")
-        self.launch_fail_test("test_device Profile 0")
-        self.launch_fail_test("test_device Profile 0 get X")
-        self.launch_fail_test("test_device Profile 10 get")
+        self.launch_fail_test("profile 0 get")
+        self.launch_fail_test("test_device profile 0")
+        self.launch_fail_test("test_device profile 0 get X")
+        self.launch_fail_test("test_device profile 10 get")
 
     def test_profile_enable(self):
         r = self.launch_good_test("test_device profile 0 get")
@@ -239,46 +239,46 @@ class TestRatbagCtlResolution(TestRatbagCtl):
         cls.setProfile(1)
 
     def test_resolution_active_get(self):
-        command = "Resolution active get"
+        command = "resolution active get"
         r = self.launch_good_test("test_device " + command)
         self.assertEqual(int(r), 2)
         self.launch_fail_test("test_device " + command + " X")
         self.launch_fail_test("test_device " + command + " 10")
 
     def test_resolution_active_set(self):
-        command = "Resolution active set"
-        r = self.launch_good_test("test_device Resolution active get")
+        command = "resolution active set"
+        r = self.launch_good_test("test_device resolution active get")
         self.assertEqual(int(r), 2)
         r = self.launch_good_test("test_device " + command + " 0")
         self.assertEqual(r, '')
-        r = self.launch_good_test("test_device Resolution active get")
+        r = self.launch_good_test("test_device resolution active get")
         self.assertEqual(int(r), 0)
         self.launch_fail_test(command)
         self.launch_fail_test("test_device " + command + " X")
         self.launch_fail_test("test_device " + command + " 1 X")
 
     def test_resolution_n_get(self):
-        r = self.launch_good_test("test_device Resolution 1 get")
+        r = self.launch_good_test("test_device resolution 1 get")
         self.assertEqual(r, "1: 1200x1300dpi @ 2000Hz (default)")
-        self.launch_fail_test("test_device Resolution 10 get")
-        self.launch_fail_test("test_device Resolution 1 get X")
-        self.launch_fail_test("Resolution 1 get X")
+        self.launch_fail_test("test_device resolution 10 get")
+        self.launch_fail_test("test_device resolution 1 get X")
+        self.launch_fail_test("resolution 1 get X")
 
     def test_profile_resolution(self):
-        r = self.launch_good_test("test_device Profile 2 Resolution 2 get")
+        r = self.launch_good_test("test_device profile 2 resolution 2 get")
         self.assertEqual(r, "2: 2300x2400dpi @ 3000Hz")
 
     def test_resolution_default_get(self):
-        command = "Resolution default get"
+        command = "resolution default get"
         r = self.launch_good_test("test_device " + command)
         self.assertEqual(int(r), 1)
         self.launch_fail_test("test_device " + command + " X")
         self.launch_fail_test("test_device " + command + " 10")
 
     def test_resolution_default_set(self):
-        command = "Resolution default set"
+        command = "resolution default set"
         self.launch_good_test("test_device " + command + " 2")
-        r = self.launch_good_test("test_device Resolution default get")
+        r = self.launch_good_test("test_device resolution default get")
         self.assertEqual(int(r), 2)
         self.launch_fail_test(command)
         self.launch_fail_test("test_device " + command + " X")
@@ -294,7 +294,7 @@ class TestRatbagCtlDPI(TestRatbagCtl):
         cls.setProfile(0)
 
     def test_dpi_get(self):
-        command = "DPI get"
+        command = "dpi get"
         r = self.launch_good_test("test_device " + command)
         self.assertEqual(int(r[:-3]), 200)  # drop 'dpi' suffix
         self.setProfile(1)
@@ -306,7 +306,7 @@ class TestRatbagCtlDPI(TestRatbagCtl):
 
     def test_dpi_get_all(self):
         dpi_list = "50 100 150 200 250 300 350 400 450 500 550 600 650 700 750 800 850 900 950 1000 1100 1200 1300 1400 1500 1600 1700 1800 1900 2000 2100 2200 2300 2400 2500 2600 2800 3000 3200 3400 3600 3800 4000 4200 4400 4600 4800 5000"
-        command = "DPI get-all"
+        command = "dpi get-all"
         r = self.launch_good_test("test_device " + command)
         self.assertEqual(r, dpi_list)
         self.setProfile(1)
@@ -314,31 +314,31 @@ class TestRatbagCtlDPI(TestRatbagCtl):
         self.assertEqual(r, dpi_list)
 
     def test_dpi_set(self):
-        command = "DPI set"
+        command = "dpi set"
         self.setProfile(0)
-        r = self.launch_good_test("test_device DPI get ")
+        r = self.launch_good_test("test_device dpi get ")
         res = int(r[:-3]) + 50  # drop 'dpi' suffix
         r = self.launch_good_test("test_device " + command + " {}".format(res))
         self.assertEqual(r, '')
-        r = self.launch_good_test("test_device DPI get")
+        r = self.launch_good_test("test_device dpi get")
         self.assertEqual(int(r[:-3]), res)  # drop 'dpi' suffix
         self.launch_fail_test(command)
         self.launch_fail_test("test_device " + command + " X")
         self.launch_fail_test("test_device " + command + " 100 X")
 
     def test_dpi_set_xy(self):
-        command = "DPI set"
+        command = "dpi set"
         self.setProfile(2)
-        r = self.launch_good_test("test_device DPI get")
+        r = self.launch_good_test("test_device dpi get")
         self.assertEqual(r, "2100x2200dpi")
         self.launch_good_test("test_device " + command + " 1350x1450")
-        r = self.launch_good_test("test_device DPI get")
+        r = self.launch_good_test("test_device dpi get")
         self.assertEqual(r, "1350x1450dpi")
         self.launch_good_test("test_device " + command + " 2350x2450dpi")
-        r = self.launch_good_test("test_device DPI get")
+        r = self.launch_good_test("test_device dpi get")
         self.assertEqual(r, "2350x2450dpi")
         self.launch_good_test("test_device " + command + " 2350")
-        r = self.launch_good_test("test_device DPI get")
+        r = self.launch_good_test("test_device dpi get")
         self.assertEqual(r, "2350x2350dpi")
         self.launch_fail_test("test_device " + command + " 2350dpi")
         self.launch_fail_test(command)
@@ -347,14 +347,14 @@ class TestRatbagCtlDPI(TestRatbagCtl):
 
     def test_prefix_dpi(self):
         self.setProfile(0)
-        r = self.launch_good_test("test_device Profile 1 DPI get")
+        r = self.launch_good_test("test_device profile 1 dpi get")
         self.assertEqual(r, "1300x1400dpi")
-        r = self.launch_good_test("test_device Profile 1 Resolution 1 DPI get")
+        r = self.launch_good_test("test_device profile 1 resolution 1 dpi get")
         self.assertEqual(r, "1200x1300dpi")
-        r = self.launch_good_test("test_device Resolution 2 DPI get")
+        r = self.launch_good_test("test_device resolution 2 dpi get")
         self.assertEqual(int(r[:-3]), 300)  # drop 'dpi' suffix
-        self.launch_fail_test("test_device Profile 1 Profile 1 DPI get")
-        self.launch_fail_test("test_device Profile 1 Resolution 1 Resolution 2 DPI get")
+        self.launch_fail_test("test_device profile 1 profile 1 dpi get")
+        self.launch_fail_test("test_device profile 1 resolution 1 resolution 2 dpi get")
 
 
 class TestRatbagCtlReportRate(TestRatbagCtl):
@@ -393,14 +393,14 @@ class TestRatbagCtlReportRate(TestRatbagCtl):
         self.launch_fail_test("test_device " + command + " 100 X")
 
     def test_prefix_rate(self):
-        r = self.launch_good_test("test_device Profile 1 rate get")
+        r = self.launch_good_test("test_device profile 1 rate get")
         self.assertEqual(int(r), 2000)
-        r = self.launch_good_test("test_device Profile 1 Resolution 1 rate get")
+        r = self.launch_good_test("test_device profile 1 resolution 1 rate get")
         self.assertEqual(int(r), 2000)
-        r = self.launch_good_test("test_device Resolution 2 rate get")
+        r = self.launch_good_test("test_device resolution 2 rate get")
         self.assertEqual(int(r), 1000)
-        self.launch_fail_test("test_device Profile 1 Profile 1 rate get")
-        self.launch_fail_test("test_device Profile 1 Resolution 1 Resolution 2 rate get")
+        self.launch_fail_test("test_device profile 1 profile 1 rate get")
+        self.launch_fail_test("test_device profile 1 resolution 1 resolution 2 rate get")
 
 
 class TestRatbagCtlButton(TestRatbagCtl):
@@ -483,10 +483,10 @@ class TestRatbagCtlButton(TestRatbagCtl):
         self.launch_fail_test("test_device " + command + " KEY_A X")
 
     def test_prefix_button(self):
-        r = self.launch_good_test("test_device Profile 2 Button 3 get")
+        r = self.launch_good_test("test_device profile 2 button 3 get")
         self.assertEqual(r, "Button: 3 is mapped to 'button 3'")
-        self.launch_fail_test("test_device Profile 2 Profile 2 Button 3 get")
-        self.launch_fail_test("test_device Profile 2 Resolution 2 Button 3 get")
+        self.launch_fail_test("test_device profile 2 profile 2 button 3 get")
+        self.launch_fail_test("test_device profile 2 resolution 2 button 3 get")
 
 
 class TestRatbagCtlLED(TestRatbagCtl):
@@ -585,10 +585,10 @@ class TestRatbagCtlLED(TestRatbagCtl):
 
     def test_prefix_led(self):
         self.setProfile(2)
-        r = self.launch_good_test("test_device Profile 1 Led 1 get")
+        r = self.launch_good_test("test_device profile 1 led 1 get")
         self.assertEqual(r, "LED: 1, depth: rgb, mode: off")
-        self.launch_fail_test("test_device Profile 1 Profile 2 Led 1 get")
-        self.launch_fail_test("test_device Profile 1 Resolution 2 Led 1 get")
+        self.launch_fail_test("test_device profile 1 profile 2 led 1 get")
+        self.launch_fail_test("test_device profile 1 resolution 2 led 1 get")
 
     def test_led_capabilities(self):
         r = self.launch_good_test("test_device led 0 capabilities")


### PR DESCRIPTION
Because it's less funny than having a screaming gopher but a lot more sensible for the most common use-case. And it's a stable API by virtue of the device itself never changing names, so we don't have to worry about users hardcoding hidraw paths or something.