### PR TITLE
Correct Typo in additional PID

### DIFF
--- a/data/devices/logitech-MX-Anywhere2.device
+++ b/data/devices/logitech-MX-Anywhere2.device
@@ -1,4 +1,4 @@
 [Device]
 Name=Logitech MX Anywhere 2
-DeviceMatch=usb:046d:404a;bluetooth:046d:b013;bluetooth:406d:b018
+DeviceMatch=usb:046d:404a;bluetooth:046d:b013;bluetooth:046d:b018
 Driver=hidpp20


### PR DESCRIPTION
I made a typo in my previous PR; the Vendor ID should have been identical to the other ones. This corrects that error.