### PR TITLE
Add the ability to load test devices via JSON

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -66,7 +66,7 @@ fedora_prep_cache: &fedora_prep_cache
   steps:
     - run:
         name: Initializing Fedora dnf cache
-        command: dnf install -y --downloadonly libsolv tree git gcc gcc-c++ meson check-devel libudev-devel libevdev-devel valgrind python3-gobject python3-evdev glib2-devel python3-lxml libunistring-devel dbus-daemon
+        command: dnf install -y --downloadonly libsolv tree git gcc gcc-c++ meson check-devel libudev-devel libevdev-devel valgrind python3-gobject python3-evdev glib2-devel python3-lxml libunistring-devel dbus-daemon json-glib-devel
     - persist_to_workspace:
         root: /var/cache/
         paths:
@@ -82,7 +82,7 @@ fedora_install: &fedora_install
     command: |
         echo keepcache=1 >> /etc/dnf/dnf.conf
         dnf upgrade -y libsolv
-        dnf install -y tree git gcc gcc-c++ meson check-devel libudev-devel libevdev-devel valgrind python3-gobject python3-evdev glib2-devel python3-lxml python3-devel swig libunistring-devel dbus-daemon
+        dnf install -y tree git gcc gcc-c++ meson check-devel libudev-devel libevdev-devel valgrind python3-gobject python3-evdev glib2-devel python3-lxml python3-devel swig libunistring-devel dbus-daemon json-glib-devel
         sed -i 's/systemd//' /etc/nsswitch.conf
 
 fedora_settings: &fedora_settings
@@ -110,7 +110,7 @@ ubuntu_settings: &ubuntu_settings
           apt-get remove -y libnss-systemd
           add-apt-repository universe
           apt-get update
-          apt-get install -y tree git gcc g++ pkg-config meson check libudev-dev libevdev-dev libsystemd-dev valgrind python3-gi python3-evdev libglib2.0-dev python3-lxml python3-dev swig systemd libunistring-dev
+          apt-get install -y tree git gcc g++ pkg-config meson check libudev-dev libevdev-dev libsystemd-dev valgrind python3-gi python3-evdev libglib2.0-dev python3-lxml python3-dev swig systemd libunistring-dev libjson-glib-dev
     - checkout
     - *start_dbus
     - *build_and_test

--- a/meson.build
+++ b/meson.build
@@ -65,6 +65,7 @@ pkgconfig = import('pkgconfig')
 dep_udev = dependency('libudev')
 dep_libevdev = dependency('libevdev')
 dep_glib = dependency('glib-2.0')
+dep_json_glib = dependency('json-glib-1.0')
 dep_lm = cc.find_library('m')
 dep_unistring = cc.find_library('unistring')
 
@@ -183,6 +184,7 @@ deps_libratbag = [
 	dep_udev,
 	dep_libevdev,
 	dep_glib,
+	dep_json_glib,
 	dep_libutil,
 	dep_libhidpp,
 ]
@@ -394,6 +396,8 @@ src_ratbagd = [
 	'ratbagd/ratbagd-profile.c',
 	'ratbagd/ratbagd-resolution.c',
 	'ratbagd/ratbagd-test.c',
+	'ratbagd/ratbagd-json.c',
+	'ratbagd/ratbagd-json.h',
 	'src/libratbag-util.h',
 	'src/libratbag-util.c',
 ]

