### PR TITLE
Map disabling a button to the action type NONE

### DIFF
--- a/doc/dbus.rst
+++ b/doc/dbus.rst
@@ -383,6 +383,9 @@ org.freedesktop.ratbag1.Button
         |   1     | Key press event                      |
         +---------+--------------------------------------+
 
+        If the ActionType is *None*, the variant is an unsigned integer
+        (``u``) of value 0.
+
         If the ActionType is *Unknown*, the variant is an unsigned integer
         (``u``) of value 0.
 
@@ -409,10 +412,6 @@ org.freedesktop.ratbag1.Button
         functions.
 
         Clients must ignore :attr:`ActionTypes` unknown to them.
-
-.. function:: Disable() → ()
-
-        Disable this button
 
 .. _led:
 

--- a/ratbagd/ratbagd-button.c
+++ b/ratbagd/ratbagd-button.c
@@ -278,6 +278,48 @@ static int ratbagd_button_set_macro(sd_bus *bus,
 	return 0;
 }
 
+static int ratbagd_button_get_none(sd_bus *bus,
+				   const char *path,
+				   const char *interface,
+				   const char *property,
+				   sd_bus_message *reply,
+				   void *userdata,
+				   sd_bus_error *error)
+{
+	CHECK_CALL(sd_bus_message_append(reply, "(uv)",
+					 RATBAG_BUTTON_ACTION_TYPE_NONE,
+					 "u",
+					 0));
+
+	return 0;
+}
+
+static int ratbagd_button_set_none(sd_bus *bus,
+				   const char *path,
+				   const char *interface,
+				   const char *property,
+				   sd_bus_message *m,
+				   void *userdata,
+				   sd_bus_error *error)
+{
+	struct ratbagd_button *button = userdata;
+	int r;
+	_unused_ unsigned int zero;
+
+	CHECK_CALL(sd_bus_message_read(m, "v", "u", &zero));
+
+	r = ratbag_button_disable(button->lib_button);
+	if (r < 0) {
+		sd_bus_emit_properties_changed(bus,
+					       button->path,
+					       RATBAGD_NAME_ROOT ".Button",
+					       "Mapping",
+					       NULL);
+	}
+
+	return 0;
+}
+
 static int ratbagd_button_get_mapping(sd_bus *bus,
 				      const char *path,
 				      const char *interface,
@@ -290,11 +332,15 @@ static int ratbagd_button_get_mapping(sd_bus *bus,
 	enum ratbag_button_action_type type;
 
 	type = ratbag_button_get_action_type(button->lib_button);
+
 	if (type == RATBAG_BUTTON_ACTION_TYPE_KEY)
 		type = RATBAG_BUTTON_ACTION_TYPE_UNKNOWN;
 	verify_unsigned_int(type);
 
 	switch (type) {
+	case RATBAG_BUTTON_ACTION_TYPE_NONE:
+		return ratbagd_button_get_none(bus, path, interface, property,
+					       reply, userdata, error);
 	case RATBAG_BUTTON_ACTION_TYPE_BUTTON:
 		return ratbagd_button_get_button(bus, path, interface, property,
 						 reply, userdata, error);
@@ -327,6 +373,10 @@ static int ratbagd_button_set_mapping(sd_bus *bus,
 	CHECK_CALL(sd_bus_message_read(m, "u", &type));
 
 	switch (type) {
+	case RATBAG_BUTTON_ACTION_TYPE_NONE:
+		CHECK_CALL(ratbagd_button_set_none(bus, path, interface, property,
+						   m, userdata, error));
+		break;
 	case RATBAG_BUTTON_ACTION_TYPE_BUTTON:
 		CHECK_CALL(ratbagd_button_set_button(bus, path, interface, property,
 						     m, userdata, error));
@@ -360,6 +410,7 @@ static int ratbagd_button_get_action_types(sd_bus *bus,
 {
 	struct ratbagd_button *button = userdata;
 	enum ratbag_button_action_type types[] = {
+		RATBAG_BUTTON_ACTION_TYPE_NONE,
 		RATBAG_BUTTON_ACTION_TYPE_BUTTON,
 		RATBAG_BUTTON_ACTION_TYPE_SPECIAL,
 		RATBAG_BUTTON_ACTION_TYPE_MACRO
@@ -382,28 +433,6 @@ static int ratbagd_button_get_action_types(sd_bus *bus,
 	return 0;
 }
 
-static int ratbagd_button_disable(sd_bus_message *m,
-				  void *userdata,
-				  sd_bus_error *error)
-{
-	struct ratbagd_button *button = userdata;
-	int r;
-
-	CHECK_CALL(sd_bus_message_read(m, ""));
-
-	r = ratbag_button_disable(button->lib_button);
-	if (r < 0) {
-		sd_bus *bus = sd_bus_message_get_bus(m);
-		r = ratbagd_device_resync(button->device, bus);
-		if (r < 0)
-			return r;
-	}
-
-	CHECK_CALL(sd_bus_reply_method_return(m, "u", 0));
-
-	return 0;
-}
-
 const sd_bus_vtable ratbagd_button_vtable[] = {
 	SD_BUS_VTABLE_START(0),
 	SD_BUS_PROPERTY("Index", "u", NULL, offsetof(struct ratbagd_button, index), SD_BUS_VTABLE_PROPERTY_CONST),
@@ -412,7 +441,6 @@ const sd_bus_vtable ratbagd_button_vtable[] = {
 				 ratbagd_button_set_mapping,
 				 0, SD_BUS_VTABLE_UNPRIVILEGED | SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_PROPERTY("ActionTypes", "au", ratbagd_button_get_action_types, 0, SD_BUS_VTABLE_PROPERTY_CONST),
-	SD_BUS_METHOD("Disable", "", "u", ratbagd_button_disable, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_VTABLE_END,
 };
 

--- a/ratbagd/ratbagd-test.c
+++ b/ratbagd/ratbagd-test.c
@@ -136,8 +136,7 @@ static const struct ratbag_test_device ratbagd_test_device_descr = {
 				},
 				{ .action_type = RATBAG_BUTTON_ACTION_TYPE_BUTTON,
 				  .button = 2 },
-				{ .action_type = RATBAG_BUTTON_ACTION_TYPE_BUTTON,
-				  .button = 3 },
+				{ .action_type = RATBAG_BUTTON_ACTION_TYPE_NONE },
 			},
 			.resolutions = {
 				{ .xres = 2100, .yres = 2200, .active = true, .caps = RATBAG_RESOLUTION_CAP_SEPARATE_XY_RESOLUTION },

--- a/src/driver-etekcity.c
+++ b/src/driver-etekcity.c
@@ -371,6 +371,7 @@ etekcity_read_button(struct ratbag_button *button)
 		ratbag_button_set_action(button, action);
 	button->type = etekcity_raw_to_button_type(button->index);
 
+	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_NONE);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_BUTTON);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_KEY);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_SPECIAL);

--- a/src/driver-gskill.c
+++ b/src/driver-gskill.c
@@ -1164,6 +1164,7 @@ gskill_read_button(struct ratbag_button *button)
 
 	button->type = gskill_button_type_mapping[button->index];
 
+	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_NONE);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_BUTTON);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_SPECIAL);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_KEY);

--- a/src/driver-hidpp10.c
+++ b/src/driver-hidpp10.c
@@ -285,6 +285,7 @@ hidpp10drv_read_button(struct ratbag_button *button)
 
 	button->type = type;
 
+	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_NONE);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_BUTTON);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_KEY);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_SPECIAL);

