### PR TITLE
libratbag-util: move data manipulation functions out of hidpp-generic

### DIFF
--- a/src/driver-steelseries.c
+++ b/src/driver-steelseries.c
@@ -701,7 +701,7 @@ construct_cycle_buffer(struct steelseries_led_cycle *cycle,
 	/* this seems to be the minimum allowed */
 	duration = max(buf[spec->point_count_idx] * 330, cycle->duration);
 
-	hidpp_set_unaligned_le_u16(&buf[spec->duration_idx], duration);
+	set_unaligned_le_u16(&buf[spec->duration_idx], duration);
 }
 
 static int

--- a/src/hidpp-generic.h
+++ b/src/hidpp-generic.h
@@ -32,6 +32,8 @@
 #include <stdarg.h>
 #include <stddef.h>
 
+#include "libratbag-util.h"
+
 #define HIDPP_RECEIVER_IDX			0xFF
 #define HIDPP_WIRED_DEVICE_IDX			0x00
 
@@ -164,61 +166,29 @@ hidpp_log_buffer(struct hidpp_device *dev,
 uint16_t hidpp_crc_ccitt(uint8_t *data, unsigned int length);
 
 static inline uint16_t
-hidpp_get_unaligned_be_u16(uint8_t *buf)
-{
-	return (buf[0] << 8) | buf[1];
-}
-
-static inline uint16_t
 hidpp_be_u16_to_cpu(uint16_t data)
 {
-	return hidpp_get_unaligned_be_u16((uint8_t *)&data);
-}
-
-static inline void
-hidpp_set_unaligned_be_u16(uint8_t *buf, uint16_t value)
-{
-	buf[0] = value >> 8;
-	buf[1] = value & 0xFF;
+	return get_unaligned_be_u16((uint8_t *)&data);
 }
 
 static inline uint16_t
 hidpp_cpu_to_be_u16(uint16_t data)
 {
 	uint16_t result;
-	hidpp_set_unaligned_be_u16((uint8_t *)&result, data);
+	set_unaligned_be_u16((uint8_t *)&result, data);
 	return result;
-}
-
-static inline uint16_t
-hidpp_get_unaligned_le_u16(uint8_t *buf)
-{
-	return (buf[1] << 8) | buf[0];
 }
 
 static inline uint16_t
 hidpp_le_u16_to_cpu(uint16_t data)
 {
-	return hidpp_get_unaligned_le_u16((uint8_t *)&data);
-}
-
-static inline void
-hidpp_set_unaligned_le_u16(uint8_t *buf, uint16_t value)
-{
-	buf[0] = value & 0xFF;
-	buf[1] = value >> 8;
+	return get_unaligned_le_u16((uint8_t *)&data);
 }
 
 static inline uint16_t
 hidpp_cpu_to_le_u16(uint16_t data)
 {
 	uint16_t result;
-	hidpp_set_unaligned_le_u16((uint8_t *)&result, data);
+	set_unaligned_le_u16((uint8_t *)&result, data);
 	return result;
-}
-
-static inline uint32_t
-hidpp_get_unaligned_be_u32(uint8_t *buf)
-{
-	return (buf[0] << 24) | (buf[1] << 16) | (buf[2] << 8) | buf[3];
 }

--- a/src/hidpp10.c
+++ b/src/hidpp10.c
@@ -700,7 +700,7 @@ hidpp10_write_profile_directory(struct hidpp10_device *dev)
 	}
 
 	crc = hidpp_crc_ccitt(bytes, HIDPP10_PAGE_SIZE - 2);