--- a/ratbagd/ratbagd-json.c
+++ b/ratbagd/ratbagd-json.c
@@ -1,0 +1,562 @@
+/*
+ * Copyright © 2019 Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+/* JSON parser for ratbag test devices. The JSON format is not fixed and may
+   change at any time, but basically looks like this:
+
+   {
+     "profiles": [
+       {
+         "is_active": bool,
+         "is_default": bool,
+	 "is_disabled": bool,
+	 "rate": int,
+	 "report_rates": [ int, ...],
+	 "capabilities": [int, ...] # profile capabilities
+	 "resolutions": [
+	   {
+	     "xres": int,
+	     "yres": int,
+	     "dpi_min", int,
+	     "dpi_max", int,
+	     "is_active": bool,
+	     "is_default": bool,
+	     "capabilities": [int, ...] # resolution capabilities
+	   }
+	 ]
+	 "buttons": [
+		 "action_type": "<enum>" # none, button, key, special, macro, unknown
+		 "button": int, # if button
+		 "key": int, # if key
+		 "special": "<enum>", # if special, for values see see special_lookup()
+		 "macro": ["+B", "-B", "t400"] # if macro. uppercase only
+
+	 ]
+	 "leds": [ ]
+       },
+       {
+	 ... next profile ...
+       }
+     ]
+   }
+
+   ratbagd uses a minimum sane device (1 profile, 1 resolution, etc.) and any
+   JSON instructions get merged into that device. Which means you usually
+   only need to set those bits you care about being checked.
+ */
+
+#include "libratbag-util.h"
+#include "ratbagd-json.h"
+#include "ratbagd-test.h"
+#include <json-glib/json-glib.h>
+#include <libevdev/libevdev.h>
+
+/* Hack because we don't do proper data passing */
+static int num_resolutions;
+static int num_buttons;
+static int num_leds;
+
+static int parse_error = 0;
+
+#define parser_error(element_) { \
+	log_error("json: parser error: %s:%d: element '%s'\n", __func__, __LINE__, (element_)); \
+	parse_error = -EINVAL; \
+	goto out; \
+}
+
+static void parse_resolution_member(JsonObject *obj, const gchar *name,
+				    JsonNode *node, void *data)
+{
+	struct ratbag_test_resolution *resolution = data;
+
+	if (streq(name, "xres")) {
+		gboolean v = json_object_get_int_member(obj, name);
+
+		if (v < 0 || v > 20000)
+			parser_error("xres");
+
+		resolution->xres = v;
+		log_verbose("json:    xres: %d\n", v);
+	} else if (streq(name, "yres")) {
+		gboolean v = json_object_get_int_member(obj, name);
+
+		if (v < 0 || v > 20000)
+			parser_error("yres");
+
+		resolution->yres = v;
+		log_verbose("json:    yres: %d\n", v);
+	} else if (streq(name, "dpi_min")) {
+		gboolean v = json_object_get_int_member(obj, name);
+
+		if (v < 0 || v > 20000)
+			parser_error("dpi_min");
+
+		resolution->dpi_min = v;
+		log_verbose("json:    dpi_min: %d\n", v);
+	} else if (streq(name, "dpi_max")) {
+		gboolean v = json_object_get_int_member(obj, name);
+
+		if (v < 0 || v > 20000)
+			parser_error("dpi_min");
+
+		resolution->dpi_max = v;
+		log_verbose("json:    dpi_max: %d\n", v);
+	} else if (streq(name, "is_active")) {
+		gboolean v = json_object_get_boolean_member(obj, name);
+		resolution->active = v;
+		log_verbose("json:    is_active: %d\n", v);
+	} else if (streq(name, "is_default")) {
+		gboolean v = json_object_get_boolean_member(obj, name);
+		resolution->dflt = v;
+		log_verbose("json:    is_default: %d\n", v);
+	} else if (streq(name, "capabilities")) {
+		JsonArray *a = json_object_get_array_member(obj, name);
+
+		assert(json_array_get_length(a) < ARRAY_LENGTH(resolution->caps));
+		for (size_t s = 0; s < json_array_get_length(a); s++) {
+			int v = json_array_get_int_element(a, s);
+			if (v > RATBAG_RESOLUTION_CAP_SEPARATE_XY_RESOLUTION)
+				parser_error("capabilities");
+			resolution->caps[s] = v;
+		}
+
+		log_verbose("json:    caps: %d %d %d %d %d...\n",
+			    resolution->caps[0],
+			    resolution->caps[1],
+			    resolution->caps[2],
+			    resolution->caps[3],
+			    resolution->caps[4]);
+	} else {
+		log_error("json:    unknown resolution key '%s'\n", name);
+		parse_error = -EINVAL;
+	}
+out:
+	return;
+}
+
+static void parse_resolution(JsonNode *node,
+			     struct ratbag_test_resolution *resolution)
+{
+	JsonObject *obj = json_node_get_object(node);
+
+	json_object_foreach_member(obj, parse_resolution_member, resolution);
+}
+
+static void parse_led_member(JsonObject *obj, const gchar *name,
+			     JsonNode *node, void *data)
+{
+	struct ratbag_test_led *led = data;
+
+	if (streq(name, "type")) {
+		gboolean v = json_object_get_int_member(obj, name);
+
+		if (v < 0 || v > RATBAG_LED_TYPE_WHEEL)
+			parser_error("type");
+
+		led->type = v;
+		log_verbose("json:    type: %d\n", v);
+	} else if (streq(name, "mode")) {
+		gboolean v = json_object_get_int_member(obj, name);
+
+		if (v < 0 || v > RATBAG_LED_BREATHING)
+			parser_error("mode");
+
+		led->mode = v;
+		log_verbose("json:    mode: %d\n", v);
+	} else if (streq(name, "duration")) {
+		gboolean v = json_object_get_int_member(obj, name);
+
+		if (v < 0 || v > 10000)
+			parser_error("duration");
+
+		led->ms = v;
+		log_verbose("json:    duration: %d\n", v);
+	} else if (streq(name, "brightness")) {
+		gboolean v = json_object_get_int_member(obj, name);
+
+		if (v < 0 || v > 100)
+			parser_error("brightness");
+
+		led->brightness = v;
+		log_verbose("json:    brightness: %d\n", v);
+	} else if (streq(name, "color")) {
+		JsonArray *a = json_object_get_array_member(obj, name);
+
+		assert(json_array_get_length(a) == 3);
+		led->color.red   = json_array_get_int_element(a, 0);
+		led->color.green = json_array_get_int_element(a, 1);
+		led->color.blue  = json_array_get_int_element(a, 2);
+		log_verbose("json:    color: %02x%02x%02x\n",
+			    led->color.red,
+			    led->color.green,
+			    led->color.blue);
+	} else {
+		log_error("json:    unknown led key '%s'\n", name);
+		parse_error = -EINVAL;
+	}
+out:
+	return;
+}
+
+static void parse_led(JsonNode *node, struct ratbag_test_led *led)
+{
+	JsonObject *obj = json_node_get_object(node);
+
+	json_object_foreach_member(obj, parse_led_member, led);
+}
+
+static enum ratbag_button_action_special
+special_lookup(const char *string)
+{
+	const struct {
+		const char *key;
+		enum ratbag_button_action_special special;
+	} lut[] = {
+		{ "invalid", RATBAG_BUTTON_ACTION_SPECIAL_INVALID},
+		{ "unknown", RATBAG_BUTTON_ACTION_SPECIAL_UNKNOWN},
+		{ "doubleclick", RATBAG_BUTTON_ACTION_SPECIAL_DOUBLECLICK},
+		{ "wheel-left", RATBAG_BUTTON_ACTION_SPECIAL_WHEEL_LEFT},
+		{ "wheel-right", RATBAG_BUTTON_ACTION_SPECIAL_WHEEL_RIGHT},
+		{ "wheel-up", RATBAG_BUTTON_ACTION_SPECIAL_WHEEL_UP},
+		{ "wheel-down", RATBAG_BUTTON_ACTION_SPECIAL_WHEEL_DOWN},
+		{ "ratchet-mode-switch", RATBAG_BUTTON_ACTION_SPECIAL_RATCHET_MODE_SWITCH},
+		{ "resolution-cycle-up", RATBAG_BUTTON_ACTION_SPECIAL_RESOLUTION_CYCLE_UP},
+		{ "resolution-cycledown", RATBAG_BUTTON_ACTION_SPECIAL_RESOLUTION_CYCLE_DOWN},
+		{ "resolution-up", RATBAG_BUTTON_ACTION_SPECIAL_RESOLUTION_UP},
+		{ "resolution-down", RATBAG_BUTTON_ACTION_SPECIAL_RESOLUTION_DOWN},
+		{ "resolution-alternate", RATBAG_BUTTON_ACTION_SPECIAL_RESOLUTION_ALTERNATE},
+		{ "resolution-default", RATBAG_BUTTON_ACTION_SPECIAL_RESOLUTION_DEFAULT},
+		{ "profile-cycle-up", RATBAG_BUTTON_ACTION_SPECIAL_PROFILE_CYCLE_UP},
+		{ "profile-cycle-down", RATBAG_BUTTON_ACTION_SPECIAL_PROFILE_CYCLE_DOWN},
+		{ "profile-up", RATBAG_BUTTON_ACTION_SPECIAL_PROFILE_UP},
+		{ "profile-down", RATBAG_BUTTON_ACTION_SPECIAL_PROFILE_DOWN},
+		{ "second-mode", RATBAG_BUTTON_ACTION_SPECIAL_SECOND_MODE},
+		{ "battery-level", RATBAG_BUTTON_ACTION_SPECIAL_BATTERY_LEVEL},
+	};
+
+	for (size_t i = 0; i < ARRAY_LENGTH(lut); i++) {
+		if (streq(string, lut[i].key))
+			return lut[i].special;
+	}
+
+	parser_error("special");
+
+out:
+	return RATBAG_BUTTON_ACTION_SPECIAL_INVALID;
+}
+
+static enum ratbag_button_action_type
+action_type_lookup(const char *string)
+{
+	const struct {
+		const char *key;
+		enum ratbag_button_action_type type;
+	} lut[] = {
+		{ "none", RATBAG_BUTTON_ACTION_TYPE_NONE},
+		{ "button", RATBAG_BUTTON_ACTION_TYPE_BUTTON},
+		{ "special", RATBAG_BUTTON_ACTION_TYPE_SPECIAL},
+		{ "key", RATBAG_BUTTON_ACTION_TYPE_KEY},
+		{ "macro", RATBAG_BUTTON_ACTION_TYPE_MACRO},
+		{ "unknown", RATBAG_BUTTON_ACTION_TYPE_UNKNOWN},
+	};
+
+	for (size_t i = 0; i < ARRAY_LENGTH(lut); i++) {
+		if (streq(string, lut[i].key))
+			return lut[i].type;
+	}
+
+	parser_error("action_type");
+
+out:
+	return RATBAG_BUTTON_ACTION_TYPE_UNKNOWN;
+}
+
+static inline struct ratbag_test_macro_event
+parse_macro(const char *m)
+{
+	struct ratbag_test_macro_event event = {
+		.type = RATBAG_MACRO_EVENT_INVALID,
+		.value = 0,
+	};
+	char keyname[32];
+
+	if (strlen(m) < 2)
+		goto out;
+
+	switch(m[0]) {
+	case '+':
+		event.type = RATBAG_MACRO_EVENT_KEY_PRESSED;
+		snprintf(keyname, sizeof(keyname), "KEY_%s", m + 1);
+		event.value = libevdev_event_code_from_name(EV_KEY,
+							    keyname);
+		log_verbose("json:     macro: +%s\n", keyname);
+		break;
+	case '-':
+		event.type = RATBAG_MACRO_EVENT_KEY_RELEASED;
+		snprintf(keyname, sizeof(keyname), "KEY_%s", m + 1);
+		event.value = libevdev_event_code_from_name(EV_KEY,
+							    keyname);
+		log_verbose("json:     macro: -%s\n", keyname);
+		break;
+	case 't':
+		event.type = RATBAG_MACRO_EVENT_WAIT;
+		event.value = atoi(m+1);
+		log_verbose("json:     macro: t%d\n", event.value);
+		break;
+	default:
+		parser_error("macro");
+		break;
+	}
+
+out:
+	return event;
+}
+
+
+static void parse_button_member(JsonObject *obj, const gchar *name,
+				JsonNode *node, void *data)
+{
+	struct ratbag_test_button *button = data;
+
+	if (streq(name, "action_type")) {
+		const gchar* v = json_object_get_string_member(obj, name);
+		button->action_type = action_type_lookup(v);
+		log_verbose("json:    action_type: %s\n", v);
+	} else if (streq(name, "button")) {
+		gint v = json_object_get_int_member(obj, name);
+
+		if (v < 0 || v > 32)
+			parser_error("button");
+
+		button->button = v;
+		log_verbose("json:    button: %d\n", v);
+	} else if (streq(name, "key")) {
+		gint v = json_object_get_int_member(obj, name);
+
+		if (v < 0 || v > KEY_MAX)
+			parser_error("key");
+
+		button->key = v;
+		log_verbose("json:    key: %d\n", v);
+	} else if (streq(name, "special")) {
+		const gchar *v = json_object_get_string_member(obj, name);
+		button->special = special_lookup(v);
+		log_verbose("json:    special: %s\n", v);
+	} else if (streq(name, "macro")) {
+		JsonArray *a = json_object_get_array_member(obj, name);
+
+		assert(json_array_get_length(a) < ARRAY_LENGTH(button->macro));
+		for (size_t s = 0; s < json_array_get_length(a); s++) {
+			const gchar *v = json_array_get_string_element(a, s);
+			button->macro[s] = parse_macro(v);
+		}
+	} else {
+		log_error("json: unknown button key '%s'\n", name);
+		parse_error = -EINVAL;
+	}
+out:
+	return;
+}
+
+static void parse_button(JsonNode *node, struct ratbag_test_button *button)
+{
+	JsonObject *obj = json_node_get_object(node);
+
+	json_object_foreach_member(obj, parse_button_member, button);
+}
+
+static void parse_profile_member(JsonObject *obj, const gchar *name,
+				 JsonNode *node, void *data)
+{
+	struct ratbag_test_profile *profile = data;
+
+	if (streq(name, "name")) {
+		const char *v = json_object_get_string_member(obj, name);
+
+		if (v == NULL)
+			parser_error("name");
+
+		free(profile->name);
+		profile->name = strdup_safe(v);
+		log_verbose("name: %s\n", v);
+	} else if (streq(name, "is_default")) {
+		gboolean v = json_object_get_boolean_member(obj, name);
+		profile->dflt = v;
+		log_verbose("json:  is_default: %d\n", v);
+	} else if (streq(name, "is_active")) {
+		gboolean v = json_object_get_boolean_member(obj, name);
+		profile->active = v;
+		log_verbose("json:  is_active: %d\n", v);
+	} else if (streq(name, "is_disabled")) {
+		gboolean v = json_object_get_boolean_member(obj, name);
+		profile->disabled = v;
+		log_verbose("json:  is_disabled: %d\n", v);
+	} else if (streq(name, "rate")) {
+		gboolean v = json_object_get_int_member(obj, name);
+
+		if (v < 0 || v > 20000)
+			parser_error("rate");
+
+		profile->hz = v;
+		log_verbose("json:  rate: %d\n", v);
+	} else if (streq(name, "report_rates")) {
+		JsonArray *a = json_object_get_array_member(obj, name);
+		assert(json_array_get_length(a) < ARRAY_LENGTH(profile->report_rates));
+		for (size_t s = 0; s < json_array_get_length(a); s++) {
+			int v = json_array_get_int_element(a, s);
+			if (v < 0 || v > 20000)
+				parser_error("report_rate");
+			profile->report_rates[s] = v;
+		}
+
+		log_verbose("json:  report rates: %d %d %d %d %d\n",
+			    profile->report_rates[0],
+			    profile->report_rates[1],
+			    profile->report_rates[2],
+			    profile->report_rates[3],
+			    profile->report_rates[4]);
+	} else if (streq(name, "capabilities")) {
+		JsonArray *a = json_object_get_array_member(obj, name);
+
+		assert(json_array_get_length(a) < ARRAY_LENGTH(profile->caps));
+		for (size_t s = 0; s < json_array_get_length(a); s++) {
+			int v = json_array_get_int_element(a, s);
+			profile->caps[s] = v;
+		}
+
+		log_verbose("json:  caps: %d %d %d %d %d...\n",
+			    profile->caps[0],
+			    profile->caps[1],
+			    profile->caps[2],
+			    profile->caps[3],
+			    profile->caps[4]);
+	} else if (streq(name, "resolutions")) {
+		JsonArray *a = json_object_get_array_member(obj, name);
+		GList *list = json_array_get_elements(a);
+		GList *l = list;
+		int idx = 0;
+		while (l != NULL) {
+			log_verbose("json:  processing resolution %d\n", idx);
+			parse_resolution(l->data, &profile->resolutions[idx]);
+			l = g_list_next(l);
+			idx++;
+		}
+		g_list_free(list);
+		num_resolutions = max(idx, num_resolutions);
+	} else if (streq(name, "leds")) {
+		JsonArray *a = json_object_get_array_member(obj, name);
+		GList *list = json_array_get_elements(a);
+		GList *l = list;
+		int idx = 0;
+		while (l != NULL) {
+			log_verbose("json:  processing LED %d\n", idx);
+			parse_led(l->data, &profile->leds[idx]);
+			l = g_list_next(l);
+			idx++;
+		}
+		g_list_free(list);
+		num_leds = max(idx, num_leds);
+	} else if (streq(name, "buttons")) {
+		JsonArray *a = json_object_get_array_member(obj, name);
+		GList *list = json_array_get_elements(a);
+		GList *l = list;
+		int idx = 0;
+		while (l != NULL) {
+			log_verbose("json:  processing button %d\n", idx);
+			parse_button(l->data, &profile->buttons[idx]);
+			l = g_list_next(l);
+			idx++;
+		}
+		g_list_free(list);
+		num_buttons = max(idx, num_buttons);
+	} else {
+		log_error("json: unknown profile key '%s'\n", name);
+		parse_error = -EINVAL;
+	}
+out:
+	return;
+}
+
+static void parse_profile(JsonNode *node,
+			 struct ratbag_test_profile *profile)
+{
+	JsonObject *obj = json_node_get_object(node);
+
+	json_object_foreach_member(obj, parse_profile_member, profile);
+}
+
+/* declared here because this isn't really public API, we just need to
+ * access it from the tests */
+int ratbagd_parse_json(const char *data, struct ratbag_test_device *device)
+{
+	g_autoptr(JsonParser) parser = NULL;
+	JsonNode *root;
+	JsonObject *obj;
+	JsonArray *arr;
+	int r = -EINVAL;
+	g_autoptr(GError) error = NULL;
+
+	error = 0;
+	parser = json_parser_new();
+	if (!json_parser_load_from_data(parser, data, strlen(data), &error)) {
+		log_error("Failed to load JSON: %s\n", error->message);
+		r = -EINVAL;
+		goto out;
+	}
+
+	log_verbose("json: data: %s\n", data);
+
+	root = json_parser_get_root(parser);
+	if (JSON_NODE_TYPE(root) != JSON_NODE_OBJECT)
+		parser_error("root");
+
+	obj = json_node_get_object(root);
+	arr = json_object_get_array_member(obj, "profiles");
+	if (!arr)
+		parser_error("profiles");
+
+	/* Our test device is preloaded with sane defaults, let's keep those */
+	num_resolutions = device->num_resolutions;
+	num_buttons = device->num_buttons;
+	num_leds = device->num_leds;
+
+	g_autoptr(GList) list = json_array_get_elements(arr);
+	GList *l = list;
+	int idx = 0;
+	while (l != NULL) {
+		log_verbose("json: processing profile %d\n", idx);
+		parse_profile(l->data, &device->profiles[idx]);
+		if (parse_error != 0)
+			goto out;;
+		l = g_list_next(l);
+		idx++;
+	}
+	device->num_profiles = idx;
+	device->num_resolutions = num_resolutions;
+	device->num_buttons = num_buttons;
+	device->num_leds = num_leds;
+
+	r = 0;
+out:
+	return r;
+}

