### PR TITLE
Fix crasher during the ratbagctl test suite

### DIFF
--- a/ratbagd/ratbagd-device.c
+++ b/ratbagd/ratbagd-device.c
@@ -174,6 +174,7 @@ static void ratbagd_device_commit_pending(void *data)
 	r = ratbag_device_commit(device->lib_device);
 	if (r < 0)
 		ratbagd_device_resync(device, device->ctx->bus);
+	ratbagd_device_unref(device);
 }
 
 static int ratbagd_device_commit(sd_bus_message *m,
@@ -184,7 +185,7 @@ static int ratbagd_device_commit(sd_bus_message *m,
 
 	ratbagd_schedule_task(device->ctx,
 			      ratbagd_device_commit_pending,
-			      device);
+			      ratbagd_device_ref(device));
 
 	CHECK_CALL(sd_bus_reply_method_return(m, "u", 0));
 

--- a/ratbagd/ratbagd-test.c
+++ b/ratbagd/ratbagd-test.c
@@ -185,7 +185,7 @@ int ratbagd_reset_test_device(sd_bus_message *m,
 
 	if (ratbagd_test_device) {
 		ratbagd_device_unlink(ratbagd_test_device);
-		ratbagd_device_free(ratbagd_test_device);
+		ratbagd_device_unref(ratbagd_test_device);
 
 		(void) sd_bus_emit_properties_changed(ctx->bus,
 						      RATBAGD_OBJ_ROOT,

--- a/ratbagd/ratbagd-test.c
+++ b/ratbagd/ratbagd-test.c
@@ -178,10 +178,12 @@ int ratbagd_reset_test_device(sd_bus_message *m,
 			      void *userdata,
 			      sd_bus_error *error)
 {
+	static int count;
 	static struct ratbagd_device *ratbagd_test_device = NULL;
 	struct ratbagd *ctx = userdata;
 	struct ratbag_device *device;
 	int r;
+	char devicename[64];
 
 	if (ratbagd_test_device) {
 		ratbagd_device_unlink(ratbagd_test_device);
@@ -196,7 +198,8 @@ int ratbagd_reset_test_device(sd_bus_message *m,
 
 	device = ratbag_device_new_test_device(ctx->lib_ctx, &ratbagd_test_device_descr);
 
-	r = ratbagd_device_new(&ratbagd_test_device, ctx, "test_device", device);
+	snprintf(devicename, sizeof(devicename), "test_device_%d", count++);
+	r = ratbagd_device_new(&ratbagd_test_device, ctx, devicename, device);
 
 	/* the ratbagd_device takes its own reference, drop ours */
 	ratbag_device_unref(device);

--- a/ratbagd/ratbagd.c
+++ b/ratbagd/ratbagd.c
@@ -200,7 +200,7 @@ static void ratbagd_process_device(struct ratbagd *ctx,
 		/* device was removed, unlink it and destroy our context */
 		if (device) {
 			ratbagd_device_unlink(device);
-			ratbagd_device_free(device);
+			ratbagd_device_unref(device);
 
 			(void) sd_bus_emit_properties_changed(ctx->bus,
 							      RATBAGD_OBJ_ROOT,
@@ -283,7 +283,7 @@ static struct ratbagd *ratbagd_free(struct ratbagd *ctx)
 
 	RATBAGD_DEVICE_FOREACH_SAFE(device, tmp, ctx) {
 		ratbagd_device_unlink(device);
-		ratbagd_device_free(device);
+		ratbagd_device_unref(device);
 	}
 
 	ctx->bus = sd_bus_flush_close_unref(ctx->bus);

--- a/ratbagd/ratbagd.h
+++ b/ratbagd/ratbagd.h
@@ -170,7 +170,8 @@ int ratbagd_device_new(struct ratbagd_device **out,
 		       struct ratbagd *ctx,
 		       const char *sysname,
 		       struct ratbag_device *lib_device);
-struct ratbagd_device *ratbagd_device_free(struct ratbagd_device *device);
+struct ratbagd_device *ratbagd_device_ref(struct ratbagd_device *device);
+struct ratbagd_device *ratbagd_device_unref(struct ratbagd_device *device);
 const char *ratbagd_device_get_sysname(struct ratbagd_device *device);
 const char *ratbagd_device_get_path(struct ratbagd_device *device);
 unsigned int ratbagd_device_get_num_buttons(struct ratbagd_device *device);
@@ -181,7 +182,7 @@ bool ratbagd_device_linked(struct ratbagd_device *device);
 void ratbagd_device_link(struct ratbagd_device *device);
 void ratbagd_device_unlink(struct ratbagd_device *device);
 
-DEFINE_TRIVIAL_CLEANUP_FUNC(struct ratbagd_device *, ratbagd_device_free);
+DEFINE_TRIVIAL_CLEANUP_FUNC(struct ratbagd_device *, ratbagd_device_unref);
 
 struct ratbagd_device *ratbagd_device_lookup(struct ratbagd *ctx,
 					     const char *name);


### PR DESCRIPTION
Because we schedule the `commit` handling as idle callback, we may reset the test device before we ever get to run the callback. Add ref/unrefs to the ratbagd device handling to work around that.