-	hidpp_set_unaligned_be_u16(&bytes[HIDPP10_PAGE_SIZE - 2], crc);
+	set_unaligned_be_u16(&bytes[HIDPP10_PAGE_SIZE - 2], crc);
 
 	res = hidpp10_send_hot_payload(dev,
 				       0x00, 0x0000, /* destination: RAM */
@@ -964,9 +964,9 @@ hidpp10_fill_dpi_modes_16(struct hidpp10_device *dev,
 		struct _hidpp10_dpi_mode_16 *dpi = &dpi_list[i];
 
 		be = (uint8_t*)&dpi->xres;
-		profile->dpi_modes[i].xres = hidpp10_get_dpi_value(dev, hidpp_get_unaligned_be_u16(be));
+		profile->dpi_modes[i].xres = hidpp10_get_dpi_value(dev, get_unaligned_be_u16(be));
 		be = (uint8_t*)&dpi->yres;
-		profile->dpi_modes[i].yres = hidpp10_get_dpi_value(dev, hidpp_get_unaligned_be_u16(be));
+		profile->dpi_modes[i].yres = hidpp10_get_dpi_value(dev, get_unaligned_be_u16(be));
 
 		profile->dpi_modes[i].led[0] = dpi->led1 == 0x2;
 		profile->dpi_modes[i].led[1] = dpi->led2 == 0x2;
@@ -988,9 +988,9 @@ hidpp10_write_dpi_modes_16(struct hidpp10_device *dev,
 		struct _hidpp10_dpi_mode_16 *dpi = &dpi_list[i];
 
 		be = (uint8_t*)&dpi->xres;
-		hidpp_set_unaligned_be_u16(be, hidpp10_get_dpi_mapping(dev, profile->dpi_modes[i].xres));
+		set_unaligned_be_u16(be, hidpp10_get_dpi_mapping(dev, profile->dpi_modes[i].xres));
 		be = (uint8_t*)&dpi->yres;
-		hidpp_set_unaligned_be_u16(be, hidpp10_get_dpi_mapping(dev, profile->dpi_modes[i].yres));
+		set_unaligned_be_u16(be, hidpp10_get_dpi_mapping(dev, profile->dpi_modes[i].yres));
 
 		dpi->led1 = profile->dpi_modes[i].led[0] ? 0x02 : 0x01;
 		dpi->led2 = profile->dpi_modes[i].led[1] ? 0x02 : 0x01;
@@ -1757,7 +1757,7 @@ hidpp10_set_profile(struct hidpp10_device *dev, uint8_t number, struct hidpp10_p
 	}
 
 	crc = hidpp_crc_ccitt(page_data, HIDPP10_PAGE_SIZE - 2);
-	hidpp_set_unaligned_be_u16(&page_data[HIDPP10_PAGE_SIZE - 2], crc);
+	set_unaligned_be_u16(&page_data[HIDPP10_PAGE_SIZE - 2], crc);
 
 	/*
 	 * writing the data in several steps to prevent shroedinger state
@@ -2094,15 +2094,15 @@ hidpp10_get_current_resolution(struct hidpp10_device *dev,
 		if (res)
 			return res;
 		/* resolution is in 50dpi multiples */
-		*xres = *yres = hidpp10_get_dpi_value(dev, hidpp_get_unaligned_le_u16(&resolution.data[4]));
+		*xres = *yres = hidpp10_get_dpi_value(dev, get_unaligned_le_u16(&resolution.data[4]));
 		break;
         default:
 		res = hidpp10_request_command(dev, &resolution_long);
 		if (res)
 			return res;
 		/* resolution is in 50dpi multiples */
-		*xres = hidpp10_get_dpi_value(dev, hidpp_get_unaligned_le_u16(&resolution_long.data[4]));
-		*yres = hidpp10_get_dpi_value(dev, hidpp_get_unaligned_le_u16(&resolution_long.data[6]));
+		*xres = hidpp10_get_dpi_value(dev, get_unaligned_le_u16(&resolution_long.data[4]));
+		*yres = hidpp10_get_dpi_value(dev, get_unaligned_le_u16(&resolution_long.data[6]));
         }
 
 	return 0;
@@ -2124,8 +2124,8 @@ hidpp10_set_current_resolution(struct hidpp10_device *dev,
 		res = hidpp10_request_command(dev, &resolution);
 		break;
         default:
-		hidpp_set_unaligned_le_u16(&resolution_long.data[4], hidpp10_get_dpi_mapping(dev, xres));
-		hidpp_set_unaligned_le_u16(&resolution_long.data[6], hidpp10_get_dpi_mapping(dev, yres));
+		set_unaligned_le_u16(&resolution_long.data[4], hidpp10_get_dpi_mapping(dev, xres));
+		set_unaligned_le_u16(&resolution_long.data[6], hidpp10_get_dpi_mapping(dev, yres));
 
 		res = hidpp10_request_command(dev, &resolution_long);
 		break;
@@ -2483,7 +2483,7 @@ hidpp10_read_page(struct hidpp10_device *dev, uint8_t page,
 	}
 
 	crc = hidpp_crc_ccitt(bytes, HIDPP10_PAGE_SIZE - 2);
-	read_crc = hidpp_get_unaligned_be_u16(&bytes[HIDPP10_PAGE_SIZE - 2]);
+	read_crc = get_unaligned_be_u16(&bytes[HIDPP10_PAGE_SIZE - 2]);
 
 	if (crc != read_crc)
 		return -EILSEQ; /* return illegal sequence */
@@ -2573,7 +2573,7 @@ hidpp10_get_pairing_information(struct hidpp10_device *dev,
 		return -1;
 
 	*report_interval = pairing_information.msg.string[2];
-	*wpid = hidpp_get_unaligned_be_u16(&pairing_information.msg.string[3]);
+	*wpid = get_unaligned_be_u16(&pairing_information.msg.string[3]);
 	*device_type = pairing_information.msg.string[7];
 
 	return 0;
@@ -2613,7 +2613,7 @@ hidpp10_get_extended_pairing_information(struct hidpp10_device *dev,
 	if (res)
 		return -1;
 
-	*serial = hidpp_get_unaligned_be_u32(&info.msg.string[1]);
+	*serial = get_unaligned_be_u32(&info.msg.string[1]);
 
 	return 0;
 }
@@ -2665,7 +2665,7 @@ hidpp10_get_firmare_information(struct hidpp10_device *dev,
 	res = hidpp10_request_command(dev, &build_information);
 	if (res)
 		return res;
-	build = hidpp_get_unaligned_be_u16(&build_information.msg.string[1]);
+	build = get_unaligned_be_u16(&build_information.msg.string[1]);
 
 	*major_out = maj;
 	*minor_out = min;

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -245,7 +245,7 @@ hidpp_root_get_feature(struct hidpp20_device *device,
 		.msg.address = CMD_ROOT_GET_FEATURE,
 	};
 
-	hidpp_set_unaligned_be_u16(&msg.msg.parameters[0], feature);
+	set_unaligned_be_u16(&msg.msg.parameters[0], feature);
 
 	rc = hidpp20_request_command(device, &msg);
 	if (rc)
@@ -333,7 +333,7 @@ hidpp20_feature_set_get_feature_id(struct hidpp20_device *device,
 	if (rc)
 		return rc;
 
-	*feature = hidpp_get_unaligned_be_u16(msg.msg.parameters);
+	*feature = get_unaligned_be_u16(msg.msg.parameters);
 	*type = msg.msg.parameters[2];
 
 	return 0;
@@ -720,10 +720,10 @@ int hidpp20_led_sw_control_set_led_state(struct hidpp20_device* device,
 		return -EINVAL;
 
 	msg.msg.parameters[0] = state->index;
-	hidpp_set_unaligned_be_u16(&msg.msg.parameters[1], state->mode);
-	hidpp_set_unaligned_be_u16(&msg.msg.parameters[3], state->blink.index);
-	hidpp_set_unaligned_be_u16(&msg.msg.parameters[5], state->blink.on_time);
-	hidpp_set_unaligned_be_u16(&msg.msg.parameters[7], state->blink.off_time);
+	set_unaligned_be_u16(&msg.msg.parameters[1], state->mode);
+	set_unaligned_be_u16(&msg.msg.parameters[3], state->blink.index);
+	set_unaligned_be_u16(&msg.msg.parameters[5], state->blink.on_time);
+	set_unaligned_be_u16(&msg.msg.parameters[7], state->blink.off_time);
 
 	rc = hidpp20_request_command(device, &msg);
 
@@ -777,8 +777,8 @@ hidpp20_kbd_reprogrammable_keys_get_info(struct hidpp20_device *device,
 	if (rc)
 		return rc;
 
-	control->control_id = hidpp_get_unaligned_be_u16(&msg.msg.parameters[0]);
-	control->task_id = hidpp_get_unaligned_be_u16(&msg.msg.parameters[2]);
+	control->control_id = get_unaligned_be_u16(&msg.msg.parameters[0]);
+	control->task_id = get_unaligned_be_u16(&msg.msg.parameters[2]);
 	control->flags = msg.msg.parameters[4];
 
 	return 0;
@@ -983,9 +983,9 @@ hidpp20_color_led_effect_get_zone_effect_info(struct hidpp20_device *device,
 	info->zone_index = msg.msg.parameters[0];
 	info->zone_effect_index = msg.msg.parameters[1];
 
-	info->effect_id = hidpp_get_unaligned_be_u16(&msg.msg.parameters[2]);
-	info->effect_caps = hidpp_get_unaligned_be_u16(&msg.msg.parameters[4]);
-	info->effect_period = hidpp_get_unaligned_be_u16(&msg.msg.parameters[6]);
+	info->effect_id = get_unaligned_be_u16(&msg.msg.parameters[2]);
+	info->effect_caps = get_unaligned_be_u16(&msg.msg.parameters[4]);
+	info->effect_period = get_unaligned_be_u16(&msg.msg.parameters[6]);
 
 	return 0;
 }
@@ -1035,8 +1035,8 @@ hidpp20_special_keys_buttons_get_info(struct hidpp20_device *device,
 	if (rc)
 		return rc;
 
-	control->control_id = hidpp_get_unaligned_be_u16(&msg.msg.parameters[0]);
-	control->task_id = hidpp_get_unaligned_be_u16(&msg.msg.parameters[2]);
+	control->control_id = get_unaligned_be_u16(&msg.msg.parameters[0]);
+	control->task_id = get_unaligned_be_u16(&msg.msg.parameters[2]);
 	control->flags = msg.msg.parameters[4];
 	control->position = msg.msg.parameters[5];
 	control->group = msg.msg.parameters[6];
@@ -1060,13 +1060,13 @@ hidpp20_special_keys_buttons_get_reporting(struct hidpp20_device *device,
 		.msg.address = CMD_SPECIAL_KEYS_BUTTONS_GET_REPORTING,
 	};
 
-	hidpp_set_unaligned_be_u16(&msg.msg.parameters[0], control->control_id);
+	set_unaligned_be_u16(&msg.msg.parameters[0], control->control_id);
 
 	rc = hidpp20_request_command(device, &msg);
 	if (rc)
 		return rc;
 
-	control->reporting.remapped = hidpp_get_unaligned_be_u16(&msg.msg.parameters[3]);
+	control->reporting.remapped = get_unaligned_be_u16(&msg.msg.parameters[3]);
 	control->reporting.raw_XY = !!(msg.msg.parameters[2] & 0x10);
 	control->reporting.persist = !!(msg.msg.parameters[2] & 0x04);
 	control->reporting.divert = !!(msg.msg.parameters[2] & 0x01);
@@ -1160,8 +1160,8 @@ hidpp20_special_key_mouse_set_control(struct hidpp20_device *device,
 		.msg.address = CMD_SPECIAL_KEYS_BUTTONS_SET_REPORTING,
 	};
 
-	hidpp_set_unaligned_be_u16(&msg.msg.parameters[0], control->control_id);
-	hidpp_set_unaligned_be_u16(&msg.msg.parameters[3], control->reporting.remapped);
+	set_unaligned_be_u16(&msg.msg.parameters[0], control->control_id);
+	set_unaligned_be_u16(&msg.msg.parameters[3], control->reporting.remapped);
 
 	feature_index = hidpp_root_get_feature_idx(device,
 						   HIDPP_PAGE_SPECIAL_KEYS_BUTTONS);
@@ -1212,7 +1212,7 @@ hidpp20_mousepointer_get_mousepointer_info(struct hidpp20_device *device,
 	if (rc)
 		return rc;
 
-	*resolution = hidpp_get_unaligned_be_u16(msg.msg.parameters);
+	*resolution = get_unaligned_be_u16(msg.msg.parameters);
 	*flags = msg.msg.parameters[2];
 
 	return 0;
@@ -1268,8 +1268,8 @@ hidpp20_adjustable_dpi_get_dpi_list(struct hidpp20_device *device,
 
 	sensor->index = msg.msg.parameters[0];
 	while (i < LONG_MESSAGE_LENGTH - 4U &&
-	       hidpp_get_unaligned_be_u16(&msg.msg.parameters[i]) != 0) {
-		uint16_t value = hidpp_get_unaligned_be_u16(&msg.msg.parameters[i]);
+	       get_unaligned_be_u16(&msg.msg.parameters[i]) != 0) {
+		uint16_t value = get_unaligned_be_u16(&msg.msg.parameters[i]);
 
 		if (value > 0xe000) {
 			sensor->dpi_steps = value - 0xe000;
@@ -1304,8 +1304,8 @@ hidpp20_adjustable_dpi_get_dpi(struct hidpp20_device *device,
 	if (rc)
 		return rc;
 
-	sensor->dpi = hidpp_get_unaligned_be_u16(&msg.msg.parameters[1]);
-	sensor->default_dpi = hidpp_get_unaligned_be_u16(&msg.msg.parameters[3]);
+	sensor->dpi = get_unaligned_be_u16(&msg.msg.parameters[1]);
+	sensor->default_dpi = get_unaligned_be_u16(&msg.msg.parameters[3]);
 
 	return 0;
 }
@@ -1379,7 +1379,7 @@ int hidpp20_adjustable_dpi_set_sensor_dpi(struct hidpp20_device *device,
 		.msg.parameters[0] = sensor->index,
 	};
 
-	hidpp_set_unaligned_be_u16(&msg.msg.parameters[1], dpi);
+	set_unaligned_be_u16(&msg.msg.parameters[1], dpi);
 
 	feature_index = hidpp_root_get_feature_idx(device,
 						   HIDPP_PAGE_ADJUSTABLE_DPI);
@@ -1392,7 +1392,7 @@ int hidpp20_adjustable_dpi_set_sensor_dpi(struct hidpp20_device *device,
 	if (rc)
 		return rc;
 
-	returned_parameters = hidpp_get_unaligned_be_u16(&msg.msg.parameters[1]);
+	returned_parameters = get_unaligned_be_u16(&msg.msg.parameters[1]);
 
 	/* version 0 of the protocol does not echo the parameters */
 	if (returned_parameters != dpi && returned_parameters)
@@ -1548,7 +1548,7 @@ hidpp20_onboard_profiles_read_sector(struct hidpp20_device *device,
 		return -ENOTSUP;
 
 	msg.msg.sub_id = feature_index;
-	hidpp_set_unaligned_be_u16(&msg.msg.parameters[0], sector);
+	set_unaligned_be_u16(&msg.msg.parameters[0], sector);
 
 	count = sector_size;
 
@@ -1559,7 +1559,7 @@ hidpp20_onboard_profiles_read_sector(struct hidpp20_device *device,
 		 * less than 16 bytes to read we need to read from sector_size - 16
 		 */
 		offset = (sector_size - offset < 16) ? sector_size - 16 : offset;
-		hidpp_set_unaligned_be_u16(&msg.msg.parameters[2], offset);
+		set_unaligned_be_u16(&msg.msg.parameters[2], offset);
 		buf = msg;
 		rc = hidpp20_request_command(device, &buf);
 		if (rc)
@@ -1587,7 +1587,7 @@ hidpp20_onboard_profiles_is_sector_valid(struct hidpp20_device *device,
 	uint16_t crc, read_crc;
 
 	crc = hidpp_crc_ccitt(data, sector_size - 2);
-	read_crc = hidpp_get_unaligned_be_u16(&data[sector_size - 2]);
+	read_crc = get_unaligned_be_u16(&data[sector_size - 2]);
 
 	if (crc != read_crc)
 		hidpp_log_debug(&device->base, "Invalid CRC (%04x != %04x)\n", read_crc, crc);
@@ -1610,9 +1610,9 @@ hidpp20_onboard_profiles_write_start(struct hidpp20_device *device,
 		.msg.address = CMD_ONBOARD_PROFILES_MEMORY_ADDR_WRITE,
 	};
 
-	hidpp_set_unaligned_be_u16(&msg.msg.parameters[0], sector);
-	hidpp_set_unaligned_be_u16(&msg.msg.parameters[2], sub_address);
-	hidpp_set_unaligned_be_u16(&msg.msg.parameters[4], count);
+	set_unaligned_be_u16(&msg.msg.parameters[0], sector);
+	set_unaligned_be_u16(&msg.msg.parameters[2], sub_address);
+	set_unaligned_be_u16(&msg.msg.parameters[4], count);
 
 	rc = hidpp20_request_command(device, &msg);
 	if (rc)
@@ -1680,7 +1680,7 @@ hidpp20_onboard_profiles_write_sector(struct hidpp20_device *device,
 
 	if (write_crc) {
 		crc = hidpp_crc_ccitt(data, sector_size - 2);
-		hidpp_set_unaligned_be_u16(&data[sector_size - 2], crc);
+		set_unaligned_be_u16(&data[sector_size - 2], crc);
 	}
 
 	rc = hidpp20_onboard_profiles_write_start(device,
@@ -2372,7 +2372,7 @@ hidpp20_onboard_profiles_parse_profile(struct hidpp20_device *device,
 	profile->switched_dpi = pdata->profile.switched_dpi;
 
 	for (i = 0; i < 5; i++) {
-		profile->dpi[i] = hidpp_get_unaligned_le_u16(&data[2 * i + 3]);
+		profile->dpi[i] = get_unaligned_le_u16(&data[2 * i + 3]);
 	}
 
 	for (i = 0; i < profiles_list->num_leds; i++)
@@ -2429,7 +2429,7 @@ hidpp20_onboard_profiles_initialize(struct hidpp20_device *device,
 		for (i = 0; i < profiles->num_profiles; i++) {
 			uint8_t *d = data + 4 * i;
 
-			addr = hidpp_get_unaligned_be_u16(d);
+			addr = get_unaligned_be_u16(d);
 
 			if(addr == HIDPP20_PROFILE_DIR_END)
 				break;

--- a/src/libratbag-util.h
+++ b/src/libratbag-util.h
@@ -328,3 +328,35 @@ err:
 	dpi_list_free(list);
 	return NULL;
 }
+
+static inline uint16_t
+get_unaligned_be_u16(uint8_t *buf)
+{
+	return (buf[0] << 8) | buf[1];
+}
+
+static inline void
+set_unaligned_be_u16(uint8_t *buf, uint16_t value)
+{
+	buf[0] = value >> 8;
+	buf[1] = value & 0xFF;
+}
+
+static inline uint16_t
+get_unaligned_le_u16(uint8_t *buf)
+{
+	return (buf[1] << 8) | buf[0];
+}
+
+static inline void
+set_unaligned_le_u16(uint8_t *buf, uint16_t value)
+{
+	buf[0] = value & 0xFF;
+	buf[1] = value >> 8;
+}
+
+static inline uint32_t
+get_unaligned_be_u32(uint8_t *buf)
+{
+	return (buf[0] << 24) | (buf[1] << 16) | (buf[2] << 8) | buf[3];
+}


### PR DESCRIPTION
Signed-off-by: Filipe Laíns <lains@archlinux.org>