### PR TITLE
Add missing MX master PID

### DIFF
--- a/data/devices/logitech-MX-Master.device
+++ b/data/devices/logitech-MX-Master.device
@@ -1,5 +1,5 @@
 # Logitech MX Master
 [Device]
 Name=Logitech MX Master
-DeviceMatch=usb:046d:4041;bluetooth:046d:b012;usb:046d:4060;bluetooth:046d:b017;bluetooth:046d:b01e
+DeviceMatch=usb:046d:4041;bluetooth:046d:b012;usb:046d:4060;bluetooth:046d:b017;bluetooth:046d:b01e;usb:046d:4071
 Driver=hidpp20


### PR DESCRIPTION
As seen here: https://github.com/torvalds/linux/blob/master/drivers/hid/hid-logitech-hidpp.c#L3717
This mouse is a warranty replacement, shows up as MX Master in Logitech Options but has MX Master 2S Hardware.