### PR TITLE
tools: restore --keepalive functionality

### DIFF
--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -1388,7 +1388,7 @@ class RatbagParserRoot(object):
 
         # retrieve the device and remove it from the command processing
         self.parser.add_argument('device_or_list', action="store")
-        ns, rest = self.parser.parse_known_args(rest)
+        ns, rest = self.parser.parse_known_args(rest, namespace=ns)
 
         if ns.device_or_list == 'list':
             if rest:


### PR DESCRIPTION
Since 260711470964c73fcfd24bfdbc6ed74f7e7a5d5f we returned the second parser
to handle everything after the device argument. That parser didn't have the
various options we handled in the original one, causing --keepalive to stop
working. Restore this, we care about everything but --help and --version in
the second parser.
