### PR TITLE
Emulation tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 *.rej
 *.trs
 tags
+ratbag-emu-log-*.txt

--- a/test/test_emulation/__init__.py
+++ b/test/test_emulation/__init__.py
@@ -15,9 +15,8 @@ MM_TO_INCH = 0.0393700787
 
 
 class RatbagemuClient(object):
-    def __init__(self, url='http://localhost:8080'):
-        self.url = url
-
+    def __init__(self, url='http://localhost', port=8080):
+        self.url = f'{url}:{port}'
 
     # Internal wrappers around the http requests
     def _get(self, path):

--- a/test/test_emulation/__init__.py
+++ b/test/test_emulation/__init__.py
@@ -8,7 +8,7 @@ import pytest
 import threading
 
 from pathlib import Path
-from time import sleep
+from time import sleep, strftime, time
 
 
 MM_TO_INCH = 0.0393700787
@@ -90,20 +90,17 @@ class TestDevice(object):
     @pytest.fixture(autouse=True, scope='session')
     def server(self):
         p = None
-        try:
-            stdout = open('ratbag-emu-log-stdout.txt', 'w')
-            stderr = open('ratbag-emu-log-stderr.txt', 'w')
-
-            p = subprocess.Popen(['/usr/bin/env', 'python3', '-m', 'ratbag_emu'], stdout=stdout, stderr=stderr)
-            sleep(2)
-            yield
-        finally:
-            if p:
-                p.kill()
-            if stdout:
-                stdout.close()
-            if stderr:
-                stderr.close()
+        logs = f'ratbag-emu-log-{strftime("%Y-%m-%d_%H:%M")}'
+        with open(f'{logs}-stdout.txt', 'w') as stdout, \
+             open(f'{logs}-stderr.txt', 'w') as stderr:
+            try:
+                args = ['/usr/bin/env', 'python3', '-m', 'ratbag_emu']
+                p = subprocess.Popen(args, stdout=stdout, stderr=stderr)
+                sleep(2)
+                yield
+            finally:
+                if p:
+                    p.kill()
 
     @pytest.fixture(autouse=True, scope='session')
     @pytest.mark.usesfixtures('server')

--- a/test/test_emulation/__init__.py
+++ b/test/test_emulation/__init__.py
@@ -88,7 +88,7 @@ class TestDevice(object):
             rules_dest.unlink()
             self.reload_udev_rules()
 
-    @pytest.fixture(autouse=True)
+    @pytest.fixture(autouse=True, scope='session')
     def client(self):
         yield RatbagemuClient()
 

--- a/test/test_emulation/__init__.py
+++ b/test/test_emulation/__init__.py
@@ -92,12 +92,19 @@ class TestDevice(object):
     def server(self):
         p = None
         try:
-            p = subprocess.Popen('python -m ratbag_emu 2&>1 >/dev/null', shell=True)
+            stdout = open('ratbag-emu-log-stdout.txt', 'w')
+            stderr = open('ratbag-emu-log-stderr.txt', 'w')
+
+            p = subprocess.Popen(['/usr/bin/env', 'python3', '-m', 'ratbag_emu'], stdout=stdout, stderr=stderr)
             sleep(2)
             yield
         finally:
             if p:
                 p.kill()
+            if stdout:
+                stdout.close()
+            if stderr:
+                stderr.close()
 
     @pytest.fixture(autouse=True, scope='session')
     @pytest.mark.usesfixtures('server')

--- a/test/test_emulation/__init__.py
+++ b/test/test_emulation/__init__.py
@@ -92,6 +92,14 @@ class TestDevice(object):
     def client(self):
         yield RatbagemuClient()
 
+    @pytest.fixture
+    def id(self, client):
+        id = client.create(self.shortname)
+
+        yield id
+
+        client.delete(id)
+
     def _simulate(self, client, id, data):
         input_nodes = client.get_input_nodes(id)
 