--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -104,6 +104,7 @@ hidpp20drv_read_button_1b04(struct ratbag_button *button)
 	if (action)
 		ratbag_button_set_action(button, action);
 
+	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_NONE);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_BUTTON);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_KEY);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_SPECIAL);
@@ -253,6 +254,7 @@ hidpp20drv_read_button_8100(struct ratbag_button *button)
 		}
 	}
 
+	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_NONE);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_BUTTON);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_KEY);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_SPECIAL);

--- a/src/driver-logitech-g300.c
+++ b/src/driver-logitech-g300.c
@@ -352,6 +352,7 @@ logitech_g300_read_button(struct ratbag_button *button)
 	profile_report = &pdata->report;
 	button_report = &profile_report->buttons[button->index];
 
+	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_NONE);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_BUTTON);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_SPECIAL);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_KEY);

--- a/src/driver-logitech-g600.c
+++ b/src/driver-logitech-g600.c
@@ -334,6 +334,7 @@ logitech_g600_read_button(struct ratbag_button *button)
 	profile_report = &pdata->report;
 	button_report = &profile_report->buttons[button->index];
 
+	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_NONE);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_BUTTON);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_SPECIAL);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_KEY);

--- a/src/driver-test.c
+++ b/src/driver-test.c
@@ -63,6 +63,9 @@ test_read_button(struct ratbag_button *button)
 	button->type = d->profiles[0].buttons[button->index].button_type;
 
 	switch (b->action_type) {
+	case RATBAG_BUTTON_ACTION_TYPE_NONE:
+		button->action.type = RATBAG_BUTTON_ACTION_TYPE_NONE;
+		break;
 	case RATBAG_BUTTON_ACTION_TYPE_BUTTON:
 		button->action.type = RATBAG_BUTTON_ACTION_TYPE_BUTTON;
 		button->action.action.button = p->buttons[button->index].button;
@@ -92,6 +95,7 @@ test_read_button(struct ratbag_button *button)
 		button->action.type = RATBAG_BUTTON_ACTION_TYPE_UNKNOWN;
 	}
 
