### PR TITLE
Support for Roccat Kone Pure Optical Black/White Edition

### DIFF
--- a/data/devices/roccat-kone-pure.device
+++ b/data/devices/roccat-kone-pure.device
@@ -1,0 +1,4 @@
+[Device]
+Name=Roccat Kone Pure
+DeviceMatch=usb:1e7d:2dc2
+Driver=roccat

--- a/meson.build
+++ b/meson.build
@@ -308,6 +308,7 @@ data_files = files(
 	'data/devices/logitech-MX-Anywhere2.device',
 	'data/devices/logitech-MX-Anywhere2S.device',
 	'data/devices/roccat-kone-xtd.device',
+	'data/devices/roccat-kone-pure.device',
 	'data/devices/steelseries-kinzu-v2.device',
 	'data/devices/steelseries-rival-310.device',
 	'data/devices/steelseries-rival-600.device',


### PR DESCRIPTION
WARNING: Do not merge, it will break support for Roccat Kone XTD.

I'm working on adding support for Roccat Kone Pure, specifically Optical Black/White Edition. Before I proceed further I would like some advice in a few areas.

Generally I wanted to take this approach:
1. Change `roccat` driver so it can handle both Kone XTD and Kone Pure (is there anyone that can validate my changes using XTD?).
2. Migrate the driver to new structure with `commit()` function.
3. Add support for additional features already supported by ratbag (e.g. LEDs, as I have a working prototype already).

The draft pull request visualizes changes that I needed to make to handle Kone Pure mouse. On one hand it borks existing support for Kone XTD. On the other hand it shows how both these mice differ.

1. My first question is how to tell the driver which mouse model he needs to communicate with. I saw two examples in the existing codebase - the `steelseries` driver uses `DeviceVersion` property (1, 2, 3...) and the `hidpp10` driver uses `ProfileType` property (e.g. G700). I'm not sure why there are already have two different properties already. Unfortunately I would prefer a property named `DeviceModel` as `ProfileType` is confusing due to the primary meaning of profiles as a set of configuration values. Thoughts?

2. Some differences between Pure and XTD could be described in the device files, e.g. `DpiRange` (100:5000@50 vs 200:8200@50), maybe number of buttons as well.

3. More serious are remaining differences, namely a) different data structures (USB HID GET/SET_REPORT) and button mappings. One way to handle that is to introduce additional structures (e.g. rename `roccat_settings_report` to `roccat_settings_report_kone_xtd` and then add a slightly different `roccat_settings_report_kone_pure`) and use conditions (if-oriented-programming ;-)) to handle different devices - there are like around 10 places like that. I would probably introduce several helper functions as some existing functions like `roccat_read_profile()` are already pretty lengthy. Any better ideas? Note that adding support for more Roccat devices would probably require to push further in that direction, as even XTD Optical seems to differ from 'common' XTD (https://github.com/libratbag/libratbag/issues/421).

I started documenting Kone Pure protocol here: https://github.com/hipnoizz/libratbag/wiki/Roccat-Kone-Pure if someone is interested. Some of this found it's place in the codebase, but not everything, so I think it is a worthwhile addition anyway.