--- a/test/test_emulation/__init__.py
+++ b/test/test_emulation/__init__.py
@@ -89,6 +89,18 @@ class TestDevice(object):
             self.reload_udev_rules()
 
     @pytest.fixture(autouse=True, scope='session')
+    def server(self):
+        p = None
+        try:
+            p = subprocess.Popen('python -m ratbag_emu 2&>1 >/dev/null', shell=True)
+            sleep(2)
+            yield
+        finally:
+            if p:
+                p.kill()
+
+    @pytest.fixture(autouse=True, scope='session')
+    @pytest.mark.usesfixtures('server')
     def client(self):
         yield RatbagemuClient()
 

--- a/test/test_emulation/__init__.py
+++ b/test/test_emulation/__init__.py
@@ -34,10 +34,12 @@ class RatbagemuClient(object):
     '''
     ratbag-emu functions
     '''
-    def create(self, shortname):
+    def create(self, shortname, initial_state=None):
         data = {
             'shortname': shortname
         }
+        if initial_state:
+            data['initial_state'] =  initial_state
         response = self._post('/devices/add', json=data)
         assert response.status_code == 201
         return response.json()['id']
@@ -66,6 +68,8 @@ class RatbagemuClient(object):
 
 
 class TestDevice(object):
+    initial_state = None
+
     def reload_udev_rules(self):
         subprocess.run('udevadm control --reload-rules'.split())
 
@@ -127,7 +131,7 @@ class TestDevice(object):
     @pytest.fixture(autouse=True)
     @pytest.mark.first
     def id(self, client):
-        id = client.create(self.shortname)
+        id = client.create(self.shortname, initial_state=self.initial_state)
 
         yield id
 