+	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_NONE);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_BUTTON);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_KEY);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_SPECIAL);

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -1257,6 +1257,7 @@ ratbag_button_has_action_type(struct ratbag_button *button,
 			      enum ratbag_button_action_type action_type)
 {
 	switch (action_type) {
+	case RATBAG_BUTTON_ACTION_TYPE_NONE:
 	case RATBAG_BUTTON_ACTION_TYPE_BUTTON:
 	case RATBAG_BUTTON_ACTION_TYPE_SPECIAL:
 	case RATBAG_BUTTON_ACTION_TYPE_KEY:
@@ -1382,10 +1383,6 @@ LIBRATBAG_EXPORT enum ratbag_error_code
 ratbag_button_disable(struct ratbag_button *button)
 {
 	struct ratbag_button_action action = {0};
-
-	if (!ratbag_button_has_action_type(button,
-					   RATBAG_BUTTON_ACTION_TYPE_KEY))
-		return RATBAG_ERROR_CAPABILITY;
 
 	action.type = RATBAG_BUTTON_ACTION_TYPE_NONE;
 

--- a/tools/ratbagc.py.in
+++ b/tools/ratbagc.py.in
@@ -24,6 +24,7 @@
 import libratbag
 import os
 import sys
+from enum import IntEnum
 
 from evdev import ecodes
 
@@ -497,9 +498,38 @@ class RatbagdButton(metaclass=MetaRatbag):
 
     _PREFIX = "RATBAG_BUTTON_"
 
-    MACRO_KEY_PRESS = libratbag.RATBAG_MACRO_EVENT_KEY_PRESSED
-    MACRO_KEY_RELEASE = libratbag.RATBAG_MACRO_EVENT_KEY_RELEASED
-    MACRO_WAIT = libratbag.RATBAG_MACRO_EVENT_WAIT
+    class ActionType(IntEnum):
+        NONE = 0
+        BUTTON = 1
+        SPECIAL = 2
+        MACRO = 4
+
+    class ActionSpecial(IntEnum):
+        INVALID = -1
+        UNKNOWN = (1 << 30)
+        DOUBLECLICK = (1 << 30) + 1
+        WHEEL_LEFT = (1 << 30) + 2
+        WHEEL_RIGHT = (1 << 30) + 3
+        WHEEL_UP = (1 << 30) + 4
+        WHEEL_DOWN = (1 << 30) + 5
+        RATCHET_MODE_SWITCH = (1 << 30) + 6
+        RESOLUTION_CYCLE_UP = (1 << 30) + 7
+        RESOLUTION_CYCLE_DOWN = (1 << 30) + 8
+        RESOLUTION_UP = (1 << 30) + 9
+        RESOLUTION_DOWN = (1 << 30) + 10
+        RESOLUTION_ALTERNATE = (1 << 30) + 11
+        RESOLUTION_DEFAULT = (1 << 30) + 12
+        PROFILE_CYCLE_UP = (1 << 30) + 13
+        PROFILE_CYCLE_DOWN = (1 << 30) + 14
+        PROFILE_UP = (1 << 30) + 15
+        PROFILE_DOWN = (1 << 30) + 16
+        SECOND_MODE = (1 << 30) + 17
+        BATTERY_LEVEL = (1 << 30) + 18
+
+    class Macro(IntEnum):
+        KEY_PRESS = libratbag.RATBAG_MACRO_EVENT_KEY_PRESSED
+        KEY_RELEASE = libratbag.RATBAG_MACRO_EVENT_KEY_RELEASED
+        WAIT = libratbag.RATBAG_MACRO_EVENT_WAIT
 
     """A table mapping a button's index to its usual function as defined by X
     and the common desktop environments."""
@@ -517,25 +547,25 @@ class RatbagdButton(metaclass=MetaRatbag):
     @classmethod
     def __late_init__(cls):
         cls.SPECIAL_DESCRIPTION = {
-            cls.ACTION_SPECIAL_UNKNOWN: N_("Unknown"),
-            cls.ACTION_SPECIAL_DOUBLECLICK: N_("Doubleclick"),
-            cls.ACTION_SPECIAL_WHEEL_LEFT: N_("Wheel Left"),
-            cls.ACTION_SPECIAL_WHEEL_RIGHT: N_("Wheel Right"),
-            cls.ACTION_SPECIAL_WHEEL_UP: N_("Wheel Up"),
-            cls.ACTION_SPECIAL_WHEEL_DOWN: N_("Wheel Down"),
-            cls.ACTION_SPECIAL_RATCHET_MODE_SWITCH: N_("Ratchet Mode"),
-            cls.ACTION_SPECIAL_RESOLUTION_CYCLE_UP: N_("Cycle Resolution Up"),
-            cls.ACTION_SPECIAL_RESOLUTION_CYCLE_DOWN: N_("Cycle Resolution Down"),
-            cls.ACTION_SPECIAL_RESOLUTION_UP: N_("Resolution Up"),
-            cls.ACTION_SPECIAL_RESOLUTION_DOWN: N_("Resolution Down"),
-            cls.ACTION_SPECIAL_RESOLUTION_ALTERNATE: N_("Resolution Switch"),
-            cls.ACTION_SPECIAL_RESOLUTION_DEFAULT: N_("Default Resolution"),
-            cls.ACTION_SPECIAL_PROFILE_CYCLE_UP: N_("Cycle Profile Up"),
-            cls.ACTION_SPECIAL_PROFILE_CYCLE_DOWN: N_("Cycle Profile Down"),
-            cls.ACTION_SPECIAL_PROFILE_UP: N_("Profile Up"),
-            cls.ACTION_SPECIAL_PROFILE_DOWN: N_("Profile Down"),
-            cls.ACTION_SPECIAL_SECOND_MODE: N_("Second Mode"),
-            cls.ACTION_SPECIAL_BATTERY_LEVEL: N_("Battery Level"),
+            cls.ActionSpecial.UNKNOWN: N_("Unknown"),
+            cls.ActionSpecial.DOUBLECLICK: N_("Doubleclick"),
+            cls.ActionSpecial.WHEEL_LEFT: N_("Wheel Left"),
+            cls.ActionSpecial.WHEEL_RIGHT: N_("Wheel Right"),
+            cls.ActionSpecial.WHEEL_UP: N_("Wheel Up"),
+            cls.ActionSpecial.WHEEL_DOWN: N_("Wheel Down"),
+            cls.ActionSpecial.RATCHET_MODE_SWITCH: N_("Ratchet Mode"),
+            cls.ActionSpecial.RESOLUTION_CYCLE_UP: N_("Cycle Resolution Up"),
+            cls.ActionSpecial.RESOLUTION_CYCLE_DOWN: N_("Cycle Resolution Down"),
+            cls.ActionSpecial.RESOLUTION_UP: N_("Resolution Up"),
+            cls.ActionSpecial.RESOLUTION_DOWN: N_("Resolution Down"),
+            cls.ActionSpecial.RESOLUTION_ALTERNATE: N_("Resolution Switch"),
+            cls.ActionSpecial.RESOLUTION_DEFAULT: N_("Default Resolution"),
+            cls.ActionSpecial.PROFILE_CYCLE_UP: N_("Cycle Profile Up"),
+            cls.ActionSpecial.PROFILE_CYCLE_DOWN: N_("Cycle Profile Down"),
+            cls.ActionSpecial.PROFILE_UP: N_("Profile Up"),
+            cls.ActionSpecial.PROFILE_DOWN: N_("Profile Down"),
+            cls.ActionSpecial.SECOND_MODE: N_("Second Mode"),
+            cls.ActionSpecial.BATTERY_LEVEL: N_("Battery Level"),
         }
 
     def __init__(self, profile, id):
@@ -594,15 +624,15 @@ class RatbagdButton(metaclass=MetaRatbag):
     def special(self, special):
         """Set the button mapping to the given special entry.
 
-        @param special The special entry, as one of RatbagdButton.ACTION_SPECIAL_*
+        @param special The special entry, as one of RatbagdButton.ActionSpecial
         """
         libratbag.ratbag_button_set_special(self._button, special)
 
     @property
     def action_type(self):
         """An enum describing the action type of the button. One of
-        ACTION_TYPE_NONE, ACTION_TYPE_BUTTON, ACTION_TYPE_SPECIAL,
-        ACTION_TYPE_MACRO. This decides which
+        ActionType.NONE, ActionType.BUTTON, ActionType.SPECIAL,
+        ActionType.MACRO. This decides which
         *Mapping property has a value.
         """
         return libratbag.ratbag_button_get_action_type(self._button)
@@ -610,7 +640,7 @@ class RatbagdButton(metaclass=MetaRatbag):
     @property
     def action_types(self):
         """An array of possible values for ActionType."""
-        return [t for t in (RatbagdButton.ACTION_TYPE_BUTTON, RatbagdButton.ACTION_TYPE_SPECIAL, RatbagdButton.ACTION_TYPE_MACRO)
+        return [t for t in (RatbagdButton.ActionType.BUTTON, RatbagdButton.ActionType.SPECIAL, RatbagdButton.ActionType.MACRO)
                 if libratbag.ratbag_button_has_action_type(self._button, t)]
 
     def disable(self):
@@ -630,11 +660,11 @@ class RatbagdMacro(metaclass=MetaRatbag):
     _MACRO_KEY = 1000
 
     _MACRO_DESCRIPTION = {
-        RatbagdButton.MACRO_KEY_PRESS: lambda key:
+        RatbagdButton.Macro.KEY_PRESS: lambda key:
             "↓{}".format(ecodes.KEY[key][RatbagdMacro._PREFIX_LEN:]),
-        RatbagdButton.MACRO_KEY_RELEASE: lambda key:
+        RatbagdButton.Macro.KEY_RELEASE: lambda key:
             "↑{}".format(ecodes.KEY[key][RatbagdMacro._PREFIX_LEN:]),
-        RatbagdButton.MACRO_WAIT: lambda val:
+        RatbagdButton.Macro.WAIT: lambda val:
             "{}ms".format(val),
         _MACRO_KEY: lambda key:
             "↕{}".format(ecodes.KEY[key][RatbagdMacro._PREFIX_LEN:]),
@@ -652,10 +682,10 @@ class RatbagdMacro(metaclass=MetaRatbag):
         while idx < len(self._macro):
             t, v = self._macro[idx]
             try:
-                if t == RatbagdButton.MACRO_KEY_PRESS:
+                if t == RatbagdButton.Macro.KEY_PRESS:
                     # Check for a paired press/release event
                     t2, v2 = self._macro[idx + 1]
-                    if t2 == RatbagdButton.MACRO_KEY_RELEASE and v == v2:
+                    if t2 == RatbagdButton.Macro.KEY_RELEASE and v == v2:
                         t = self._MACRO_KEY
                         idx += 1
             except IndexError:
@@ -714,21 +744,27 @@ class RatbagdLed(metaclass=MetaRatbag):
 
     _PREFIX = "RATBAG_LED_"
 
-    MODE_OFF = libratbag.RATBAG_LED_OFF
-    MODE_ON = libratbag.RATBAG_LED_ON
-    MODE_CYCLE = libratbag.RATBAG_LED_CYCLE
-    MODE_BREATHING = libratbag.RATBAG_LED_BREATHING
+    class Mode(IntEnum):
+        OFF = libratbag.RATBAG_LED_OFF
+        ON = libratbag.RATBAG_LED_ON
+        CYCLE = libratbag.RATBAG_LED_CYCLE
+        BREATHING = libratbag.RATBAG_LED_BREATHING
+
+    class ColorDepth(IntEnum):
+        MONOCHROME = libratbag.RATBAG_LED_COLORDEPTH_MONOCHROME
+        RGB_888 = libratbag.RATBAG_LED_COLORDEPTH_RGB_888
+        RGB_111 = libratbag.RATBAG_LED_COLORDEPTH_RGB_111
 
     LED_DESCRIPTION = {
         # Translators: the LED is off.
-        MODE_OFF: N_("Off"),
+        Mode.OFF: N_("Off"),
         # Translators: the LED has a single, solid color.
-        MODE_ON: N_("Solid"),
+        Mode.ON: N_("Solid"),
         # Translators: the LED is cycling between red, green and blue.
-        MODE_CYCLE: N_("Cycle"),
+        Mode.CYCLE: N_("Cycle"),
         # Translators: the LED's is pulsating a single color on different
         # brightnesses.
-        MODE_BREATHING: N_("Breathing"),
+        Mode.BREATHING: N_("Breathing"),
     }
 
     def __init__(self, profile, id):
@@ -746,16 +782,16 @@ class RatbagdLed(metaclass=MetaRatbag):
 
     @property
     def mode(self):
-        """This led's mode, one of MODE_OFF, MODE_ON, MODE_CYCLE and
-        MODE_BREATHING."""
+        """This led's mode, one of Mode.OFF, Mode.ON, Mode.CYCLE and
+        Mode.BREATHING."""
         return libratbag.ratbag_led_get_mode(self._led)
 
     @mode.setter
     def mode(self, mode):
         """Set the led's mode to the given mode.
 
-        @param mode The new mode, as one of MODE_OFF, MODE_ON, MODE_CYCLE and
-                    MODE_BREATHING.
+        @param mode The new mode, as one of Mode.OFF, Mode.ON, Mode.CYCLE and
+                    Mode.BREATHING.
         """
         libratbag.ratbag_led_set_mode(self._led, mode)
 
@@ -776,7 +812,7 @@ class RatbagdLed(metaclass=MetaRatbag):
     @property
     def colordepth(self):
         """An enum describing this led's colordepth, one of
-        RatbagdLed.COLORDEPTH_MONOCHROME, RatbagdLed.COLORDEPTH_RGB"""
+        RatbagdLed.ColorDepth.MONOCHROME, RatbagdLed.ColorDepth.RGB"""
         return libratbag.ratbag_led_get_colordepth(self._led)
 
     @property

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -32,28 +32,9 @@ from ratbagd import Ratbagd, RatbagdDevice, RatbagdProfile, RatbagdMacro, Ratbag
 
 
 button_specials_strmap = {
-    RatbagdButton.ActionSpecial.UNKNOWN: "unknown",
-    RatbagdButton.ActionSpecial.DOUBLECLICK: "doubleclick",
-    RatbagdButton.ActionSpecial.WHEEL_LEFT: "wheel-left",
-    RatbagdButton.ActionSpecial.WHEEL_RIGHT: "wheel-right",
-    RatbagdButton.ActionSpecial.WHEEL_UP: "wheel-up",
-    RatbagdButton.ActionSpecial.WHEEL_DOWN: "wheel-down",
-    RatbagdButton.ActionSpecial.RATCHET_MODE_SWITCH: "ratchet-mode-switch",
-    RatbagdButton.ActionSpecial.RESOLUTION_CYCLE_UP: "resolution-cycle-up",
-    RatbagdButton.ActionSpecial.RESOLUTION_CYCLE_DOWN: "resolution-cycle-down",
-    RatbagdButton.ActionSpecial.RESOLUTION_UP: "resolution-up",
-    RatbagdButton.ActionSpecial.RESOLUTION_DOWN: "resolution-down",
-    RatbagdButton.ActionSpecial.RESOLUTION_ALTERNATE: "resolution-alternate",
-    RatbagdButton.ActionSpecial.RESOLUTION_DEFAULT: "resolution-default",
-    RatbagdButton.ActionSpecial.PROFILE_CYCLE_UP: "profile-cycle-up",
-    RatbagdButton.ActionSpecial.PROFILE_CYCLE_DOWN: "profile-cycle-down",
-    RatbagdButton.ActionSpecial.PROFILE_UP: "profile-up",
-    RatbagdButton.ActionSpecial.PROFILE_DOWN: "profile-down",
-    RatbagdButton.ActionSpecial.SECOND_MODE: "second-mode",
-    RatbagdButton.ActionSpecial.BATTERY_LEVEL: "battery-level",
+    **{e: e.name.lower().replace("_", "-") for e in RatbagdButton.ActionSpecial},
+    **{e.name.lower().replace("_", "-"): e for e in RatbagdButton.ActionSpecial}
 }
-for k, v in [(v, k) for k, v in button_specials_strmap.items()]:
-    button_specials_strmap[k] = v
 
 
 def list_devices(r, args):

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -32,25 +32,25 @@ from ratbagd import Ratbagd, RatbagdDevice, RatbagdProfile, RatbagdMacro, Ratbag
 
 
 button_specials_strmap = {
-    RatbagdButton.ACTION_SPECIAL_UNKNOWN: "unknown",
-    RatbagdButton.ACTION_SPECIAL_DOUBLECLICK: "doubleclick",
-    RatbagdButton.ACTION_SPECIAL_WHEEL_LEFT: "wheel-left",
-    RatbagdButton.ACTION_SPECIAL_WHEEL_RIGHT: "wheel-right",
-    RatbagdButton.ACTION_SPECIAL_WHEEL_UP: "wheel-up",
-    RatbagdButton.ACTION_SPECIAL_WHEEL_DOWN: "wheel-down",
-    RatbagdButton.ACTION_SPECIAL_RATCHET_MODE_SWITCH: "ratchet-mode-switch",
-    RatbagdButton.ACTION_SPECIAL_RESOLUTION_CYCLE_UP: "resolution-cycle-up",
-    RatbagdButton.ACTION_SPECIAL_RESOLUTION_CYCLE_DOWN: "resolution-cycle-down",
-    RatbagdButton.ACTION_SPECIAL_RESOLUTION_UP: "resolution-up",
-    RatbagdButton.ACTION_SPECIAL_RESOLUTION_DOWN: "resolution-down",
-    RatbagdButton.ACTION_SPECIAL_RESOLUTION_ALTERNATE: "resolution-alternate",
-    RatbagdButton.ACTION_SPECIAL_RESOLUTION_DEFAULT: "resolution-default",
-    RatbagdButton.ACTION_SPECIAL_PROFILE_CYCLE_UP: "profile-cycle-up",
-    RatbagdButton.ACTION_SPECIAL_PROFILE_CYCLE_DOWN: "profile-cycle-down",
-    RatbagdButton.ACTION_SPECIAL_PROFILE_UP: "profile-up",
-    RatbagdButton.ACTION_SPECIAL_PROFILE_DOWN: "profile-down",
-    RatbagdButton.ACTION_SPECIAL_SECOND_MODE: "second-mode",
-    RatbagdButton.ACTION_SPECIAL_BATTERY_LEVEL: "battery-level",
+    RatbagdButton.ActionSpecial.UNKNOWN: "unknown",
+    RatbagdButton.ActionSpecial.DOUBLECLICK: "doubleclick",
+    RatbagdButton.ActionSpecial.WHEEL_LEFT: "wheel-left",
+    RatbagdButton.ActionSpecial.WHEEL_RIGHT: "wheel-right",
+    RatbagdButton.ActionSpecial.WHEEL_UP: "wheel-up",
+    RatbagdButton.ActionSpecial.WHEEL_DOWN: "wheel-down",
+    RatbagdButton.ActionSpecial.RATCHET_MODE_SWITCH: "ratchet-mode-switch",
+    RatbagdButton.ActionSpecial.RESOLUTION_CYCLE_UP: "resolution-cycle-up",
+    RatbagdButton.ActionSpecial.RESOLUTION_CYCLE_DOWN: "resolution-cycle-down",
+    RatbagdButton.ActionSpecial.RESOLUTION_UP: "resolution-up",
+    RatbagdButton.ActionSpecial.RESOLUTION_DOWN: "resolution-down",
+    RatbagdButton.ActionSpecial.RESOLUTION_ALTERNATE: "resolution-alternate",
+    RatbagdButton.ActionSpecial.RESOLUTION_DEFAULT: "resolution-default",
+    RatbagdButton.ActionSpecial.PROFILE_CYCLE_UP: "profile-cycle-up",
+    RatbagdButton.ActionSpecial.PROFILE_CYCLE_DOWN: "profile-cycle-down",
+    RatbagdButton.ActionSpecial.PROFILE_UP: "profile-up",
+    RatbagdButton.ActionSpecial.PROFILE_DOWN: "profile-down",
+    RatbagdButton.ActionSpecial.SECOND_MODE: "second-mode",
+    RatbagdButton.ActionSpecial.BATTERY_LEVEL: "battery-level",
 }
 for k, v in [(v, k) for k, v in button_specials_strmap.items()]:
     button_specials_strmap[k] = v
@@ -121,34 +121,34 @@ def find_led(r, args):
 
 def print_led(d, p, l, level):
     leds = {
-        RatbagdLed.MODE_BREATHING: "breathing",
-        RatbagdLed.MODE_CYCLE: "cycle",
-        RatbagdLed.MODE_OFF: "off",
-        RatbagdLed.MODE_ON: "on",
+        RatbagdLed.Mode.BREATHING: "breathing",
+        RatbagdLed.Mode.CYCLE: "cycle",
+        RatbagdLed.Mode.OFF: "off",
+        RatbagdLed.Mode.ON: "on",
     }
     depths = {
-        RatbagdLed.COLORDEPTH_MONOCHROME: "monochrome",
-        RatbagdLed.COLORDEPTH_RGB_888: "rgb",
-        RatbagdLed.COLORDEPTH_RGB_111: "rgb111",
+        RatbagdLed.ColorDepth.MONOCHROME: "monochrome",
+        RatbagdLed.ColorDepth.RGB_888: "rgb",
+        RatbagdLed.ColorDepth.RGB_111: "rgb111",
     }
-    if l.mode == RatbagdLed.MODE_OFF:
+    if l.mode == RatbagdLed.Mode.OFF:
         print(" " * level + "LED: {}, depth: {}, mode: {}".format(l.index,
                                                                            depths[l.colordepth],
                                                                            leds[l.mode]))
-    elif l.mode == RatbagdLed.MODE_ON:
+    elif l.mode == RatbagdLed.Mode.ON:
         print(" " * level + "LED: {}, depth: {}, mode: {}, color: {:02x}{:02x}{:02x}".format(l.index,
                                                                                                       depths[l.colordepth],
                                                                                                       leds[l.mode],
                                                                                                       l.color[0],
                                                                                                       l.color[1],
                                                                                                       l.color[2]))
-    elif l.mode == RatbagdLed.MODE_CYCLE:
+    elif l.mode == RatbagdLed.Mode.CYCLE:
         print(" " * level + "LED: {}, depth: {}, mode: {}, duration: {}, brightness: {}".format(l.index,
                                                                                                          depths[l.colordepth],
                                                                                                          leds[l.mode],
                                                                                                          l.effect_duration,
                                                                                                          l.brightness))
-    elif l.mode == RatbagdLed.MODE_BREATHING:
+    elif l.mode == RatbagdLed.Mode.BREATHING:
         print(" " * level + "LED: {}, depth: {}, mode: {}, color: {:02x}{:02x}{:02x}, duration: {}, brightness: {}".format(l.index,
                                                                                                                                     depths[l.colordepth],
                                                                                                                                     leds[l.mode],
@@ -161,10 +161,10 @@ def print_led(d, p, l, level):
 
 def print_led_caps(d, p, l, level):
     leds = {
-        RatbagdLed.MODE_BREATHING: "breathing",
-        RatbagdLed.MODE_CYCLE: "cycle",
-        RatbagdLed.MODE_OFF: "off",
-        RatbagdLed.MODE_ON: "on",
+        RatbagdLed.Mode.BREATHING: "breathing",
+        RatbagdLed.Mode.CYCLE: "cycle",
+        RatbagdLed.Mode.OFF: "off",
+        RatbagdLed.Mode.ON: "on",
     }
     supported = sorted([v for k, v in leds.items() if k in l.modes])
     print(" " * level + "Modes: {}".format(", ".join(supported)))
@@ -173,13 +173,13 @@ def print_led_caps(d, p, l, level):
 def print_button(d, p, b, level):
     header = " " * level + "Button: {} is mapped to ".format(b.index)
 
-    if b.action_type == RatbagdButton.ACTION_TYPE_BUTTON:
+    if b.action_type == RatbagdButton.ActionType.BUTTON:
         print("{}'button {}'".format(header, b.mapping))
-    elif b.action_type == RatbagdButton.ACTION_TYPE_SPECIAL:
+    elif b.action_type == RatbagdButton.ActionType.SPECIAL:
         print("{}'{}'".format(header, button_specials_strmap[b.special]))
-    elif b.action_type == RatbagdButton.ACTION_TYPE_MACRO:
+    elif b.action_type == RatbagdButton.ActionType.MACRO:
         print("{}macro '{}'".format(header, str(b.macro)))
-    elif b.action_type == RatbagdButton.ACTION_TYPE_NONE:
+    elif b.action_type == RatbagdButton.ActionType.NONE:
         print("{}none".format(header))
     else:
         print("{}UNKNOWN".format(header))
@@ -279,10 +279,10 @@ def func_led_set(r, args):
         pass
     else:
         leds = {
-            "breathing": RatbagdLed.MODE_BREATHING,
-            "cycle": RatbagdLed.MODE_CYCLE,
-            "off": RatbagdLed.MODE_OFF,
-            "on": RatbagdLed.MODE_ON,
+            "breathing": RatbagdLed.Mode.BREATHING,
+            "cycle": RatbagdLed.Mode.CYCLE,
+            "off": RatbagdLed.Mode.OFF,
+            "on": RatbagdLed.Mode.ON,
         }
         l.mode = leds[mode]
     try:
@@ -336,7 +336,7 @@ def func_button_action_set_special(r, args):
 
 def func_button_action_set_macro(r, args):
     b, p, d = find_button(r, args)
-    if not b.ACTION_TYPE_MACRO in b.action_types:
+    if not b.ActionType.MACRO in b.action_types:
         raise RatbagErrorCapability("assigning a macro is not supported on this device")
 
     macro_keys = args.target_macro
@@ -360,7 +360,7 @@ def func_button_action_set_macro(r, args):
 
         if is_timeout:
             t = int(s[1:])
-            macro.append(RatbagdButton.MACRO_WAIT, t)
+            macro.append(RatbagdButton.Macro.WAIT, t)
         else:
             if not s.startswith("KEY_") and not s.startswith("BTN_"):
                 msg = "Don't know how to convert {}".format(s)
@@ -368,9 +368,9 @@ def func_button_action_set_macro(r, args):
 
             code = evdev.ecodes.ecodes[s]
             if is_press:
-                macro.append(RatbagdButton.MACRO_KEY_PRESS, code)
+                macro.append(RatbagdButton.Macro.KEY_PRESS, code)
             if is_release:
-                macro.append(RatbagdButton.MACRO_KEY_RELEASE, code)
+                macro.append(RatbagdButton.Macro.KEY_RELEASE, code)
 
     b.macro = macro
     commit(d, args)

--- a/tools/ratbagctl.in
+++ b/tools/ratbagctl.in
@@ -315,6 +315,12 @@ def func_button_action_set_special(r, args):
     commit(d, args)
 
 
+def func_button_action_set_none(r, args):
+    b, p, d = find_button(r, args)
+    b.disable()
+    commit(d, args)
+
+
 def func_button_action_set_macro(r, args):
     b, p, d = find_button(r, args)
     if not b.ActionType.MACRO in b.action_types:
@@ -995,6 +1001,13 @@ active profile if none is given.""",
                                         },
                                     ],
                                     func: func_button_action_set_macro,
+                                },
+                                {
+                                    of_type: command,
+                                    name: 'disabled',
+                                    help_str: 'Disable this button',
+                                    pos_args: [],
+                                    func: func_button_action_set_none,
                                 },
                             ]
                         },

