### PR TITLE
meson.build: enable -Werror=format-security

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -31,6 +31,7 @@ cc = meson.get_compiler('c')
 cflags = ['-Wno-unused-parameter',
 	  '-fvisibility=hidden',
 	  '-Wmissing-prototypes',
+	  '-Werror=format-security',
 	  '-Wstrict-prototypes']
 add_project_arguments(cflags, language: 'c')
 


### PR DESCRIPTION
We don't want to accidentally ignore those.