### PR TITLE
Updated G602 device with the correct USB id

### DIFF
--- a/data/devices/logitech-g602.device
+++ b/data/devices/logitech-g602.device
@@ -1,7 +1,7 @@
 # Logitech G602 over wireless USB
 [Device]
 Name=Logitech G602
-DeviceMatch=usb:046d:402c
+DeviceMatch=usb:046d:c537
 Driver=hidpp20
 
 [Driver/hidpp20]


### PR DESCRIPTION
Updated the G602 device id with the correct id found on the libratbag Wiki and the output I see from `lsusb` and `usbguard --list-devices`