### PR TITLE
 steelseries: fix bug where we were wrongly dellocating dpi_{range,list} 

### DIFF
--- a/src/driver-steelseries.c
+++ b/src/driver-steelseries.c
@@ -271,8 +271,8 @@ steelseries_probe(struct ratbag_device *device)
 	struct ratbag_button *button;
 	struct ratbag_led *led;
 	int rc, button_count, led_count, device_version, mono_led, short_button;
-	_cleanup_(dpi_list_freep) struct dpi_list *dpilist = NULL;
-	_cleanup_(freep) struct dpi_range *dpirange = NULL;
+	struct dpi_list *dpilist = NULL;
+	struct dpi_range *dpirange = NULL;
 
 	unsigned int report_rates[] = { 125, 250, 500, 1000 };
 


### PR DESCRIPTION
`_cleanup_(freep)` would deallocate the pointer returned by `ratbag_device_data_steelseries_get_dpi_range(device->data)` which resulted in a wrong step value. The step count sent to the device was then wrongly calculated due to this erroneous step value.

What about `dpi_list`? This is still an issue there, right?