### PR TITLE
swig: generate python helpers to use hidpp C library

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -618,6 +618,19 @@ shared_library(
    install: false,
 )
 
+i_source = join_paths(meson.source_root(), 'src', 'hidpp.i')
+c_source = swig_gen.process(i_source)
+shared_library(
+   'hidpp',
+   c_source,
+   name_prefix: '_',
+   c_args : ['-Wno-missing-prototypes', '-Wno-format-nonliteral'],
+   extra_files: [ i_source ] + src_libratbag ,
+   dependencies: deps_libratbag + wrapper_deps,
+   include_directories : include_directories('src', 'tools'),
+   install: false,
+)
+
 # ratbagc is the layer that maps ratbagctl to the swig bindings
 ratbagc_py_conf = configuration_data()
 ratbagc_py_conf.set('LIBRATBAG_DATA_DIR', libratbag_data_dir_devel)

--- a/src/hidpp.i
+++ b/src/hidpp.i
@@ -1,0 +1,23 @@
+/* wrapping libratbag functions from hidpp*.h using SWIG. */
+
+%module hidpp
+%{
+	/* the resulting C file should be built as a python extension */
+	#define SWIG_FILE_WITH_INIT
+	/*  Includes the header in the wrapper code */
+	#include <shared.h>
+	#include <hidpp-generic.h>
+	#include <hidpp20.h>
+%}
+#define __attribute__(x)
+#define _Static_assert(a,b)
+
+
+/*  Parse the header file to generate wrappers */
+%include "stdint.i"
+%include "cpointer.i"
+%pointer_functions(int, intp);
+%pointer_functions(uint8_t, uint8_tp);
+%pointer_functions(uint16_t, uint16_tp);
+%include "hidpp-generic.h"
+%include "hidpp20.h"


### PR DESCRIPTION
```
$> sudo python3
Python 3.7.1 (default, Nov 23 2018, 10:01:49)
[GCC 8.2.1 20181105 (Red Hat 8.2.1-5)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import hidpp
>>> f = open('/dev/hidraw1', 'r+b')
>>> base = hidpp.hidpp_device()
>>> hidpp.hidpp_device_init(base, f.fileno())
>>> dev = hidpp.hidpp20_device_new(base, 0xff)
>>> hidpp.hidpp20_feature_get_name(0x8100)
'HIDPP_PAGE_ONBOARD_PROFILES'
>>> hidpp.new_uint8_tp()
<Swig Object of type 'uint8_t *' at 0x7f865198fb70>
>>> feature_index = hidpp.new_uint8_tp()
>>> feature_type = hidpp.new_uint8_tp()
>>> feature_version = hidpp.new_uint8_tp()
>>> hidpp.hidpp_root_get_feature(dev, 0x8100, feature_index, feature_type, feature_version)
0
>>> hidpp.uint8_tp_value(feature_index)
14
```

Signed-off-by: Benjamin Tissoires <benjamin.tissoires@gmail.com>
Signed-off-by: Filipe Laíns <lains@archlinux.org>