--- a/tools/ratbagctl.test.in
+++ b/tools/ratbagctl.test.in
@@ -487,7 +487,7 @@ class TestRatbagCtlButton(TestRatbagCtl):
 
     def test_prefix_button(self):
         r = self.launch_good_test("test_device profile 2 button 3 get")
-        self.assertEqual(r, "Button: 3 is mapped to 'button 3'")
+        self.assertEqual(r, "Button: 3 is mapped to none")
         self.launch_fail_test("test_device profile 2 profile 2 button 3 get")
         self.launch_fail_test("test_device profile 2 resolution 2 button 3 get")
 

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -751,9 +751,16 @@ class RatbagdButton(_RatbagdDBus):
         """An array of possible values for ActionType."""
         return self._get_dbus_property("ActionTypes")
 
+    @GObject.Property
+    def disabled(self):
+        type, unused = self._mapping()
+        return type == RatbagdButton.ActionType.NONE
+
     def disable(self):
         """Disables this button."""
-        return self._dbus_call("Disable", "")
+        zero = GLib.Variant('u', 0)
+        self._set_dbus_property("Mapping", "(uv)",
+                                (RatbagdButton.ActionType.NONE, zero))
 
 
 class RatbagdMacro(GObject.Object):

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -595,35 +595,38 @@ class RatbagdResolution(_RatbagdDBus):
 class RatbagdButton(_RatbagdDBus):
     """Represents a ratbagd button."""
 
