### PR TITLE
Use python3-embed as dependency on Python 3.8

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -573,8 +573,14 @@ swig_gen = generator(
                 '@INPUT@'],
 )
 
+# From python 3.8 we neeed python3-embed
+dep_python3 = dependency('python3-embed', required: false)
+if not dep_python3.found()
+	dep_python3 = dependency('python3')
+endif
+
 wrapper_deps = [
-    dependency('python3'),
+    dep_python3,
     dep_libratbag,
     dep_libshared,
 ]


### PR DESCRIPTION
Python 3.8 no longer links to libpython, resulting in undefined references to
Python API.

But it provides a python3-embed.pc now, so let's try using that first and only
fall back on the normal case if that fails.

See https://github.com/mesonbuild/meson/issues/5629