### PR TITLE
Drop libratbag-enums.h from the dbus docs

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -125,7 +125,7 @@ doc_build: &doc_build
     - *fedora_install
     - run:
         name: Install documentation build-deps
-        command: dnf install -y python3-sphinx python3-sphinx_rtd_theme doxygen libxslt
+        command: dnf install -y python3-sphinx python3-sphinx_rtd_theme
     - checkout
     - *build_with_docs
     - *export_logs

--- a/doc/dbus.rst
+++ b/doc/dbus.rst
@@ -28,8 +28,6 @@ must be prepared to receive a :func:`org.freedesktop.ratbag1.Device.Resync
 
 Notes on the DBus API
 ---------------------
-Values listed as enums are defined in `libratbag-enums.h
-<https://github.com/libratbag/libratbag/blob/master/src/libratbag-enums.h>`_
 
 For easier debugging, objects paths are constructed from the device. e.g.
 ``/org/freedesktop/ratbag/button/event5/p0/b10`` is the button interface for

--- a/doc/dbus.rst
+++ b/doc/dbus.rst
@@ -82,11 +82,11 @@ interact with ratbagd.
 
 .. attribute:: Devices
 
-	:type: ao
-	:flags: read-only, mutable
+        :type: ao
+        :flags: read-only, mutable
 
-	An array of read-only object paths referencing the available
-	devices. The devices implement the :ref:`device` interface.
+        An array of read-only object paths referencing the available
+        devices. The devices implement the :ref:`device` interface.
 
 .. _device:
 
@@ -98,45 +98,45 @@ known to ratbagd.
 
 .. attribute:: Model
 
-	:type: s
-	:flags: read-only, constant
+        :type: s
+        :flags: read-only, constant
 
-	An ID identifying the physical device model. This string is
-	guaranteed to be unique for a specific model and always identical
-	for devices of that model.
+        An ID identifying the physical device model. This string is
+        guaranteed to be unique for a specific model and always identical
+        for devices of that model.
 
-	This is a string of one of the following formats:
+        This is a string of one of the following formats:
 
-	- ``usb:1234:abcd:0``
-	- ``bluetooth:5678:ef01:0``
-	- ``unknown``
+        - ``usb:1234:abcd:0``
+        - ``bluetooth:5678:ef01:0``
+        - ``unknown``
 
-	In the future, other formats may get added. Clients must ignore
-	unknown string formats.
+        In the future, other formats may get added. Clients must ignore
+        unknown string formats.
 
-	For a string starting with ``usb:``, the format is the bus type (USB)
-	followed by a 4-digit lowercase hex USB vendor ID, followed by a
-	4-digit lowercase hex USB product ID, followed by an decimal version
-	number of unspecified length. These four elements are separated by a
-	colon (``:``).
+        For a string starting with ``usb:``, the format is the bus type (USB)
+        followed by a 4-digit lowercase hex USB vendor ID, followed by a
+        4-digit lowercase hex USB product ID, followed by an decimal version
+        number of unspecified length. These four elements are separated by a
+        colon (``:``).
 
-	For a string starting with ``bluetooth:``, the format is the bus type
-	(Bluetooth) followed by a 4-digit lowercase hex Bluetooth vendor ID,
-	followed by a 4-digit lowercase hex Bluetooth product ID, followed
-	by an decimal version number of unspecified length. These four
-	elements are separated by a colon (``:``).
+        For a string starting with ``bluetooth:``, the format is the bus type
+        (Bluetooth) followed by a 4-digit lowercase hex Bluetooth vendor ID,
+        followed by a 4-digit lowercase hex Bluetooth product ID, followed
+        by an decimal version number of unspecified length. These four
+        elements are separated by a colon (``:``).
 
-	For the string ``unknown``, the model of the device cannot be
-	determined. This is usually a bug in libratbag.
+        For the string ``unknown``, the model of the device cannot be
+        determined. This is usually a bug in libratbag.
 
-	For a ``Model`` of type ``usb`` and ``bluetooth``, the version
-	number is reserved for use by libratbag. Device with identical
-	vendor and product IDs but different versions must be considered
-	different devices. For example, the version may increase when a
-	manufacturer re-uses USB Ids.
+        For a ``Model`` of type ``usb`` and ``bluetooth``, the version
+        number is reserved for use by libratbag. Device with identical
+        vendor and product IDs but different versions must be considered
+        different devices. For example, the version may increase when a
+        manufacturer re-uses USB Ids.
 
-	Vendor or product IDs of 0 are valid IDs (e.g. used used by test
-	devices).
+        Vendor or product IDs of 0 are valid IDs (e.g. used used by test
+        devices).
 
 .. attribute:: Name
 
@@ -154,14 +154,14 @@ known to ratbagd.
         profiles.
 
         Provides the list of profile paths for all profiles on this device, see
