### PR TITLE
Revert "add quirk system & full support for the G305"

### DIFF
--- a/data/devices/logitech-g305.device
+++ b/data/devices/logitech-g305.device
@@ -1,7 +1,0 @@
-[Device]
-Name=Logitech Gaming Mouse G305
-DeviceMatch=usb:046d:4074
-Driver=hidpp20
-
-[Driver/hidpp20]
-Quirk=G305

--- a/meson.build
+++ b/meson.build
@@ -294,7 +294,6 @@ data_files = files(
 	'data/devices/logitech-g300.device',
 	'data/devices/logitech-g302.device',
 	'data/devices/logitech-g303.device',
-	'data/devices/logitech-g305.device',
 	'data/devices/logitech-g402.device',
 	'data/devices/logitech-g403-hero.device',
 	'data/devices/logitech-g403-wireless.device',

--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -1560,14 +1560,9 @@ hidpp20drv_probe(struct ratbag_device *device)
 		goto err;
 	}
 
-	dev->quirk = ratbag_device_data_hidpp20_get_quirk(device->data);
-
 	drv_data->dev = dev;
 
 	log_debug(device->ratbag, "'%s' is using protocol v%d.%d\n", ratbag_device_get_name(device), dev->proto_major, dev->proto_minor);
-
-	if(dev->quirk != HIDPP20_QUIRK_NONE)
-		log_debug(device->ratbag, "'%s' is quirked (%s)\n", ratbag_device_get_name(device), hidpp20_get_quirk_string(dev->quirk));
 
 	/* add some defaults that will be overwritten by the device */
 	drv_data->num_profiles = 1;

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -99,24 +99,6 @@ hidpp20_sw_led_control_get_mode_string(const enum hidpp20_led_sw_ctrl_led_mode m
 		str = numeric;
 		break;
 	}
