### PR TITLE
Error out if NDEBUG is defined

### DIFF
--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -32,6 +32,10 @@
 #include "libratbag-util.h"
 #include "libratbag-hidraw.h"
 
+#ifdef NDEBUG
+#error "libratbag relies on assert(). Do not define NDEBUG"
+#endif
+
 #define RATBAG_LED_TYPE_UNKNOWN 0
 
 void


### PR DESCRIPTION
At some point meson #defined NDEBUG depending on the build type, thus
disabling asserts. libratbag relies on those, so let's error out if NDEBUG is
defined.

Related #685