### PR TITLE
meson: require >= 0.46.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project('libratbag', 'c', 'cpp',
 	version : '0.9.905',
 	license : 'MIT/Expat',
 	default_options : [ 'c_std=gnu99', 'warning_level=2' ],
-	meson_version : '>= 0.40.0')
+	meson_version : '>= 0.46.0')
 
 libratbag_version = meson.project_version().split('.')
 


### PR DESCRIPTION
When building, I got

```
WARNING: Project specifies a minimum meson_version '>= 0.40.0' but uses features which were added in newer versions:
 * 0.46.0: {'Python Module'}
```

So let's bump the required version for meson.