### PR TITLE
ratbagd: change the Resolution property to a variant

### DIFF
--- a/doc/dbus.rst
+++ b/doc/dbus.rst
@@ -298,15 +298,22 @@ org.freedesktop.ratbag1.Resolution
 
 .. attribute:: Resolution
 
-        :type: uu
+        :type: v
         :flags: read-write, mutable
 
-        uint for the x and y resolution assigned to this entry,
-        respectively.  The value for the resolution must be equal to
-        one of the values in :attr:`Resolutions`.
+        The resolution for this entry in dpi.
 
-        If the resolution does not support separate x/y resolutions,
-        x and y must be the same value.
+        If the variant is a single unsigned integer (``u``), the value is
+        the resolution for both the x- and the y- axis.
+
+        If the variant is a unsigned integer tuple (``(uu)``), the value is
+        the resolution for the x- and y- axis separately.
+
+        A client must leave the type intact, assigning a single ``u`` to a
+        resolution object previously exporting ``(uu)`` is invalid.
+
+        The value for the resolution must be equal to one of the values in
+        :attr:`Resolutions`.
 
 .. attribute:: Resolutions
 

--- a/tools/ratbagc.py.in
+++ b/tools/ratbagc.py.in
@@ -436,7 +436,8 @@ class RatbagdResolution(metaclass=MetaRatbag):
         dpi_y = dpi_x = libratbag.ratbag_resolution_get_dpi_x(self._res)
         if libratbag.RATBAG_RESOLUTION_CAP_SEPARATE_XY_RESOLUTION in self._capabilities:
             dpi_y = libratbag.ratbag_resolution_get_dpi_y(self._res)
-        return (dpi_x, dpi_y)
+            return (dpi_x, dpi_y)
+        return (dpi_x, )
 
     @resolution.setter
     def resolution(self, res):

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -186,7 +186,7 @@ def print_resolution(d, p, r, level):
     if r.resolution == (0, 0):
         print(" " * level + "{}: <disabled>".format(r.index))
         return
-    if RatbagdResolution.CAP_SEPARATE_XY_RESOLUTION in r.capabilities:
+    if len(r.resolution) == 2:
         dpi = "{}x{}".format(r.resolution[0], r.resolution[1])
     else:
         dpi = "{}".format(r.resolution[0])
@@ -380,7 +380,7 @@ def func_button_count(r, args):
 
 def func_dpi_get(r, args):
     r, p, d = find_resolution(r, args)
-    if RatbagdResolution.CAP_SEPARATE_XY_RESOLUTION in r.capabilities:
+    if len(r.resolution) == 2:
         print("{}x{}dpi".format(r.resolution[0], r.resolution[1]))
     else:
         print("{}dpi".format(r.resolution[0]))
@@ -394,7 +394,10 @@ def func_dpi_get_all(r, args):
 
 def func_dpi_set(r, args):
     r, p, d = find_resolution(r, args)
-    r.resolution = (args.dpi_n[0], args.dpi_n[1])
+    dpi = args.dpi_n
+    if len(r.resolution) > len(dpi):
+        dpi = (dpi[0], dpi[0])
+    r.resolution = dpi
     commit(d, args)
 
 
@@ -590,7 +593,7 @@ def dpi(string):
     except ValueError:
         pass
     else:
-        return (int_value, int_value)
+        return (int_value, )
     if string.endswith("dpi"):
         string = string[:-3]
     x, y = string.split("x")

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -534,16 +534,28 @@ class RatbagdResolution(_RatbagdDBus):
 
     @GObject.Property
     def resolution(self):
-        """The tuple (xres, yres) with each resolution in DPI."""
-        return self._get_dbus_property("Resolution")
+        """The resolution in DPI, either as single value tuple ``(res, )``
+        or as tuple ``(xres, yres)``.
+        """
+        res = self._get_dbus_property("Resolution")
+        if isinstance(res, int):
+            res = tuple([res])
+        return res
 
     @resolution.setter
-    def resolution(self, res):
+    def resolution(self, resolution):
         """Set the x- and y-resolution using the given (xres, yres) tuple.
 
         @param res The new resolution, as (int, int)
         """
-        self._set_dbus_property("Resolution", "(uu)", res)
+        res = self.resolution
+        if len(res) != len(resolution) or len(res) > 2:
+            raise ValueError('invalid resolution precision')
+        if len(res) == 1:
+            variant = GLib.Variant('u', resolution[0]);
+        else:
+            variant = GLib.Variant('(uu)', resolution);
+        self._set_dbus_property("Resolution", "v", variant)
 
     @GObject.Property
     def report_rate(self):


### PR DESCRIPTION
Instead of a fixed (uu) with an extra capability flag, let's just make this a
variant defined to be a u or a (uu), depending on whether we have a single or
a separate resolution.

In the ratbagd.py bindings we return a tuple for both, but a simple len()
check will tell us which one it is.