### PR TITLE
meson: add 'sphinx-build' to sphinx executable name list

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -1,6 +1,6 @@
 if get_option('documentation')
 
-cmd_sphinx = find_program('sphinx-build-3', 'sphinx-build3')
+cmd_sphinx = find_program('sphinx-build-3', 'sphinx-build3', 'sphinx-build')
 
 doc_config = configuration_data()
 doc_config.set('PACKAGE_NAME', meson.project_name())


### PR DESCRIPTION
We currently assume the user is using Python 2 as default (over Python 3) and so they renamed the Sphinx Python 3 executable to `sphinx-build{3,-3}`. The default name is `sphinx-build` and is usually kept when using Python 3 as the default Python version. With Python 2 dying in 7 months (https://pythonclock.org/) and Sphinx officially dropping Python 2 (https://github.com/sphinx-doc/sphinx/commit/9412bd76b7f5fdf0adc231ef8130e45bda130164) this seems safe to merge.