### PR TITLE
Add battery voltage reporting for newer mice

### DIFF
--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -56,6 +56,7 @@
 #define HIDPP_CAP_ONBOARD_PROFILES_8100			(1 << 6)
 #define HIDPP_CAP_LED_SW_CONTROL_1300			(1 << 7)
 #define HIDPP_CAP_ADJUSTIBLE_REPORT_RATE_8060		(1 << 8)
+#define HIDPP_CAP_BATTERY_VOLTAGE_1001			(1 << 9)
 
 struct hidpp20drv_data {
 	struct hidpp20_device *dev;
@@ -1147,6 +1148,22 @@ hidpp20drv_init_feature(struct ratbag_device *device, uint16_t feature)
 			  level, next_level, status);
 
 		drv_data->capabilities |= HIDPP_CAP_BATTERY_LEVEL_1000;
+		break;
+	}
+	case HIDPP_PAGE_BATTERY_VOLTAGE: {
+		uint16_t voltage;
+		enum hidpp20_battery_voltage_status status;
+
+		rc = hidpp20_batteryvoltage_get_battery_voltage(drv_data->dev, &voltage);
+		if (rc < 0)
+			return rc;
+
+		status = rc;
+
+		log_debug(ratbag, "device battery voltage is %dmv, status %02x \n",
+			  voltage, status);
+
+		drv_data->capabilities |= HIDPP_CAP_BATTERY_VOLTAGE_1001;
 		break;
 	}
 	case HIDPP_PAGE_KBD_REPROGRAMMABLE_KEYS: {

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -58,6 +58,7 @@ hidpp20_feature_get_name(uint16_t feature)
 	CASE_RETURN_STRING(HIDPP_PAGE_DEVICE_NAME);
 	CASE_RETURN_STRING(HIDPP_PAGE_RESET);
 	CASE_RETURN_STRING(HIDPP_PAGE_BATTERY_LEVEL_STATUS);
+	CASE_RETURN_STRING(HIDPP_PAGE_BATTERY_VOLTAGE);
 	CASE_RETURN_STRING(HIDPP_PAGE_KBD_REPROGRAMMABLE_KEYS);
 	CASE_RETURN_STRING(HIDPP_PAGE_SPECIAL_KEYS_BUTTONS);
 	CASE_RETURN_STRING(HIDPP_PAGE_WIRELESS_DEVICE_STATUS);
@@ -426,6 +427,40 @@ hidpp20_batterylevel_get_battery_level(struct hidpp20_device *device,
 
 	*level = msg.msg.parameters[0];
 	*next_level = msg.msg.parameters[1];
+
+	return msg.msg.parameters[2];
+}
+
+/* -------------------------------------------------------------------------- */
+/* 0x1000: Battery level status                                               */
+/* -------------------------------------------------------------------------- */
+
+#define CMD_BATTERY_VOLTAGE_GET_BATTERY_VOLTAGE 0x00
+
+int
+hidpp20_batteryvoltage_get_battery_voltage(struct hidpp20_device *device,
+					   uint16_t *voltage)
+{
+	uint8_t feature_index;
+	union hidpp20_message msg = {
+		.msg.report_id = REPORT_ID_SHORT,
+		.msg.device_idx = device->index,
+		.msg.address = CMD_BATTERY_VOLTAGE_GET_BATTERY_VOLTAGE,
+	};
+	int rc;
+
+	feature_index = hidpp_root_get_feature_idx(device,
+						   HIDPP_PAGE_BATTERY_VOLTAGE);
+	if (feature_index == 0)
+		return -ENOTSUP;
+
+	msg.msg.sub_id = feature_index;
+
+	rc = hidpp20_request_command(device, &msg);
+	if (rc)
+		return rc;
+
+	*voltage = (msg.msg.parameters[0] << 8) + msg.msg.parameters[1];
 
 	return msg.msg.parameters[2];
 }

--- a/src/hidpp20.h
+++ b/src/hidpp20.h
@@ -139,6 +139,25 @@ int hidpp20_batterylevel_get_battery_level(struct hidpp20_device *device,
 					   uint16_t *next_level);
 
 /* -------------------------------------------------------------------------- */
+/* 0x1001: Battery Voltage                                                    */
+/* -------------------------------------------------------------------------- */
+#define HIDPP_PAGE_BATTERY_VOLTAGE		0x1001
+
+enum hidpp20_battery_voltage_status {
+	BATTERY_VOLTAGE_STATUS_DISCHARGING = 0,
+	BATTERY_VOLTAGE_STATUS_WIRELESS_CHARGING = 0x10,
+	BATTERY_VOLTAGE_STATUS_CHARGING = 0x80,
+};
+
+/**
+ * Retrieves the battery voltage
+ *
+ * @return the battery status or a negative errno on error
+ */
+int hidpp20_batteryvoltage_get_battery_voltage(struct hidpp20_device *device,
+					       uint16_t *voltage);
+
+/* -------------------------------------------------------------------------- */
 /* 0x1300: LED software control                                               */
 /* -------------------------------------------------------------------------- */
 


### PR DESCRIPTION
Newer mice don't report their battery levels. Instead, they report the voltage read by the SOC. The lghub app does some math with it to figure out the percentage, using some tables shipped with it, but for our purposes I believe having the battery voltage (in millivolts) and the status (charging, wireless charging, charged, discharging...) should suffice.

This is related to [this piper issue](https://github.com/libratbag/piper/issues/222) and the discussion there.