### PR TITLE
hidpp20: fix reading onboard profiles (8100)

### DIFF
--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -1558,7 +1558,7 @@ hidpp20_onboard_profiles_read_sector(struct hidpp20_device *device,
 			return rc;
 
 		/* msg.msg.parameters is guaranteed to have a size >= 16 */
-		memcpy(data + offset, buf.msg.parameters, min(count, 16));
+		memcpy(data + offset, buf.msg.parameters, 16);
 
 		/*
 		 * no need to check for count >= 0:


### PR DESCRIPTION
when we read the memory from the device we already align the offset so
that it matches the end of the sector. for ex, for a 255 sector size the
offset will be set to 255-16.
when we copy the memory (using memcpy) we just copy the bytes that will
finish filling the buffer, ignoring that the offset was aligned. we need
to copy the full 16 bytes, otherwise it will fail when sector_size does
not align with 16.

Signed-off-by: Filipe Laíns <lains@archlinux.org>