### PR TITLE
Add a APIVersion field to ratbagd

### DIFF
--- a/doc/dbus.rst
+++ b/doc/dbus.rst
@@ -80,6 +80,19 @@ org.freedesktop.ratbag1.Manager
 The **org.freedesktop.ratbag1.Manager** interface is the entry point to
 interact with ratbagd.
 
+.. attribute:: APIVersion
+
+        :type: i
+        :flags: read-only,constant
+
+	The DBus API version. This is a stopgap feature while the DBus API
+	is still in flux. The version has no backwards or
+	forward-compatibilty guarantees - your client must understand
+	**exactly** the same version, it is not enough to support an older
+	or a newer version.
+
+	This API will be removed once the DBus API is declared stable.
+
 .. attribute:: Devices
 
         :type: ao

--- a/meson.build
+++ b/meson.build
@@ -4,6 +4,12 @@ project('libratbag', 'c',
 	default_options : [ 'c_std=gnu99', 'warning_level=2' ],
 	meson_version : '>= 0.40.0')
 
+# The DBus API version. Increase this every time the DBus API changes.
+# No backwards/forwards guarantee, clients are expected to understand
+# whatever ratbagd speaks or bail out. This should be removed if we ever
+# finish the API and declare it stable.
+ratbagd_api_version = 1
+
 # We use libtool-version numbers because it's easier to understand.
 # Before making a release, the libratbag_so_* and liblur_so_*
 # numbers should be modified. The components are of the form C:R:A.
@@ -35,6 +41,7 @@ add_project_arguments(cflags, language: 'c')
 config_h = configuration_data()
 config_h.set('_GNU_SOURCE', '1')
 config_h.set_quoted('RATBAG_VERSION', meson.project_version())
+config_h.set('RATBAGD_API_VERSION', ratbagd_api_version)
 libratbag_data_dir = join_paths(get_option('prefix'),
 				get_option('datadir'),
 				'libratbag')
@@ -520,15 +527,22 @@ else
   py3 = pymod.find_installation()
 endif
 
+config_ratbagctl = configuration_data()
+config_ratbagctl.set('RATBAGD_API_VERSION', ratbagd_api_version)
+config_ratbagctl.set('version', meson.project_version())
+
+ratbagctl_in = configure_file(input : 'tools/ratbagctl.in.in',
+			      output : 'ratbagctl.in',
+			      configuration: config_ratbagctl)
+
 # ratbagctl is the commandline tool to interact with ratbagd over DBus.
 custom_target('ratbagctl',
   output : 'ratbagctl',
-  input : ['tools/ratbagctl.in', 'tools/ratbagd.py'],
+  input : [ratbagctl_in, 'tools/ratbagd.py'],
   build_by_default : true,
   command : [py3, join_paths(meson.source_root(), 'tools', 'merge_ratbagd.py'),
 				'@INPUT@',
-				'--output', '@OUTPUT@',
-				'--version', meson.project_version()],
+				'--output', '@OUTPUT@'],
   install: true,
   install_dir: get_option('bindir'))
 
