### PR TITLE
hidpp10: fix segfault for the c531 (and possibly other 27MHz receivers)

### DIFF
--- a/src/hidpp10.c
+++ b/src/hidpp10.c
@@ -1161,7 +1161,7 @@ hidpp10_onboard_profiles_parse_macro(struct hidpp10_device *device,
 	hidpp_log_raw(&device->base, "*** macro starts at (0x%02x, 0x%04x) ***\n", page, offset);
 
 	rc = hidpp10_onboard_profiles_read_macro(device, page, offset, &macro);
-	if (rc < 0)
+	if (rc)
 		return rc;
 
 	count = rc;


### PR DESCRIPTION
hidpp10_read_memory will return the HID++ error if the request fails.
right now, the error code from hidpp10_read_memory is transparently
passed through hidpp10_onboard_profiles_read_macro. This is problematic
because hidpp10_onboard_profiles_parse_macro only aborts on rc < 0 and
HID++ error are > 0.

Signed-off-by: Filipe Laíns <lains@archlinux.org>

---

Is this the right approach. Do we want `hidpp10_onboard_profiles_read_macro` to keep `hidpp10_read_memory`'s error code? Or should I overwrite `rc` when we see that `hidpp10_read_memory` failed?