### PR TITLE
meson: bump project version to 0.9.906

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('libratbag', 'c',
-	version : '0.9.905',
+	version : '0.9.906',
 	license : 'MIT/Expat',
 	default_options : [ 'c_std=gnu99', 'warning_level=2' ],
 	meson_version : '>= 0.40.0')


### PR DESCRIPTION
Signed-off-by: Filipe Laíns <lains@archlinux.org>