### PR TITLE
hidpp20: fallback to 1st profile when no 8100 profile is active

### DIFF
--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -1516,6 +1516,7 @@ hidpp20drv_init_device(struct ratbag_device *device,
 		       struct hidpp20drv_data *drv_data)
 {
 	struct ratbag_profile *profile;
+	bool active_profile = false;
 
 	ratbag_device_init_profiles(device,
 				    drv_data->num_profiles,
@@ -1525,6 +1526,18 @@ hidpp20drv_init_device(struct ratbag_device *device,
 
 	ratbag_device_for_each_profile(device, profile)
 		hidpp20drv_read_profile(profile);
+
+	if (drv_data->capabilities & HIDPP_CAP_ONBOARD_PROFILES_8100) {
+		/* Fallback to the first profile if no profile is active */
+		list_for_each(profile, &device->profiles, link)
+			if (profile->is_active)
+				active_profile = true;
+
+		if (!active_profile && device->num_profiles >= 1) {
+			profile = ratbag_device_get_profile(device, 0);
+			profile->is_active = true;
+		}
+	}
 }
 
 static int


### PR DESCRIPTION
When the windows driver puts a device host mode it will mark all 8100
profiles as disabled. If no 8100 profile is enabled no libratbag profile
will get enabled. This patch prevents this by marking the first profile
as enabled if no profile is already enabled.

Signed-off-by: Filipe Laíns <lains@archlinux.org>