-
-	return str;
-}
-
-const char*
-hidpp20_get_quirk_string(unsigned quirk)
-{
-	static char numeric[8];
-	const char* str = NULL;
-	switch (quirk)
-	{
-	CASE_RETURN_STRING(HIDPP20_QUIRK_NONE);
-	CASE_RETURN_STRING(HIDPP20_QUIRK_G305);
-	default:
-		sprintf_safe(numeric, "%#4x", quirk);
-		str = numeric;
-		break;
-	}
 #undef CASE_RETURN_STRING
 
 	return str;

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -2620,15 +2620,6 @@ hidpp20_onboard_profiles_initialize(struct hidpp20_device *device,
 						  HIDPP20_USER_PROFILES_G402,
 						  profiles->sector_size,
 						  data);
-
-	if (rc && device->quirk != HIDPP20_QUIRK_G305) {
-		/* The G305 has a bug where it throws an ERR_INVALID_ARGUMENT
-		   if the sector has not been written to yet. If this happens
-		   we will read the ROM profiles.*/
-		read_userdata = false;
-		goto read_profiles;
-	}
-
 	if (rc < 0)
 		return rc; // ignore_clang_sa_mem_leak
 
@@ -2662,7 +2653,6 @@ hidpp20_onboard_profiles_initialize(struct hidpp20_device *device,
 		read_userdata = false;
 	}
 
-read_profiles:
 	for (i = 0; i < profiles->num_profiles; i++) {
 		if (read_userdata) {
 			hidpp_log_debug(&device->base, "Parsing profile %u\n", i);

--- a/src/hidpp20.h
+++ b/src/hidpp20.h
@@ -83,8 +83,8 @@ hidpp20_device_destroy(struct hidpp20_device *device);
 
 enum {
 	HIDPP20_QUIRK_NONE,
-	HIDPP20_QUIRK_G305,
 }
+#define HIDPP20_QUIRK_G305				1
 
 /* -------------------------------------------------------------------------- */
 /* 0x0000: Root                                                               */

--- a/src/hidpp20.h
+++ b/src/hidpp20.h
@@ -58,14 +58,11 @@ struct hidpp20_device {
 	unsigned proto_minor;
 	unsigned feature_count;
 	struct hidpp20_feature *feature_list;
-	unsigned quirk;
 };
 
 int hidpp20_request_command(struct hidpp20_device *dev, union hidpp20_message *msg);
 
 const char *hidpp20_feature_get_name(uint16_t feature);
-
-const char *hidpp20_get_quirk_string(unsigned quirk);
 
 /* -------------------------------------------------------------------------- */
 /* generic hidpp20 device operations                                          */
@@ -76,15 +73,6 @@ hidpp20_device_new(const struct hidpp_device *base, unsigned int idx);
 
 void
 hidpp20_device_destroy(struct hidpp20_device *device);
-
-/* -------------------------------------------------------------------------- */
-/* quirks                                                                     */
-/* -------------------------------------------------------------------------- */
-
-enum {
-	HIDPP20_QUIRK_NONE,
-}
-#define HIDPP20_QUIRK_G305				1
 
 /* -------------------------------------------------------------------------- */
 /* 0x0000: Root                                                               */

--- a/src/libratbag-data.c
+++ b/src/libratbag-data.c
@@ -166,10 +166,6 @@ init_data_hidpp20(struct ratbag *ratbag,
 
 	str = g_key_file_get_string(keyfile, group, "Quirk", NULL);
 	data->hidpp20.quirk = HIDPP20_QUIRK_NONE;
-	if (str) {
-		if (streq(str, "G305"))
-			data->hidpp20.quirk = HIDPP20_QUIRK_G305;
-	}
 }
 
 static void

--- a/src/libratbag-data.c
+++ b/src/libratbag-data.c
@@ -33,7 +33,6 @@
 #include "libratbag.h"
 #include "libratbag-private.h"
 #include "libratbag-data.h"
-#include "hidpp20.h"
 
 #define GROUP_DEVICE "Device"
 
@@ -55,7 +54,6 @@ enum driver {
 
 struct data_hidpp20 {
 	int index;
-	unsigned quirk;
 };
 
 struct data_hidpp10 {
@@ -154,7 +152,6 @@ init_data_hidpp20(struct ratbag *ratbag,
 	const char *group = "Driver/hidpp20";
 	GError *error = NULL;
 	int num;
-	char *str;
 
 	data->hidpp20.index = -1;
 
@@ -163,9 +160,6 @@ init_data_hidpp20(struct ratbag *ratbag,
 		data->hidpp20.index = num;
 	if (error)
 		g_error_free(error);
-
-	str = g_key_file_get_string(keyfile, group, "Quirk", NULL);
-	data->hidpp20.quirk = HIDPP20_QUIRK_NONE;
 }
 
 static void
@@ -566,14 +560,6 @@ ratbag_device_data_hidpp20_get_index(const struct ratbag_device_data *data)
 	assert(data->drivertype == HIDPP20);
 
 	return data->hidpp20.index;
-}
-
-int
-ratbag_device_data_hidpp20_get_quirk(const struct ratbag_device_data *data)
-{
-	assert(data->drivertype == HIDPP20);
-
-	return data->hidpp20.quirk;
 }
 
 /* SteelSeries */

--- a/src/libratbag-data.h
+++ b/src/libratbag-data.h
@@ -80,9 +80,6 @@ ratbag_device_data_hidpp10_get_led_count(const struct ratbag_device_data *data);
 int
 ratbag_device_data_hidpp20_get_index(const struct ratbag_device_data *data);
 
-int
-ratbag_device_data_hidpp20_get_quirk(const struct ratbag_device_data *data);
-
 /* SteelSeries */
 
 /**


### PR DESCRIPTION
Reverts libratbag/libratbag#784

Sorry, need to revert. This fails to compile, there's a `;` missing after the enum declaration. which makes me wonder why circleci didn't run on this PR.

And looking at the git log (reviewed the whole diff before and didn't notice): 
```
+enum {
+       HIDPP20_QUIRK_NONE,
+}
+#define HIDPP20_QUIRK_G305     
```
That's fixed in the second patch so I guess that's a rebase gone wrong?

And the test suite now fails with `AssertionError: Quirk must be in ['DeviceIndex']`. Also something that should've been picked up by the CI which for some reason didn't run.