-    ACTION_TYPE_NONE = 0
-    ACTION_TYPE_BUTTON = 1
-    ACTION_TYPE_SPECIAL = 2
-    ACTION_TYPE_MACRO = 4
+    class ActionType(IntEnum):
+        NONE = 0
+        BUTTON = 1
+        SPECIAL = 2
+        MACRO = 4
 
-    ACTION_SPECIAL_INVALID = -1
-    ACTION_SPECIAL_UNKNOWN = (1 << 30)
-    ACTION_SPECIAL_DOUBLECLICK = (1 << 30) + 1
-    ACTION_SPECIAL_WHEEL_LEFT = (1 << 30) + 2
-    ACTION_SPECIAL_WHEEL_RIGHT = (1 << 30) + 3
-    ACTION_SPECIAL_WHEEL_UP = (1 << 30) + 4
-    ACTION_SPECIAL_WHEEL_DOWN = (1 << 30) + 5
-    ACTION_SPECIAL_RATCHET_MODE_SWITCH = (1 << 30) + 6
-    ACTION_SPECIAL_RESOLUTION_CYCLE_UP = (1 << 30) + 7
-    ACTION_SPECIAL_RESOLUTION_CYCLE_DOWN = (1 << 30) + 8
-    ACTION_SPECIAL_RESOLUTION_UP = (1 << 30) + 9
-    ACTION_SPECIAL_RESOLUTION_DOWN = (1 << 30) + 10
-    ACTION_SPECIAL_RESOLUTION_ALTERNATE = (1 << 30) + 11
-    ACTION_SPECIAL_RESOLUTION_DEFAULT = (1 << 30) + 12
-    ACTION_SPECIAL_PROFILE_CYCLE_UP = (1 << 30) + 13
-    ACTION_SPECIAL_PROFILE_CYCLE_DOWN = (1 << 30) + 14
-    ACTION_SPECIAL_PROFILE_UP = (1 << 30) + 15
-    ACTION_SPECIAL_PROFILE_DOWN = (1 << 30) + 16
-    ACTION_SPECIAL_SECOND_MODE = (1 << 30) + 17
-    ACTION_SPECIAL_BATTERY_LEVEL = (1 << 30) + 18
+    class ActionSpecial(IntEnum):
+        INVALID = -1
+        UNKNOWN = (1 << 30)
+        DOUBLECLICK = (1 << 30) + 1
+        WHEEL_LEFT = (1 << 30) + 2
+        WHEEL_RIGHT = (1 << 30) + 3
+        WHEEL_UP = (1 << 30) + 4
+        WHEEL_DOWN = (1 << 30) + 5
+        RATCHET_MODE_SWITCH = (1 << 30) + 6
+        RESOLUTION_CYCLE_UP = (1 << 30) + 7
+        RESOLUTION_CYCLE_DOWN = (1 << 30) + 8
+        RESOLUTION_UP = (1 << 30) + 9
+        RESOLUTION_DOWN = (1 << 30) + 10
+        RESOLUTION_ALTERNATE = (1 << 30) + 11
+        RESOLUTION_DEFAULT = (1 << 30) + 12
+        PROFILE_CYCLE_UP = (1 << 30) + 13
+        PROFILE_CYCLE_DOWN = (1 << 30) + 14
+        PROFILE_UP = (1 << 30) + 15
+        PROFILE_DOWN = (1 << 30) + 16
+        SECOND_MODE = (1 << 30) + 17
+        BATTERY_LEVEL = (1 << 30) + 18
 