-	:ref:`profile`
+        :ref:`profile`
 
 .. function:: Commit() → ()
 
         Commits the changes to the device. This call always succeeds,
-	the data is written to the device asynchronously. Where an error
-	occurs, the :func:`Resync` signal is emitted and all properties are
-	updated to the current state.
+        the data is written to the device asynchronously. Where an error
+        occurs, the :func:`Resync` signal is emitted and all properties are
+        updated to the current state.
 
 .. function:: Resync()
 
@@ -201,8 +201,8 @@ org.freedesktop.ratbag1.Profile
         True if this is the profile is enabled, false otherwise.
 
         Note that a disabled profile might not have correct bindings, so it's
-	a good thing to rebind everything before calling
-	:func:`Commit`.
+        a good thing to rebind everything before calling
+        :func:`Commit`.
 
 .. attribute:: IsActive
 
@@ -224,7 +224,7 @@ org.freedesktop.ratbag1.Profile
         resolutions.
 
         Provides the object paths of all resolutions in this profile, see
-	:ref:`resolution`.
+        :ref:`resolution`.
 
 .. attribute:: Buttons
 
@@ -232,7 +232,7 @@ org.freedesktop.ratbag1.Profile
         :flags: read-only, constant
 
         Provides the object paths of all buttons in this profile, see
-	:ref:`button`.
+        :ref:`button`.
 
 .. attribute:: Leds
 
@@ -240,7 +240,7 @@ org.freedesktop.ratbag1.Profile
         :flags: read-only, constant
 
         Provides the object paths of all LEDs in this profile, see
-	:ref:`led`.
+        :ref:`led`.
 
 .. attribute:: ReportRate
 

--- a/doc/dbus.rst
+++ b/doc/dbus.rst
@@ -364,21 +364,28 @@ org.freedesktop.ratbag1.Button
         :type: (uv)
         :flags: read-write, mutable
 
-        The current button mapping. The first element is the ActionType
-        selected for this button.
+        The current button mapping. The first element is the ``ActionType``
+        for this button and must be one of those in :attr:`ActionTypes`.
 
-        If the ActionType is Button, the variant is an unsigned integer
+        If the ActionType is *Button*, the variant is an unsigned integer
         (``u``) denoting the button number to map to.
 
-        If the ActionType is Special, the variant is an unsigned integer
+        If the ActionType is *Special*, the variant is an unsigned integer
         (``u``) denoting the special value to map to.
 
-        If the ActionType is Macro, the variant is an array of integer
+        If the ActionType is *Macro*, the variant is an array of integer
         tuples (``a(uu)``) where each tuple is ``(type, keycode)`` and the
-        type is one of :cpp:enumerator:`RATBAG_MACRO_EVENT_KEY_PRESSED` or
-        :cpp:enumerator:`RATBAG_MACRO_EVENT_KEY_RELEASED`.
+        type is one of the following:
 
-        If the ActionType is Unknown, the variant is an unsigned integer
+        +---------+--------------------------------------+
+        | Value   | Description                          |
+        +=========+======================================+
+        |   0     | Key release event                    |
+        +---------+--------------------------------------+
+        |   1     | Key press event                      |
+        +---------+--------------------------------------+
+
+        If the ActionType is *Unknown*, the variant is an unsigned integer
         (``u``) of value 0.
 
 .. attribute:: ActionTypes
@@ -386,8 +393,24 @@ org.freedesktop.ratbag1.Button
         :type: au
         :flags: read-only, constant
 
-        Array of :cpp:enum:`ratbag_button_action_type`, possible values
-        for ActionType on the current device.
+        +---------+---------+--------------------------------------+
+        | Value   | Name    | Description                          |
+        +=========+=========+======================================+
+        |   0     | None    | No mapping configured                |
+        +---------+---------+--------------------------------------+
+        |   1     | Button  | Mapping to a logical button number   |
+        +---------+---------+--------------------------------------+
+        |   2     | Special | Mapping to a special function        |
+        +---------+---------+--------------------------------------+
+        |   3     | Macro   | Mapping to a macro key sequence      |
+        +---------+---------+--------------------------------------+
+        | 1000    | Unknown | An unknown or unreadable mapping type|
+        +---------+---------+--------------------------------------+
+
+        See :ref:`button_special` for a list of supported special
+        functions.
+
+        Clients must ignore :attr:`ActionTypes` unknown to them.
 
 .. function:: Disable() → ()
 
@@ -484,3 +507,53 @@ org.freedesktop.ratbag1.Led
         the value to a device-supported value in an implementation-defined
         manner.
 
