### PR TITLE
ratbagd: make raw the default verbosity level

### DIFF
--- a/ratbagd/ratbagd.8
+++ b/ratbagd/ratbagd.8
@@ -3,7 +3,7 @@
 ratbagd \- system daemon to introspect and modify configurable mice
 .SH SYNOPSIS
 .B ratbagd
-.RB [ \-\-verbose[=raw]|\-\-quiet|\-\-version|\-\-help]
+.RB [ \-\-verbose[=debug]|\-\-quiet|\-\-version|\-\-help]
 .SH DESCRIPTION
 .B ratbagd
 starts the daemon. It shouldn't be invoked directly;
@@ -14,7 +14,7 @@ is normally started through DBus activation.
 .B \-\-help
 Print help and exit
 .TP 8
-.B \-\-verbose, \-\-verbose=raw
+.B \-\-verbose, \-\-verbose=debug
 Enable verbose output, optionally including raw messages as sent and
 received from the device. This should be use to debug any issues with the
 device.

--- a/ratbagd/ratbagd.c
+++ b/ratbagd/ratbagd.c
@@ -617,12 +617,12 @@ int main(int argc, char *argv[])
 			return 0;
 		} else if (streq(argv[1], "--quiet")) {
 			log_level = LL_QUIET;
-		} else if (streq(argv[1], "--verbose=raw")) {
-			log_level = LL_RAW;
 		} else if (streq(argv[1], "--verbose")) {
+			log_level = LL_RAW;
+		} else if (streq(argv[1], "--verbose=debug")) {
 			log_level = LL_VERBOSE;
 		} else {
-			fprintf(stderr, "Usage: %s [--version | --quiet | --verbose[=raw]]\n",
+			fprintf(stderr, "Usage: %s [--version | --quiet | --verbose[=debug]]\n",
 				program_invocation_short_name);
 			r = -EINVAL;
 			goto exit;

--- a/tools/toolbox.py
+++ b/tools/toolbox.py
@@ -62,9 +62,9 @@ def start_ratbagd(verbosity=0):
     args = [os.path.join('@MESON_BUILD_ROOT@', "ratbagd.devel")]
 
     if verbosity >= 3:
-        args.append('--verbose=raw')
-    elif verbosity >= 2:
         args.append('--verbose')
+    elif verbosity >= 2:
+        args.append('--verbose=debug')
     elif verbosity == 0:
         args.append('--quiet')
 


### PR DESCRIPTION
TBH `--verbose` is not really that useful. We receive a several of report where the users pasted the log with `--verbose` and 99.9% of the cases that is not helpful, we need `--verbose=raw`. I think it would make sense for `raw` to be the default level when `--verbose` is specified.