-    MACRO_KEY_PRESS = 1
-    MACRO_KEY_RELEASE = 2
-    MACRO_WAIT = 3
+    class Macro(IntEnum):
+        KEY_PRESS = 1
+        KEY_RELEASE = 2
+        WAIT = 3
 
     """A table mapping a button's index to its usual function as defined by X
     and the common desktop environments."""
@@ -637,26 +640,26 @@ class RatbagdButton(_RatbagdDBus):
 
     """A table mapping a special function to its human-readable description."""
     SPECIAL_DESCRIPTION = {
-        ACTION_SPECIAL_INVALID: N_("Invalid"),
-        ACTION_SPECIAL_UNKNOWN: N_("Unknown"),
-        ACTION_SPECIAL_DOUBLECLICK: N_("Doubleclick"),
-        ACTION_SPECIAL_WHEEL_LEFT: N_("Wheel Left"),
-        ACTION_SPECIAL_WHEEL_RIGHT: N_("Wheel Right"),
-        ACTION_SPECIAL_WHEEL_UP: N_("Wheel Up"),
-        ACTION_SPECIAL_WHEEL_DOWN: N_("Wheel Down"),
-        ACTION_SPECIAL_RATCHET_MODE_SWITCH: N_("Ratchet Mode"),
-        ACTION_SPECIAL_RESOLUTION_CYCLE_UP: N_("Cycle Resolution Up"),
-        ACTION_SPECIAL_RESOLUTION_CYCLE_DOWN: N_("Cycle Resolution Down"),
-        ACTION_SPECIAL_RESOLUTION_UP: N_("Resolution Up"),
-        ACTION_SPECIAL_RESOLUTION_DOWN: N_("Resolution Down"),
-        ACTION_SPECIAL_RESOLUTION_ALTERNATE: N_("Resolution Switch"),
-        ACTION_SPECIAL_RESOLUTION_DEFAULT: N_("Default Resolution"),
-        ACTION_SPECIAL_PROFILE_CYCLE_UP: N_("Cycle Profile Up"),
-        ACTION_SPECIAL_PROFILE_CYCLE_DOWN: N_("Cycle Profile Down"),
-        ACTION_SPECIAL_PROFILE_UP: N_("Profile Up"),
-        ACTION_SPECIAL_PROFILE_DOWN: N_("Profile Down"),
-        ACTION_SPECIAL_SECOND_MODE: N_("Second Mode"),
-        ACTION_SPECIAL_BATTERY_LEVEL: N_("Battery Level"),
+        ActionSpecial.INVALID: N_("Invalid"),
+        ActionSpecial.UNKNOWN: N_("Unknown"),
+        ActionSpecial.DOUBLECLICK: N_("Doubleclick"),
+        ActionSpecial.WHEEL_LEFT: N_("Wheel Left"),
+        ActionSpecial.WHEEL_RIGHT: N_("Wheel Right"),
+        ActionSpecial.WHEEL_UP: N_("Wheel Up"),
+        ActionSpecial.WHEEL_DOWN: N_("Wheel Down"),
+        ActionSpecial.RATCHET_MODE_SWITCH: N_("Ratchet Mode"),
+        ActionSpecial.RESOLUTION_CYCLE_UP: N_("Cycle Resolution Up"),
+        ActionSpecial.RESOLUTION_CYCLE_DOWN: N_("Cycle Resolution Down"),
+        ActionSpecial.RESOLUTION_UP: N_("Resolution Up"),
+        ActionSpecial.RESOLUTION_DOWN: N_("Resolution Down"),
+        ActionSpecial.RESOLUTION_ALTERNATE: N_("Resolution Switch"),
+        ActionSpecial.RESOLUTION_DEFAULT: N_("Default Resolution"),
+        ActionSpecial.PROFILE_CYCLE_UP: N_("Cycle Profile Up"),
+        ActionSpecial.PROFILE_CYCLE_DOWN: N_("Cycle Profile Down"),
+        ActionSpecial.PROFILE_UP: N_("Profile Up"),
+        ActionSpecial.PROFILE_DOWN: N_("Profile Down"),
+        ActionSpecial.SECOND_MODE: N_("Second Mode"),
+        ActionSpecial.BATTERY_LEVEL: N_("Battery Level"),
     }
 
     def __init__(self, object_path):