+
+.. _button_special:
+
+Special button functions
+------------------------
+
+        All special button function values are based on the value
+        ``0x40000000`` (``1 << 30``).
+
+        +------------+------------+---------------------------------------------------+
+        | Offset     | Value      |Description                                        |
+        +============+============+===================================================+
+        |  0         | 0x40000000 | Unknown                                           |
+        +------------+------------+---------------------------------------------------+
+        |  1         | 0x40000001 | Doublelick                                        |
+        +------------+------------+---------------------------------------------------+
+        |  2         | 0x40000002 | Wheel left                                        |
+        +------------+------------+---------------------------------------------------+
+        |  3         | 0x40000003 | Wheel right                                       |
+        +------------+------------+---------------------------------------------------+
+        |  4         | 0x40000004 | Wheel up                                          |
+        +------------+------------+---------------------------------------------------+
+        |  5         | 0x40000005 | Wheel down                                        |
+        +------------+------------+---------------------------------------------------+
+        |  6         | 0x40000006 | Ratchet mode switch                               |
+        +------------+------------+---------------------------------------------------+
+        |  7         | 0x40000007 | Resolution cycle up                               |
+        +------------+------------+---------------------------------------------------+
+        |  8         | 0x40000008 | Resolution cycle down                             |
+        +------------+------------+---------------------------------------------------+
+        |  9         | 0x40000009 | Resolution up                                     |
+        +------------+------------+---------------------------------------------------+
+        |  10        | 0x4000000a | Resolution down                                   |
+        +------------+------------+---------------------------------------------------+
+        |  11        | 0x4000000b | Resolution alternate                              |
+        +------------+------------+---------------------------------------------------+
+        |  12        | 0x4000000c | Resolution default                                |
+        +------------+------------+---------------------------------------------------+
+        |  13        | 0x4000000d | Profile cycle up                                  |
+        +------------+------------+---------------------------------------------------+
+        |  14        | 0x4000000e | Profile cycle down                                |
+        +------------+------------+---------------------------------------------------+
+        |  15        | 0x4000000f | Profile up                                        |
+        +------------+------------+---------------------------------------------------+
+        |  16        | 0x40000010 | Profile down                                      |
+        +------------+------------+---------------------------------------------------+
+        |  17        | 0x40000011 | Second mode                                       |
+        +------------+------------+---------------------------------------------------+
+        |  18        | 0x40000012 | Battery level                                     |
+        +------------+------------+---------------------------------------------------+

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,7 +15,6 @@ The libratbag DBus API
    :caption: Contents:
 
      The DBus Interfaces <dbus.rst>
-     Enumerations <enums.rst>
 
 This document describes the DBus API that is the public interface for
 libratbag.

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -1,53 +1,22 @@
 if get_option('documentation')
 
 cmd_sphinx = find_program('sphinx-build-3', 'sphinx-build3')
-cmd_doxygen = find_program('doxygen')
-cmd_xsltproc = find_program('xsltproc')
 
 doc_config = configuration_data()
 doc_config.set('PACKAGE_NAME', meson.project_name())
 doc_config.set('PACKAGE_VERSION', meson.project_version())
 doc_config.set('top_srcdir', meson.source_root())
 
-# We have a dependency chain here:
-# - generate doxygen xml from the source
-# - convert the xml to rst with xstlproc
-# - generate the sphinx conf
-# - run sphinx against the generated rst
-doxyfile = configure_file(input : 'libratbag.doxygen.in',
-                          output : 'libratbag.doxygen',
-                          configuration : doc_config,
-                          install : false)
-
-src_doxygen = [ doxyfile,
-                files('../src/libratbag-enums.h') ]
-doxygen = custom_target('doxygen',
-			input : src_doxygen,
-			output : [ 'xml' ],
-			command : [ cmd_doxygen, doxyfile ],
-			install : false,
-			build_by_default : true)
-
-
 # Sphinx really really wants a _static directory in its source tree. Let's
 # make it happy
 run_command('mkdir', '-p', join_paths(meson.build_root(), 'doc', '_static'))
-
-xsl = join_paths(meson.source_root(), 'doc', 'doxygen-enums-to-rst.xsl')
-src_xsltproc = join_paths(meson.build_root(), 'xml', 'group__enums.xml')
-dst_xstlproc = join_paths(meson.build_root(), 'doc', 'enums.rst')
-rst_enum = custom_target('xsltproc',
-			 input : doxygen,
-			 output : 'enums.rst',
-			 command: [ cmd_xsltproc, '-o', dst_xstlproc, xsl, src_xsltproc],
-			 build_by_default : true)
 
 # Effectively a noop copy. We *must* generate enums.rst so that will end up
 # in the build directory. sphinx doesn't allow for multiple source
 # directories, so any .rst and the conf.py must be copied over to the
 # build directory too
 src_rsts = ['index.rst', 'dbus.rst']
-dst_rsts = [rst_enum]
+dst_rsts = []
 foreach rst : src_rsts
 	f = configure_file(input : rst,
 			   output : rst,


### PR DESCRIPTION
This isn't ABI anymore, we now documented all possible values in the docs.