@@ -543,6 +557,7 @@ man_ratbagctl = configure_file (
 config_ratbagctl_devel = configuration_data()
 config_ratbagctl_devel.set('MESON_BUILD_ROOT', meson.build_root())
 config_ratbagctl_devel.set('LIBRATBAG_DATA_DIR', libratbag_data_dir_devel)
+config_ratbagctl_devel.set('RATBAGD_API_VERSION', ratbagd_api_version)
 
 configure_file(input : 'tools/toolbox.py',
 	       output : 'toolbox.py',
@@ -610,12 +625,11 @@ ratbagc_py = configure_file(input: 'tools/ratbagc.py.in',
 # development tool for protocol debugging etc.
 custom_target('ratbag-command',
   output : 'ratbag-command',
-  input : ['tools/ratbagctl.in', ratbagc_py],
+  input : [ratbagctl_in, ratbagc_py],
   build_by_default : true,
   command : [py3, join_paths(meson.source_root(), 'tools', 'merge_ratbagd.py'),
 				'@INPUT@',
-				'--output', '@OUTPUT@',
-				'--version', meson.project_version()],
+				'--output', '@OUTPUT@'],
   install: false)
 
 #### output files ####

--- a/ratbagd/ratbagd.c
+++ b/ratbagd/ratbagd.c
@@ -166,6 +166,7 @@ static int ratbagd_get_devices(sd_bus *bus,
 
 static const sd_bus_vtable ratbagd_vtable[] = {
 	SD_BUS_VTABLE_START(0),
+	SD_BUS_PROPERTY("APIVersion", "i", 0, offsetof(struct ratbagd, api_version), SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_PROPERTY("Devices", "ao", ratbagd_get_devices, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 #ifdef RATBAG_DEVELOPER_EDITION
 	SD_BUS_METHOD("LoadTestDevice", "s", "i", ratbagd_load_test_device, SD_BUS_VTABLE_UNPRIVILEGED),
@@ -345,6 +346,7 @@ static int ratbagd_new(struct ratbagd **out)
 	int r;
 
 	ctx = zalloc(sizeof(*ctx));
+	ctx->api_version = RATBAGD_API_VERSION;
 
 	r = sd_event_default(&ctx->event);
 	if (r < 0)

--- a/ratbagd/ratbagd.h
+++ b/ratbagd/ratbagd.h
@@ -218,6 +218,8 @@ struct ratbagd_device *ratbagd_device_next(struct ratbagd_device *device);
  */
 
 struct ratbagd {
+	int api_version;
+
 	sd_event *event;
 	struct ratbag *lib_ctx;
 	struct udev_monitor *monitor;

--- a/tools/ratbagc.py.in
+++ b/tools/ratbagc.py.in
@@ -216,11 +216,11 @@ class Ratbagd(object):
 def get_capabilities(type, object):
     capabilities = []
     for k in libratbag.__dict__.keys():
-            if k.startswith("RATBAG_{}_CAP_".format(type.upper())) and "CAP_NONE" not in k:
-                cap = getattr(libratbag, k)
-                func = getattr(libratbag, "ratbag_{}_has_capability".format(type.lower()))
-                if func(object, cap):
-                    capabilities.append(cap)
+        if k.startswith("RATBAG_{}_CAP_".format(type.upper())) and "CAP_NONE" not in k:
+            cap = getattr(libratbag, k)
+            func = getattr(libratbag, "ratbag_{}_has_capability".format(type.lower()))
+            if func(object, cap):
+                capabilities.append(cap)
     return capabilities
 
 

--- a/tools/ratbagctl.in.in
+++ b/tools/ratbagctl.in.in
@@ -1465,7 +1465,7 @@ def on_device_added(ratbagd, device):
 
 def open_ratbagd(ratbagd_process=None, verbose=0):
     try:
-        r = Ratbagd()
+        r = Ratbagd(@RATBAGD_API_VERSION@)
         r.verbose = verbose
         try:
             r.connect('device-added', on_device_added)

--- a/tools/ratbagctl.test.in
+++ b/tools/ratbagctl.test.in
@@ -800,8 +800,13 @@ def setUpModule():
         ratbagd_process = toolbox.start_ratbagd()
         assert ratbagd_process is not None
 
-    ratbagd = toolbox.open_ratbagd(ratbagd_process)
-    assert ratbagd is not None
+    try:
+        ratbagd = toolbox.open_ratbagd(ratbagd_process)
+        assert ratbagd is not None
+    except Exception as e:
+        if ratbagd_process is not None:
+            toolbox.terminate_ratbagd(ratbagd_process)
+        raise e
 
     parser = toolbox.get_parser()
 

--- a/tools/ratbagctl.test.in
+++ b/tools/ratbagctl.test.in
@@ -81,9 +81,9 @@ class TestRatbagCtl(unittest.TestCase):
             cmd.func(ratbagd, cmd)
         except SystemExit as e:
             returncode = e.code
-        except AttributeError as e:
+        except AttributeError:
             returncode = 2
-        except argparse.ArgumentTypeError as e:
+        except argparse.ArgumentTypeError:
             returncode = 2
         output = sys.stdout.getvalue()
         error = sys.stderr.getvalue()

--- a/tools/toolbox.py
+++ b/tools/toolbox.py
@@ -25,7 +25,6 @@
 
 import imp
 import os
-import shutil
 import subprocess
 import sys
 
@@ -112,7 +111,7 @@ def sync_dbus():
 
 ratbagctl = import_non_standard_path(RATBAGCTL_NAME, RATBAGCTL_PATH)
 
-from ratbagctl import open_ratbagd, get_parser, RatbagError, RatbagErrorCapability
+from ratbagctl import open_ratbagd, get_parser, RatbagError, RatbagErrorCapability  # NOQA
 
 __all__ = [
     RATBAGCTL_NAME,


### PR DESCRIPTION
Synchronizing piper and libratbag is a pain, especially if one runs from a PPA and the other runs from flatpak. Usually something just blows up and then we get to figure out which package doesn't match.

We haven't done anything about this in the past because the stable DBus API was always just around the corner. Let's give up on that hope and add a specific field with the version so it's easier to force the compatibility. We can remove that in a few decades when we finally finish the API.