@@ -679,7 +682,7 @@ class RatbagdButton(_RatbagdDBus):
         """An integer of the current button mapping, if mapping to a button
         or None otherwise."""
         type, button = self._mapping()
-        if type != RatbagdButton.ACTION_TYPE_BUTTON:
+        if type != RatbagdButton.ActionType.BUTTON:
             return None
         return button
 
@@ -691,14 +694,14 @@ class RatbagdButton(_RatbagdDBus):
         """
         button = GLib.Variant("u", button)
         self._set_dbus_property("Mapping", "(uv)",
-                                (RatbagdButton.ACTION_TYPE_BUTTON, button))
+                                (RatbagdButton.ActionType.BUTTON, button))
 
     @GObject.Property
     def macro(self):
         """A RatbagdMacro object representing the currently set macro or
         None otherwise."""
         type, macro = self._mapping()
-        if type != RatbagdButton.ACTION_TYPE_MACRO:
+        if type != RatbagdButton.ActionType.MACRO:
             return None
         return RatbagdMacro.from_ratbag(macro)
 
@@ -712,14 +715,14 @@ class RatbagdButton(_RatbagdDBus):
         """
         macro = GLib.Variant("a(uu)", macro.keys)
         self._set_dbus_property("Mapping", "(uv)",
-                                (RatbagdButton.ACTION_TYPE_MACRO, macro))
+                                (RatbagdButton.ActionType.MACRO, macro))
 
     @GObject.Property
     def special(self):
         """An enum describing the current special mapping, if mapped to
         special or None otherwise."""
         type, special = self._mapping()
