### PR TITLE
meson: fix minimum version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project('libratbag', 'c',
 	version : '0.11',
 	license : 'MIT/Expat',
 	default_options : [ 'c_std=gnu99', 'warning_level=2' ],
-	meson_version : '>= 0.40.0')
+	meson_version : '>= 0.50.0')
 
 # The DBus API version. Increase this every time the DBus API changes.
 # No backwards/forwards guarantee, clients are expected to understand


### PR DESCRIPTION
```
WARNING: Project specifies a minimum meson_version '>= 0.40.0' but uses features which were added in newer versions:
 * 0.46.0: {'Python Module'}
 * 0.50.0: {'install arg in configure_file'}
```

Signed-off-by: Filipe Laíns <lains@archlinux.org>