--- a/ratbagd/ratbagd-json.h
+++ b/ratbagd/ratbagd-json.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Red Hat, Inc.
+ * Copyright © 2019 Red Hat, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,15 +24,5 @@
 #pragma once
 
 #include "libratbag-test.h"
-#include "ratbagd.h"
 
-void ratbagd_init_test_device(struct ratbagd *ctx);
-
-#ifdef RATBAG_DEVELOPER_EDITION
-int ratbagd_reset_test_device(sd_bus_message *m,
-			      void *userdata,
-			      sd_bus_error *error);
-int ratbagd_load_test_device(sd_bus_message *m,
-			     void *userdata,
-			     sd_bus_error *error);
-#endif /* RATBAG_DEVELOPER_EDITION */
+int ratbagd_parse_json(const char *data, struct ratbag_test_device *device);

--- a/ratbagd/ratbagd-test.c
+++ b/ratbagd/ratbagd-test.c
@@ -32,148 +32,6 @@
 #include "libratbag-test.h"
 #include "ratbagd-json.h"
 
-/* A pre-setup sane device. Use for sanity testing by toggling the various
- * error conditions.
- */
-static const struct ratbag_test_device ratbagd_test_device_descr = {
-	.num_profiles = 4,
-	.num_resolutions = 3,
-	.num_buttons = 4,
-	.num_leds = 3,
-	.profiles = {
-		{
-			.name = NULL,
-			.buttons = {
-				{ .button_type = RATBAG_BUTTON_TYPE_LEFT,
-				  .action_type = RATBAG_BUTTON_ACTION_TYPE_BUTTON,
-				  .button = 0 },
-				{ .button_type = RATBAG_BUTTON_TYPE_MIDDLE,
-				  .action_type = RATBAG_BUTTON_ACTION_TYPE_KEY,
-				  .key = KEY_3 },
-				{ .button_type = RATBAG_BUTTON_TYPE_RIGHT,
-				  .action_type = RATBAG_BUTTON_ACTION_TYPE_SPECIAL,
-				  .special = RATBAG_BUTTON_ACTION_SPECIAL_PROFILE_CYCLE_UP },
-				{ .action_type = RATBAG_BUTTON_ACTION_TYPE_MACRO,
-				  .macro = {
-					  { .type = RATBAG_MACRO_EVENT_KEY_PRESSED,
-					    .value = KEY_B },
-					  { .type = RATBAG_MACRO_EVENT_KEY_RELEASED,
-					    .value = KEY_B },
-					  { .type = RATBAG_MACRO_EVENT_WAIT,
-					    .value = 300 },
-				  },
-				}
-			},
-			.resolutions = {
-				{ .xres = 100, .yres = 200,
-					.dpi_min = 50, .dpi_max = 5000},
-				{ .xres = 200, .yres = 300, .active = true, .dflt = true },
-				{ .xres = 300, .yres = 400 },
-			},
-			.active = true,
-			.dflt = false,
-			.hz = 1000,
-			.report_rates = {500, 1000},
-
-			.leds = {
-				{
-					.mode = RATBAG_LED_OFF,
-					.color = { .red = 255, .green = 0, .blue = 0 },
-					.ms = 1000,
-					.brightness = 20,
-					.type = RATBAG_LED_TYPE_LOGO,
-				},
-				{
-					.mode = RATBAG_LED_ON,
-					.color = { .red = 255, .green = 0, .blue = 0 },
-					.ms = 1000,
-					.brightness = 20,
-					.type = RATBAG_LED_TYPE_SIDE,
-				},
-				{
-					.mode = RATBAG_LED_CYCLE,
-					.color = { .red = 255, .green = 255, .blue = 0 },
-					.ms = 333,
-					.brightness = 40,
-					.type = RATBAG_LED_TYPE_SIDE,
-				}
-			},
-		},
-		{
-			.buttons = {
-				{ .action_type = RATBAG_BUTTON_ACTION_TYPE_KEY,
-				  .key = 4 },
-				{ .action_type = RATBAG_BUTTON_ACTION_TYPE_KEY,
-				  .key = 5 },
-				{ .action_type = RATBAG_BUTTON_ACTION_TYPE_KEY,
-				  .key = 6 },
-				{ .action_type = RATBAG_BUTTON_ACTION_TYPE_KEY,
-				  .key = 7 },
-			},
-			.resolutions = {
-				{ .xres = 1100, .yres = 1200,
-				  .caps = {RATBAG_RESOLUTION_CAP_SEPARATE_XY_RESOLUTION} },
-				{ .xres = 1200, .yres = 1300, .dflt = true,
-				  .caps = {RATBAG_RESOLUTION_CAP_SEPARATE_XY_RESOLUTION} },
-				{ .xres = 1300, .yres = 1400, .active = true,
-				  .caps = {RATBAG_RESOLUTION_CAP_SEPARATE_XY_RESOLUTION} },
-			},
-			.hz = 2000,
-			.active = false,
-			.dflt = true,
-			.name = "test profile 2",
-		},
-		{
-			.buttons = {
-				{ .button_type = RATBAG_BUTTON_TYPE_LEFT,
-				  .action_type = RATBAG_BUTTON_ACTION_TYPE_SPECIAL,
-				  .special = RATBAG_BUTTON_ACTION_SPECIAL_PROFILE_CYCLE_UP },
-				{ .action_type = RATBAG_BUTTON_ACTION_TYPE_MACRO,
-				  .macro = {
-					  { .type = RATBAG_MACRO_EVENT_KEY_PRESSED,
-					    .value = KEY_A },
-					  { .type = RATBAG_MACRO_EVENT_KEY_RELEASED,
-					    .value = KEY_A },
-					  { .type = RATBAG_MACRO_EVENT_WAIT,
-					    .value = 150 },
-				  }
-				},
-				{ .action_type = RATBAG_BUTTON_ACTION_TYPE_BUTTON,
-				  .button = 2 },
-				{ .action_type = RATBAG_BUTTON_ACTION_TYPE_BUTTON,
-				  .button = 3 },
-			},
-			.resolutions = {
-				{ .xres = 2100, .yres = 2200, .active = true, .caps = {RATBAG_RESOLUTION_CAP_SEPARATE_XY_RESOLUTION} },
-				{ .xres = 2200, .yres = 2300, .dflt = true, .caps = {RATBAG_RESOLUTION_CAP_SEPARATE_XY_RESOLUTION} },
-				{ .xres = 2300, .yres = 2400, .caps = {RATBAG_RESOLUTION_CAP_SEPARATE_XY_RESOLUTION} },
-			},
-			.hz = 3000,
-			.leds = {
-				{
-					.mode = RATBAG_LED_ON,
-					.color = { .red = 255, .green = 0, .blue = 0 },
-					.ms = 1000,
-					.brightness = 20
-				},
-				{
-					.mode = RATBAG_LED_CYCLE,
-					.color = { .red = 255, .green = 255, .blue = 0 },
-					.ms = 333,
-					.brightness = 40
-				}
-			},
-			.active = false,
-			.dflt = false,
-		},
-		{
-			.disabled = true,
-		},
-	},
-	.destroyed = NULL,
-	.destroyed_data = NULL,
-};
-
 static int load_test_device(sd_bus_message *m,
 			    struct ratbagd *ctx,
 			    const struct ratbag_test_device *source)
