### PR TITLE
hidpp10: make raw debugging messages a bit easier to read

### DIFF
--- a/src/hidpp-generic.h
+++ b/src/hidpp-generic.h
@@ -147,6 +147,9 @@ hidpp_log(struct hidpp_device *dev,
 	  ...)
 	__attribute__ ((format (printf, 3, 4)));
 
+char *
+hidpp_buffer_to_string(const uint8_t *buf, size_t len);
+
 void
 hidpp_log_buffer(struct hidpp_device *dev,
 		 enum hidpp_log_priority priority,

--- a/src/libratbag-hidraw.c
+++ b/src/libratbag-hidraw.c
@@ -1239,6 +1239,8 @@ ratbag_hidraw_parse_report_descriptor(struct ratbag_device *device)
 	if (rc < 0)
 		return rc;
 
+	log_debug(device->ratbag, "Parsing HID report descriptor\n");
+
 	i = 0;
 	usage_page = 0;
 	usage = 0;
@@ -1260,7 +1262,7 @@ ratbag_hidraw_parse_report_descriptor(struct ratbag_device *device)
 		switch (hid) {
 		case HID_REPORT_ID:
 			if (hidraw->reports) {
-				log_debug(device->ratbag, "HID report ID %02x\n", content);
+				log_debug(device->ratbag, "- HID report ID %02x\n", content);
 				hidraw->reports[hidraw->num_reports].report_id = content;
 				hidraw->reports[hidraw->num_reports].usage_page = usage_page;
 				hidraw->reports[hidraw->num_reports].usage = usage;


### PR DESCRIPTION
some indentations, some linebreaks in the profile raw data, and dropping the "expected_header" and "expected_error" messages which confused me every time I saw them float past.