### PR TITLE
Give a more specific error message if user cannot reach ratbagd

### DIFF
--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -252,13 +252,13 @@ class Ratbagd(_RatbagdDBus):
 
     def __init__(self, api_version):
         super().__init__("Manager", None)
-        result = self._get_dbus_property("Devices") or []
-        self._devices = [RatbagdDevice(objpath) for objpath in result]
-        self._proxy.connect("notify::g-name-owner", self._on_name_owner_changed)
-        if self.api_version == None and not self._proxy.get_cached_property_names():
+        result = self._get_dbus_property("Devices")
+        if result is None and not self._proxy.get_cached_property_names():
             raise RatbagdUnavailable("Make sure it is running and your user is in the required groups.")
         if self.api_version != api_version:
             raise RatbagdIncompatible(self.api_version or -1, api_version)
+        self._devices = [RatbagdDevice(objpath) for objpath in result or []]
+        self._proxy.connect("notify::g-name-owner", self._on_name_owner_changed)
 
     def _on_name_owner_changed(self, *kwargs):
         self.emit("daemon-disappeared")

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -255,6 +255,8 @@ class Ratbagd(_RatbagdDBus):
         result = self._get_dbus_property("Devices") or []
         self._devices = [RatbagdDevice(objpath) for objpath in result]
         self._proxy.connect("notify::g-name-owner", self._on_name_owner_changed)
+        if self.api_version == None and not self._proxy.get_cached_property_names():
+            raise RatbagdUnavailable("Make sure it is running and your user is in the required groups.")
         if self.api_version != api_version:
             raise RatbagdIncompatible(self.api_version or -1, api_version)
 


### PR DESCRIPTION
If access failed, e.g. due to insufficient permissions, don't confuse
the user by reporting an API mismatch.

This is a minimal improvement to target issue #802. As, if access is
restricted to a group, that group is known in Meson, it would even be
possible to report that group in the error message. But, that would
require converting ratbagd.py to a template or finding some other way to
inject that information at build time.