--- a/test/test_emulation/__init__.py
+++ b/test/test_emulation/__init__.py
@@ -1,0 +1,148 @@
+import fcntl
+import libevdev
+import requests
+import shutil
+import subprocess
+import os
+import pytest
+import threading
+
+from pathlib import Path
+from time import sleep
+
+
+MM_TO_INCH = 0.0393700787
+
+
+class RatbagemuClient(object):
+    def __init__(self, url='http://localhost:8080'):
+        self.url = url
+
+
+    # Internal wrappers around the http requests
+    def _get(self, path):
+        return requests.get(f'{self.url}{path}')
+
+    def _post(self, path, data=None, json=None):
+        return requests.post(f'{self.url}{path}', data=data, json=json)
+
+    def _delete(self, path):
+        return requests.delete(f'{self.url}{path}')
+
+    def _put(self, path, data=None, json=None):
+        return requests.put(f'{self.url}{path}', data=data, json=json)
+
+    '''
+    ratbag-emu functions
+    '''
+    def create(self, shortname):
+        data = {
+            'shortname': shortname
+        }
+        response = self._post('/devices/add', json=data)
+        assert response.status_code == 201
+        return response.json()['id']
+
+    def delete(self, id):
+        response = self._delete(f'/devices/{id}')
+        assert response.status_code == 204
+
+    def get_dpi(self, id, dpi_id):
+        response = self._get(f'/devices/{id}/phys_props/dpi/{dpi_id}')
+        assert response.status_code == 200
+        return response.json()
+
+    def set_dpi(self, id, dpi_id, new_dpi):
+        response = self._put(f'/devices/{id}/phys_props/dpi/{dpi_id}', json=new_dpi)
+        assert response.status_code == 200
+
+    def get_input_nodes(self, id):
+        response = self._get(f'/devices/{id}')
+        if response.status_code == 200 and 'input_nodes' in response.json():
+            return response.json()['input_nodes']
+
+    def send_event(self, id, event):
+        response = self._post(f'/devices/{id}/event', json=event)
+        assert response.status_code == 200
+
+
+class TestDevice(object):
+    def reload_udev_rules(self):
+        subprocess.run('udevadm control --reload-rules'.split())
+
+    @pytest.fixture(scope='session', autouse=True)
+    def udev_rules(self):
+        rules_file = '61-ratbag-emu-ignore-test-devices.rules'
+        rules_dir = Path('/run/udev/rules.d')
+
+        rules_src = Path('test/test_emulation/rules.d') / rules_file
+        rules_dest = rules_dir / rules_file
+
+        rules_dir.mkdir(exist_ok=True)
+        shutil.copyfile(rules_src, rules_dest)
+        self.reload_udev_rules()
+
+        yield
+
+        if rules_dest.is_file():
+            rules_dest.unlink()
+            self.reload_udev_rules()
+
+    @pytest.fixture(autouse=True)
+    def client(self):
+        yield RatbagemuClient()
+
+    def _simulate(self, client, id, data):
+        input_nodes = client.get_input_nodes(id)
+
+        # Open the event nodes
+        event_nodes = []
+        for node in set(input_nodes):
+            fd = open(node, 'rb')
+            fcntl.fcntl(fd, fcntl.F_SETFL, os.O_NONBLOCK)
+            event_nodes.append(libevdev.Device(fd))
+
+        events = []
+        def collect_events(stop):
+            nonlocal events
+            while not stop.is_set():
+                for node in event_nodes:
+                    events += list(node.events())
+
+        stop_event_thread = threading.Event()
+        event_thread = threading.Thread(target=collect_events, args=(stop_event_thread,))
+        event_thread.start()
+
+        client.send_event(id, data)
+
+        sleep(1)
+        stop_event_thread.set()
+        event_thread.join()
+
+        for node in event_nodes:
+            node.fd.close()
+
+        received = MouseData()
+        for e in events:
+            if e.matches(libevdev.EV_REL.REL_X):
+                received.x += e.value
+            elif e.matches(libevdev.EV_REL.REL_Y):
+                received.y += e.value
+
+        return received
+
+
+class MouseData(object):
+    '''
+    Holds event data
+    '''
+
+    def __init__(self, x=0, y=0):
+        self.x = x
+        self.y = y
+
+    @staticmethod
+    def from_mm(dpi, x=0, y=0):
+        return MouseData(x=int(x * MM_TO_INCH * dpi),
+                         y=int(y * MM_TO_INCH * dpi))
+

--- a/test/test_emulation/rules.d/61-ratbag-emu-ignore-test-devices.rules
+++ b/test/test_emulation/rules.d/61-ratbag-emu-ignore-test-devices.rules
@@ -1,2 +1,2 @@
 # Ignore ratbag-emu test devices
-KERNELS=="*input*", ATTRS{name}=="ratbag-emu test device *", ENV{LIBINPUT_IGNORE_DEVICE}="1"
+KERNELS=="*input*", ATTRS{name}=="ratbag-emu *", ENV{LIBINPUT_IGNORE_DEVICE}="1"

--- a/test/test_emulation/rules.d/61-ratbag-emu-ignore-test-devices.rules
+++ b/test/test_emulation/rules.d/61-ratbag-emu-ignore-test-devices.rules
@@ -1,0 +1,2 @@
+# Ignore ratbag-emu test devices
+KERNELS=="*input*", ATTRS{name}=="ratbag-emu test device *", ENV{LIBINPUT_IGNORE_DEVICE}="1"

--- a/test/test_emulation/test_steelseries.py
+++ b/test/test_emulation/test_steelseries.py
@@ -7,14 +7,14 @@ class TestSteelseriesDevice2(TestDevice):
     shortname = 'steelseries-rival310'
 
     def test_create(self, id, client):
-        subprocess.check_call(f"ratbagctl 'ratbag-emu test device #{id}' info >/dev/null", shell=True)
+        subprocess.check_call(f"ratbagctl 'ratbag-emu {id}' info >/dev/null", shell=True)
 
     def test_dpi(self, id, client, dpi_id=0):
         old_dpi = 500
         new_dpi = 1000
 
         client.set_dpi(id, dpi_id, old_dpi)