@@ -219,15 +77,6 @@ static int load_test_device(sd_bus_message *m,
 	}
 
 	return 0;
-}
-
-int ratbagd_reset_test_device(sd_bus_message *m,
-			      void *userdata,
-			      sd_bus_error *error)
-{
-	struct ratbagd *ctx = userdata;
-
-	return load_test_device(m, ctx, &ratbagd_test_device_descr);
 }
 
 static const struct ratbag_test_device default_device_descr = {
@@ -286,7 +135,7 @@ void ratbagd_init_test_device(struct ratbagd *ctx)
 #ifdef RATBAG_DEVELOPER_EDITION
 	setenv("RATBAG_TEST", "1", 0);
 
-	ratbagd_reset_test_device(NULL, ctx, NULL);
+	load_test_device(NULL, ctx, &default_device_descr);
 #endif
 }
 

--- a/ratbagd/ratbagd.c
+++ b/ratbagd/ratbagd.c
@@ -169,6 +169,7 @@ static const sd_bus_vtable ratbagd_vtable[] = {
 	SD_BUS_PROPERTY("Devices", "ao", ratbagd_get_devices, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 #ifdef RATBAG_DEVELOPER_EDITION
 	SD_BUS_METHOD("ResetTestDevice", "", "u", ratbagd_reset_test_device, SD_BUS_VTABLE_UNPRIVILEGED),
+	SD_BUS_METHOD("LoadTestDevice", "s", "i", ratbagd_load_test_device, SD_BUS_VTABLE_UNPRIVILEGED),
 #endif /* RATBAG_DEVELOPER_EDITION */
 	SD_BUS_VTABLE_END,
 };

--- a/ratbagd/ratbagd.c
+++ b/ratbagd/ratbagd.c
@@ -168,7 +168,6 @@ static const sd_bus_vtable ratbagd_vtable[] = {
 	SD_BUS_VTABLE_START(0),
 	SD_BUS_PROPERTY("Devices", "ao", ratbagd_get_devices, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 #ifdef RATBAG_DEVELOPER_EDITION
-	SD_BUS_METHOD("ResetTestDevice", "", "u", ratbagd_reset_test_device, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("LoadTestDevice", "s", "i", ratbagd_load_test_device, SD_BUS_VTABLE_UNPRIVILEGED),
 #endif /* RATBAG_DEVELOPER_EDITION */
 	SD_BUS_VTABLE_END,

--- a/src/libratbag-test.h
+++ b/src/libratbag-test.h
@@ -73,7 +73,7 @@ struct ratbag_test_led {
 };
 
 struct ratbag_test_profile {
-	const char *name;
+	char *name;
 	struct ratbag_test_button buttons[RATBAG_TEST_MAX_BUTTONS];
 	struct ratbag_test_resolution resolutions[RATBAG_TEST_MAX_RESOLUTIONS];
 	struct ratbag_test_led leds[RATBAG_TEST_MAX_LEDS];

--- a/tools/ratbagctl.test.in
+++ b/tools/ratbagctl.test.in
@@ -464,10 +464,25 @@ class TestRatbagCtlDPI(TestRatbagCtl):
 
 
 class TestRatbagCtlReportRate(TestRatbagCtl):
+    json = '''
+    {
+      "profiles": [
+        { "is_active": true,
+          "rate":  1000,
+          "report_rates": [500, 1000]
+        },
+        { "is_active": false,
+          "rate":  2000
+        },
+        { "is_active": false,
+          "rate":  3000
+        }
+      ]
+    }
+    '''
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.setProfile(0)
 
     def test_rate_get(self):
         command = "rate get"

--- a/tools/ratbagctl.test.in
+++ b/tools/ratbagctl.test.in
@@ -526,10 +526,38 @@ class TestRatbagCtlReportRate(TestRatbagCtl):
 
 
 class TestRatbagCtlButton(TestRatbagCtl):
+    json = '''
+    {
+      "profiles": [
+        { "is_active": true,
+          "buttons": [
+              { "button": 0 },
+              { "action_type": "none" },
+              { "action_type": "special",
+                "special": "profile-cycle-up" },
+              { "action_type": "macro",
+                "macro": [ "+B", "-B", "t300" ] }
+          ]
+        },
+        { "is_active": false
+        },
+        { "is_active": false,
+          "buttons": [
+              { "action_type": "special",
+                "special": "profile-cycle-up" },
+              { "action_type": "special" },
+              { "button": 2,
+                "action_type": "button" },
+              { "button": 3,
+                "action_type": "button" }
+          ]
+        }
+      ]
+    }
+    '''
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.setProfile(0)
 
     def test_button_count(self):
         command = "button count"

--- a/tools/ratbagctl.test.in
+++ b/tools/ratbagctl.test.in
@@ -38,10 +38,22 @@ run_ratbagctl_in_subprocess = False
 
 
 class TestRatbagCtl(unittest.TestCase):
+    json = None
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.reset_test_device()
+
+        # it's a lot easier to debug a validataion failure here than
+        # with ratbagd failing
+        if cls.json is not None:
+            import json
+            json.loads(cls.json)
+
+        if cls.json is None:
+            cls.reset_test_device()
+        else:
+            cls.load_test_device(cls.json)
         cls.find_test_device()
 
     @classmethod
@@ -93,6 +105,13 @@ class TestRatbagCtl(unittest.TestCase):
     def reset_test_device(cls):
         global ratbagd
         ratbagd._dbus_call("ResetTestDevice", "")
+        toolbox.sync_dbus()
+
+    @classmethod
+    def load_test_device(cls, json):
+        global ratbagd
+        rc = ratbagd._dbus_call("LoadTestDevice", "s", json)
+        assert(rc == 0)
         toolbox.sync_dbus()
 
     @classmethod
@@ -153,24 +172,42 @@ class TestRatbagCtlName(TestRatbagCtl):
 
 
 class TestRatbagCtlProfile(TestRatbagCtl):
+    json = '''
+    {
+      "profiles": [
+        {
+          "is_active": false
+        },
+        {
+          "name": "test profile x2",
+          "is_active": false
+        },
+        {
+          "is_active": true
+        },
+        {
+          "is_active": false,
+          "is_disabled": true
+        }
+      ]
+    }
+    '''
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.setProfile(0)
-        cls.setProfile(1)
-        cls.setProfile(0)
 
     def test_profile_name_get(self):
         command = "profile 1 name get"
         r = self.launch_good_test("test_device " + command)
-        self.assertEqual(r, 'test profile 2')
+        self.assertEqual(r, 'test profile x2')
         self.launch_fail_test(command)
         self.launch_fail_test("test_device " + command + " X")
         self.launch_fail_test("test_device profile name get")
 
     def test_profile_name_set(self):
         r = self.launch_good_test("test_device profile 1 name get")
-        self.assertEqual(r, 'test profile 2')
+        self.assertEqual(r, 'test profile x2')
         self.launch_good_test("test_device profile 1 name set banana")
         r = self.launch_good_test("test_device profile 1 name get")
         self.assertEqual(r, 'banana')
@@ -186,7 +223,7 @@ class TestRatbagCtlProfile(TestRatbagCtl):
     def test_profile_active_get(self):
         command = "profile active get"
         r = self.launch_good_test("test_device " + command)
-        self.assertEqual(int(r), 0)
+        self.assertEqual(int(r), 2)
         self.launch_fail_test(command)
         self.launch_fail_test("test_device " + command + " X")
 

--- a/tools/ratbagctl.test.in
+++ b/tools/ratbagctl.test.in
@@ -612,10 +612,57 @@ class TestRatbagCtlButton(TestRatbagCtl):
 
 
 class TestRatbagCtlLED(TestRatbagCtl):
+    json = '''
+    {
+      "profiles": [
+        { "is_active": true,
+          "leds": [
+            { "type": 1,
+              "mode": 0,
+              "duration": 1000,
+              "brightness": 20 },
+            { "type": 1,
+              "mode": 1,
+              "duration": 333,
+              "brightness": 40,
+              "color": [255, 0, 0] },
+            { "type": 1,
+              "mode": 2,
+              "duration": 333,
+              "brightness": 40 }
+          ]
+        },
+        {
+          "leds": [
+            { "type": 1,
+              "mode": 1 },
+            { "type": 1,
+              "mode": 0 },
+            { "type": 1,
+              "mode": 1 }
+          ]
+        },
+        {
+          "leds": [
+            { "type": 1,
+              "mode": 1,
+              "color": [255, 0, 0],
+              "duration": 1000 },
+            { "type": 1,
+              "mode": 2,
+              "brightness": 40,
+              "duration": 333 },
+            { "type": 1,
+              "mode": 1 }
+          ]
+        }
+      ]
+    }
+    '''
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.setProfile(0)
 
     def test_led_n_get(self):
         self.setProfile(0)

--- a/tools/ratbagctl.test.in
+++ b/tools/ratbagctl.test.in
@@ -272,10 +272,41 @@ class TestRatbagCtlProfile(TestRatbagCtl):
 
 
 class TestRatbagCtlResolution(TestRatbagCtl):
+    json = '''
+    {
+      "profiles": [
+        {
+          "is_active": false
+        },
+        {
+          "is_active": false
+        },
+        {
+          "is_active": true,
+          "resolutions": [
+            { "is_active": false,
+              "is_default": true },
+            { "xres": 1200, "yres": 1300,
+              "capabilities": [1],
+              "is_default": false,
+              "is_active": false },
+            { "xres": 2300, "yres": 2400,
+              "capabilities": [1],
+              "is_active": true,
+              "is_default": false }
+          ]
+        },
+        {
+          "is_active": false,
+          "is_disabled": true
+        }
+      ]
+    }
+    '''
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.setProfile(1)
 
     def test_resolution_active_get(self):
         command = "resolution active get"
@@ -304,13 +335,13 @@ class TestRatbagCtlResolution(TestRatbagCtl):
         self.launch_fail_test("resolution 1 get X")
 
     def test_profile_resolution(self):
-        r = self.launch_good_test("test_device profile 2 resolution 2 get")
-        self.assertEqual(r, "2: 2300x2400dpi")
+        r = self.launch_good_test("test_device profile 2 resolution 1 get")
+        self.assertEqual(r, "1: 1200x1300dpi")
 
     def test_resolution_default_get(self):
         command = "resolution default get"
         r = self.launch_good_test("test_device " + command)
-        self.assertEqual(int(r), 1)
+        self.assertEqual(int(r), 0)
         self.launch_fail_test("test_device " + command + " X")
         self.launch_fail_test("test_device " + command + " 10")
 

--- a/tools/ratbagctl.test.in
+++ b/tools/ratbagctl.test.in
@@ -358,10 +358,46 @@ class TestRatbagCtlResolution(TestRatbagCtl):
 
 
 class TestRatbagCtlDPI(TestRatbagCtl):
+    json = '''
+    {
+      "profiles": [
+        { "is_active": true,
+          "resolutions": [
+            { "xres": 200,
+              "is_active": true,
+              "dpi_min": 50,
+              "dpi_max": 5000 },
+            { "xres": 250,
+              "is_active": false },
+            { "xres": 300,
+              "is_active": false }
+          ]
+        },
+        { "is_active": false,
+          "resolutions": [
+            { "xres": 1000, "yres": 1100,
+              "is_active": false },
+            { "xres": 1300, "yres": 1400,
+              "capabilities": [1],
+              "is_active": true }
+          ]
+        },
+        { "is_active": false,
+          "resolutions": [
+            { "xres": 2100, "yres": 2200,
+              "capabilities": [1],
+              "is_active": true},
+            { "xres": 2200, "yres": 2300,
+              "capabilities": [1],
+              "is_active": false }
+          ]
+        }
+      ]
+    }
+    '''
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.setProfile(0)
 
     def test_dpi_get(self):
         command = "dpi get"
@@ -419,8 +455,8 @@ class TestRatbagCtlDPI(TestRatbagCtl):
         self.setProfile(0)
         r = self.launch_good_test("test_device profile 1 dpi get")
         self.assertEqual(r, "1300x1400dpi")
-        r = self.launch_good_test("test_device profile 1 resolution 1 dpi get")
-        self.assertEqual(r, "1200x1300dpi")
+        r = self.launch_good_test("test_device profile 2 resolution 1 dpi get")
+        self.assertEqual(r, "2200x2300dpi")
         r = self.launch_good_test("test_device resolution 2 dpi get")
         self.assertEqual(int(r[:-3]), 300)  # drop 'dpi' suffix
         self.launch_fail_test("test_device profile 1 profile 1 dpi get")

--- a/tools/ratbagctl.test.in
+++ b/tools/ratbagctl.test.in
@@ -50,9 +50,7 @@ class TestRatbagCtl(unittest.TestCase):
             import json
             json.loads(cls.json)
 
-        if cls.json is None:
-            cls.reset_test_device()
-        else:
+        if cls.json is not None:
             cls.load_test_device(cls.json)
         cls.find_test_device()
 


### PR DESCRIPTION
Right now, we have a hardcoded test device with "magic" values that the tests just have to know. This makes it hard to expand the tests, because it's not obvious which value can be changed without breaking tests or making things worse.

This PR replaces that test device with a new DBus call to load a test device based on a JSON file. That 

most basic one (1 profile, 1 resolution, etc.) and adds a new devel DBus API to load a JSON file with the data to merge into the test device. This makes the test more flexible and more obvious too - it's clear why we can test for say dpi 1300.

I'm planning to squash the test changes into one commit but for easier reviewing it's separated out.

The JSON parsing doesn't have a lot of error checking and is a bit hacky, but since this is a developer-only testing interface anyway crashing or asserting isn't the worst of all things.