-        if type != RatbagdButton.ACTION_TYPE_SPECIAL:
+        if type != RatbagdButton.ActionType.SPECIAL:
             return None
         return special
 
@@ -727,17 +730,17 @@ class RatbagdButton(_RatbagdDBus):
     def special(self, special):
         """Set the button mapping to the given special entry.
 
-        @param special The special entry, as one of RatbagdButton.ACTION_SPECIAL_*
+        @param special The special entry, as one of RatbagdButton.ActionSpecial
         """
         special = GLib.Variant("u", special)
         self._set_dbus_property("Mapping", "(uv)",
-                                (RatbagdButton.ACTION_TYPE_SPECIAL, special))
+                                (RatbagdButton.ActionType.SPECIAL, special))
 
     @GObject.Property
     def action_type(self):
         """An enum describing the action type of the button. One of
-        ACTION_TYPE_NONE, ACTION_TYPE_BUTTON, ACTION_TYPE_SPECIAL,
-        ACTION_TYPE_MACRO. This decides which
+        ActionType.NONE, ActionType.BUTTON, ActionType.SPECIAL,
+        ActionType.MACRO. This decides which
         *Mapping property has a value.
         """
         type, mapping = self._mapping()
@@ -765,11 +768,11 @@ class RatbagdMacro(GObject.Object):
     _MACRO_KEY = 1000
 
     _MACRO_DESCRIPTION = {
-        RatbagdButton.MACRO_KEY_PRESS: lambda key:
+        RatbagdButton.Macro.KEY_PRESS: lambda key:
             "↓{}".format(ecodes.KEY[key][RatbagdMacro._PREFIX_LEN:]),
-        RatbagdButton.MACRO_KEY_RELEASE: lambda key:
+        RatbagdButton.Macro.KEY_RELEASE: lambda key:
             "↑{}".format(ecodes.KEY[key][RatbagdMacro._PREFIX_LEN:]),
-        RatbagdButton.MACRO_WAIT: lambda val:
+        RatbagdButton.Macro.WAIT: lambda val:
             "{}ms".format(val),
         _MACRO_KEY: lambda key:
             "↕{}".format(ecodes.KEY[key][RatbagdMacro._PREFIX_LEN:]),
@@ -793,10 +796,10 @@ class RatbagdMacro(GObject.Object):
         while idx < len(self._macro):
             t, v = self._macro[idx]
             try:
-                if t == RatbagdButton.MACRO_KEY_PRESS:
+                if t == RatbagdButton.Macro.KEY_PRESS:
                     # Check for a paired press/release event
                     t2, v2 = self._macro[idx + 1]
-                    if t2 == RatbagdButton.MACRO_KEY_RELEASE and v == v2:
+                    if t2 == RatbagdButton.Macro.KEY_RELEASE and v == v2:
                         t = self._MACRO_KEY
                         idx += 1
             except IndexError:
@@ -855,25 +858,27 @@ class RatbagdLed(_RatbagdDBus):
     TYPE_DPI = 4
     TYPE_WHEEL = 5
 
-    MODE_OFF = 0
-    MODE_ON = 1
-    MODE_CYCLE = 2
-    MODE_BREATHING = 3
+    class Mode(IntEnum):
+        OFF = 0
+        ON = 1
+        CYCLE = 2
+        BREATHING = 3
 
-    COLORDEPTH_MONOCHROME = 0
-    COLORDEPTH_RGB_888 = 1
-    COLORDEPTH_RGB_111 = 2
+    class ColorDepth(IntEnum):
+        MONOCHROME = 0
+        RGB_888 = 1
+        RGB_111 = 2
 
     LED_DESCRIPTION = {
         # Translators: the LED is off.
-        MODE_OFF: N_("Off"),
+        Mode.OFF: N_("Off"),
         # Translators: the LED has a single, solid color.
-        MODE_ON: N_("Solid"),
+        Mode.ON: N_("Solid"),
         # Translators: the LED is cycling between red, green and blue.
-        MODE_CYCLE: N_("Cycle"),
+        Mode.CYCLE: N_("Cycle"),
         # Translators: the LED's is pulsating a single color on different
         # brightnesses.
-        MODE_BREATHING: N_("Breathing"),
+        Mode.BREATHING: N_("Breathing"),
     }
 
     def __init__(self, object_path):
@@ -886,16 +891,16 @@ class RatbagdLed(_RatbagdDBus):
 
     @GObject.Property
     def mode(self):
-        """This led's mode, one of MODE_OFF, MODE_ON, MODE_CYCLE and
-        MODE_BREATHING."""
+        """This led's mode, one of Mode.OFF, Mode.ON, Mode.CYCLE and
+        Mode.BREATHING."""
         return self._get_dbus_property("Mode")
 
     @mode.setter
     def mode(self, mode):
         """Set the led's mode to the given mode.
 
-        @param mode The new mode, as one of MODE_OFF, MODE_ON, MODE_CYCLE and
-                    MODE_BREATHING.
+        @param mode The new mode, as one of Mode.OFF, Mode.ON, Mode.CYCLE and
+                    Mode.BREATHING.
         """
         self._set_dbus_property("Mode", "u", mode)
 
@@ -920,7 +925,7 @@ class RatbagdLed(_RatbagdDBus):
     @GObject.Property
     def colordepth(self):
         """An enum describing this led's colordepth, one of
-        RatbagdLed.COLORDEPTH_MONOCHROME, RatbagdLed.COLORDEPTH_RGB"""
+        RatbagdLed.ColorDepth.MONOCHROME, RatbagdLed.ColorDepth.RGB"""
         return self._get_dbus_property("ColorDepth")
 
     @GObject.Property


### PR DESCRIPTION
We already have `ACTION_TYPE_NONE` which is specified as disabling a button, there's no need for a separate DBus interface here. 


WIP, simply because I haven't tested it yet and there may be a corner case missing.