### PR TITLE
updating deviceMatch for Logitech G Pro #684

### DIFF
--- a/data/devices/logitech-g-pro.device
+++ b/data/devices/logitech-g-pro.device
@@ -1,5 +1,5 @@
 [Device]
 Name=Logitech Gaming Mouse G Pro
-DeviceMatch=usb:046d:c085
+DeviceMatch=usb:046d:c085;usb:046d:c08c
 Driver=hidpp20
 LedTypes=logo;side


### PR DESCRIPTION
adding 046d:c08c to the list of usb devices in