### PR TITLE
data: add other Bluetooth PID to MX Anywhere 2

### DIFF
--- a/data/devices/logitech-MX-Anywhere2.device
+++ b/data/devices/logitech-MX-Anywhere2.device
@@ -1,4 +1,4 @@
 [Device]
 Name=Logitech MX Anywhere 2
-DeviceMatch=usb:046d:404a;bluetooth:046d:b013
+DeviceMatch=usb:046d:404a;bluetooth:046d:b013;bluetooth:406d:b018
 Driver=hidpp20


### PR DESCRIPTION
My MX Anywhere 2 has a different PID from the one supplied in the default .device file. This adds the PID to the device file to ensure mice with this PID get detected too.

Fixes #721