-        subprocess.check_call(f"ratbagctl 'ratbag-emu test device #{id}' resolution {str(dpi_id)} dpi set {str(new_dpi)}", shell=True)
+        subprocess.check_call(f"ratbagctl 'ratbag-emu {id}' resolution {str(dpi_id)} dpi set {str(new_dpi)}", shell=True)
 
         x = y = 5
         data = [

--- a/test/test_emulation/test_steelseries.py
+++ b/test/test_emulation/test_steelseries.py
@@ -15,7 +15,7 @@ class TestSteelseriesDevice2(TestDevice):
         new_dpi = 1000
 
         client.set_dpi(id, dpi_id, old_dpi)
-        subprocess.run(f'ratbagctl ratbag-emu resolution {str(dpi_id)} dpi set {str(new_dpi)}', shell=True)
+        subprocess.run(f"ratbagctl 'ratbag-emu test device #{id}' resolution {str(dpi_id)} dpi set {str(new_dpi)}", shell=True)
 
         x = y = 5
         data = [

--- a/test/test_emulation/test_steelseries.py
+++ b/test/test_emulation/test_steelseries.py
@@ -4,13 +4,12 @@ from test_emulation import TestDevice, MouseData, MM_TO_INCH
 
 
 class TestSteelseriesDevice2(TestDevice):
-    def test_create(self, client):
-        id = client.create('steelseries-rival310')
-        client.delete(id)
+    shortname = 'steelseries-rival310'
 
-    def test_dpi(self, client, dpi_id=0):
-        id = client.create('steelseries-rival310')
+    def test_create(self, id, client):
+        subprocess.check_call(f"ratbagctl 'ratbag-emu test device #{id}' info >/dev/null", shell=True)
 
+    def test_dpi(self, id, client, dpi_id=0):
         old_dpi = 500
         new_dpi = 1000
 
@@ -35,5 +34,3 @@ class TestSteelseriesDevice2(TestDevice):
 
         assert expected.x - 1 <= received.x <= expected.x + 1
         assert expected.y - 1 <= received.y <= expected.y + 1
-
-        client.delete(id)

--- a/test/test_emulation/test_steelseries.py
+++ b/test/test_emulation/test_steelseries.py
@@ -7,15 +7,20 @@ from test_emulation import TestDevice, MouseData, MM_TO_INCH
 
 class TestSteelseriesDevice2(TestDevice):
     shortname = 'steelseries-rival310'
+    initial_state = {
+        'dpi': [
+            800,
+            1600
+        ],
+        'active_dpi': 1
+    }
 
     def test_create(self, id, ratbagd, client):
         assert ratbagd.find_device(f'ratbag-emu {id}')
 
     def test_dpi(self, id, ratbagd, client, dpi_id=0):
-        old_dpi = 500
+        old_dpi = self.initial_state['dpi'][self.initial_state['active_dpi']]
         new_dpi = 1000
-
-        client.set_dpi(id, dpi_id, old_dpi)
 
         device = ratbagd.find_device(f'ratbag-emu {id}')
         device.active_profile.resolutions[dpi_id].resolution = (new_dpi,)

--- a/test/test_emulation/test_steelseries.py
+++ b/test/test_emulation/test_steelseries.py
@@ -15,7 +15,7 @@ class TestSteelseriesDevice2(TestDevice):
         new_dpi = 1000
 
         client.set_dpi(id, dpi_id, old_dpi)
-        subprocess.run(f"ratbagctl 'ratbag-emu test device #{id}' resolution {str(dpi_id)} dpi set {str(new_dpi)}", shell=True)
+        subprocess.check_call(f"ratbagctl 'ratbag-emu test device #{id}' resolution {str(dpi_id)} dpi set {str(new_dpi)}", shell=True)
 
         x = y = 5
         data = [

--- a/test/test_emulation/test_steelseries.py
+++ b/test/test_emulation/test_steelseries.py
@@ -1,0 +1,39 @@
+import subprocess
+
+from test_emulation import TestDevice, MouseData, MM_TO_INCH
+
+
+class TestSteelseriesDevice2(TestDevice):
+    def test_create(self, client):
+        id = client.create('steelseries-rival310')
+        client.delete(id)
+
+    def test_dpi(self, client, dpi_id=0):
+        id = client.create('steelseries-rival310')
+
+        old_dpi = 500
+        new_dpi = 1000
+
+        client.set_dpi(id, dpi_id, old_dpi)
+        subprocess.run(f'ratbagctl ratbag-emu resolution {str(dpi_id)} dpi set {str(new_dpi)}', shell=True)
+
+        x = y = 5
+        data = [
+            {
+                'start': 0,
+                'end': 500,
+                'action': {
+                    'type': 'xy',
+                    'x': x,
+                    'y': y
+                }
+            }
+        ]
+        received = self._simulate(client, id, data)
+
+        expected = MouseData.from_mm(new_dpi, x=x, y=y)
+
+        assert expected.x - 1 <= received.x <= expected.x + 1
+        assert expected.y - 1 <= received.y <= expected.y + 1
+
+        client.delete(id)

--- a/test/test_emulation/test_steelseries.py
+++ b/test/test_emulation/test_steelseries.py
@@ -1,20 +1,26 @@
 import subprocess
 
+from time import sleep
+
 from test_emulation import TestDevice, MouseData, MM_TO_INCH
 
 
 class TestSteelseriesDevice2(TestDevice):
     shortname = 'steelseries-rival310'
 
-    def test_create(self, id, client):
-        subprocess.check_call(f"ratbagctl 'ratbag-emu {id}' info >/dev/null", shell=True)
+    def test_create(self, id, ratbagd, client):
+        assert ratbagd.find_device(f'ratbag-emu {id}')
 
-    def test_dpi(self, id, client, dpi_id=0):
+    def test_dpi(self, id, ratbagd, client, dpi_id=0):
         old_dpi = 500
         new_dpi = 1000
 
         client.set_dpi(id, dpi_id, old_dpi)
-        subprocess.check_call(f"ratbagctl 'ratbag-emu {id}' resolution {str(dpi_id)} dpi set {str(new_dpi)}", shell=True)
+
+        device = ratbagd.find_device(f'ratbag-emu {id}')
+        device.active_profile.resolutions[dpi_id].resolution = (new_dpi,)
+        device.commit()
+        sleep(0.1)
 
         x = y = 5
         data = [

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -284,6 +284,11 @@ class Ratbagd(_RatbagdDBus):
         """A list of RatbagdDevice objects supported by ratbagd."""
         return self._devices
 
+    def find_device(self, name):
+        for device in self._devices:
+            if device.name.startswith(name):
+                return device
+
     def __getitem__(self, id):
         """Returns the requested device, or None."""
         for d in self.devices:


### PR DESCRIPTION
~~@bentiss I didn't do some of the things you asked me:~~
  - ~~Start `ratbag-emu` using `Popen`: this is tricky to integrate with pytest, it's the same issue I had in the ratbag-emu test suite.  If you think it's worth to spend more time making this work let me know.~~
  - ~~Use `ratbag-command`: I was having some trouble using it so I changed to `ratbagctl` and it worked perfectly. I don't really think it matters for this simple POC.~~

~~I just want some feedback right now, I can deal with the two points above next, if you still think they are relevant.~~

@whot @bentiss could you have a look at the structure of the tests I implemented and tell me if it's fine?

Instructions:
  - Start `ratbagd`
  - Start ratbag-emu (`src/main.py`)
  - Invoke `pytest` on libratbag's root directrectory