### PR TITLE
meson.build: fix builds with --buildtype=plain

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -27,6 +27,7 @@ cc = meson.get_compiler('c')
 cflags = ['-Wno-unused-parameter',
 	  '-fvisibility=hidden',
 	  '-Wmissing-prototypes',
+	  '-Wformat', # required by format-security
 	  '-Werror=format-security',
 	  '-Wstrict-prototypes']
 add_project_arguments(cflags, language: 'c')


### PR DESCRIPTION
When building with --buildtype=plain, the build fails with the following
error:

    cc1: error: ‘-Wformat-security’ ignored without ‘-Wformat’ [-Werror=format-security]

-Werror=format-security was recently added in 43def1b3a5a by #745