### PR TITLE
Rework the button mapping API

### DIFF
--- a/doc/dbus.rst
+++ b/doc/dbus.rst
@@ -359,38 +359,27 @@ org.freedesktop.ratbag1.Button
 
         Index of the button
 
-.. attribute:: ButtonMapping
+.. attribute:: Mapping
 
-        :type: u
+        :type: (uv)
         :flags: read-write, mutable
 
-        uint of the current button mapping (if mapping to button)
+        The current button mapping. The first element is the ActionType
+        selected for this button.
 
-.. attribute:: SpecialMapping
+        If the ActionType is Button, the variant is an unsigned integer
+        (``u``) denoting the button number to map to.
 
-        :type: u
-        :flags: read-write, mutable
+        If the ActionType is Special, the variant is an unsigned integer
+        (``u``) denoting the special value to map to.
 
-        Enum describing the current special mapping (if mapped to special)
-
-.. attribute:: Macro
-
-        :type: a(uu)
-        :flags: read-write, mutable
-
-        Array of (type, keycode), where type may be one of
-        :cpp:enumerator:`RATBAG_MACRO_EVENT_KEY_PRESSED` or
+        If the ActionType is Macro, the variant is an array of integer
+        tuples (``a(uu)``) where each tuple is ``(type, keycode)`` and the
+        type is one of :cpp:enumerator:`RATBAG_MACRO_EVENT_KEY_PRESSED` or
         :cpp:enumerator:`RATBAG_MACRO_EVENT_KEY_RELEASED`.
 
-.. attribute:: ActionType
-
-        :type: u
-        :flags: read-only, mutable
-
-        An enum describing the action type of the button, see
-        :cpp:enum:`ratbag_button_action_type` for the list of enums.
-        This decides which one of :attr:`ButtonMapping`,
-	:attr:`SpecialMapping` and :attr:`Macro` has a value.
+        If the ActionType is Unknown, the variant is an unsigned integer
+        (``u``) of value 0.
 
 .. attribute:: ActionTypes
 
@@ -398,7 +387,7 @@ org.freedesktop.ratbag1.Button
         :flags: read-only, constant
 
         Array of :cpp:enum:`ratbag_button_action_type`, possible values
-        for ActionType on the current device
+        for ActionType on the current device.
 
 .. function:: Disable() → ()
 

--- a/tools/ratbagctl.test.in
+++ b/tools/ratbagctl.test.in
@@ -110,6 +110,8 @@ class TestRatbagCtl(unittest.TestCase):
     def launch_good_test(self, params):
         returncode, stdout, stderr = self.run_ratbagctl(params)
         self.assertEqual(returncode, 0, msg=stderr + stdout)
+        self.maxDiff = None
+        self.assertEqual(stderr, '')
         return stdout
 
     def launch_fail_test(self, params):

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -678,6 +678,9 @@ class RatbagdButton(_RatbagdDBus):
         if "ActionType" in changed_props.keys():
             self.notify("action-type")
 
+    def _mapping(self):
+        return self._get_dbus_property("Mapping")
+
     @GObject.Property
     def index(self):
         """The index of this button."""
@@ -685,8 +688,12 @@ class RatbagdButton(_RatbagdDBus):
 
     @GObject.Property
     def mapping(self):
-        """An integer of the current button mapping, if mapping to a button."""
-        return self._get_dbus_property("ButtonMapping")
+        """An integer of the current button mapping, if mapping to a button
+        or None otherwise."""
+        type, button = self._mapping()
+        if type != RatbagdButton.ACTION_TYPE_BUTTON:
+            return None
+        return button
 
     @mapping.setter
     def mapping(self, button):
@@ -694,12 +701,18 @@ class RatbagdButton(_RatbagdDBus):
 
         @param button The button to map to, as int
         """
-        self._set_dbus_property("ButtonMapping", "u", button)
+        button = GLib.Variant("u", button)
+        self._set_dbus_property("Mapping", "(uv)",
+                (RatbagdButton.ACTION_TYPE_BUTTON, button))
 
     @GObject.Property
     def macro(self):
-        """A RatbagdMacro object representing the currently set macro."""
-        return RatbagdMacro.from_ratbag(self._get_dbus_property("Macro"))
+        """A RatbagdMacro object representing the currently set macro or
+        None otherwise."""
+        type, macro = self._mapping()
+        if type != RatbagdButton.ACTION_TYPE_MACRO:
+            return None
+        return RatbagdMacro.from_ratbag(macro)
 
     @macro.setter
     def macro(self, macro):
@@ -709,12 +722,18 @@ class RatbagdButton(_RatbagdDBus):
         @param macro A RatbagdMacro object representing the macro to apply to
                      the button, as RatbagdMacro.
         """
-        self._set_dbus_property("Macro", "a(uu)", macro.keys)
+        macro = GLib.Variant("a(uu)", macro.keys)
+        self._set_dbus_property("Mapping", "(uv)",
+                (RatbagdButton.ACTION_TYPE_MACRO, macro))
 
     @GObject.Property
     def special(self):
-        """An enum describing the current special mapping, if mapped to special."""
-        return self._get_dbus_property("SpecialMapping")
+        """An enum describing the current special mapping, if mapped to
+        special or None otherwise."""
+        type, special = self._mapping()
+        if type != RatbagdButton.ACTION_TYPE_SPECIAL:
+            return None
+        return special
 
     @special.setter
     def special(self, special):
@@ -722,7 +741,9 @@ class RatbagdButton(_RatbagdDBus):
 
         @param special The special entry, as one of RatbagdButton.ACTION_SPECIAL_*
         """
-        self._set_dbus_property("SpecialMapping", "u", special)
+        special = GLib.Variant("u", special)
+        self._set_dbus_property("Mapping", "(uv)",
+                (RatbagdButton.ACTION_TYPE_SPECIAL, special))
 
     @GObject.Property
     def action_type(self):
@@ -731,7 +752,8 @@ class RatbagdButton(_RatbagdDBus):
         ACTION_TYPE_MACRO. This decides which
         *Mapping property has a value.
         """
-        return self._get_dbus_property("ActionType")
+        type, mapping = self._mapping()
+        return type
 
     @GObject.Property
     def action_types(self):


### PR DESCRIPTION
Fixes #647 

Instead of different entry points that depend on each other, let's just export one entry point that tells us what we need. IOW we now take an enum value (action type) and a variant, the latter depends on the action type to be set.

Doesn't affect ratbagd at this point, it's all abstracted.