### PR TITLE
added bluetooth device ID in profiles for Logitech MX Master AMZ (amazon)

### DIFF
--- a/data/devices/logitech-MX-Master.device
+++ b/data/devices/logitech-MX-Master.device
@@ -1,5 +1,5 @@
 # Logitech MX Master
 [Device]
 Name=Logitech MX Master
-DeviceMatch=usb:046d:4041;bluetooth:046d:b012;usb:046d:4060;bluetooth:046d:b017
+DeviceMatch=usb:046d:4041;bluetooth:046d:b012;usb:046d:4060;bluetooth:046d:b017;bluetooth:046d:b01e
 Driver=hidpp20


### PR DESCRIPTION
Added support for the item in question. The device ID for the AMZ version is different from the standard one. Simply adding a new bluetooth device ID in the device match makes the mouse working. I have just updated the Logitech MX Master device file