### PR TITLE
drivers: fix G305 quirk detection

### DIFF
--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -1509,7 +1509,6 @@ hidpp20drv_remove(struct ratbag_device *device)
 	if (drv_data->profiles)
 		hidpp20_onboard_profiles_destroy(drv_data->profiles);
 	free(drv_data->led_infos.color_leds_8070);
-	free(drv_data->led_infos.color_leds_8071);
 	free(drv_data->controls);
 	free(drv_data->sensors);
 	if (drv_data->dev)

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -2627,7 +2627,7 @@ hidpp20_onboard_profiles_initialize(struct hidpp20_device *device,
 						  profiles->sector_size,
 						  data);
 
-	if (rc && device->quirk != HIDPP20_QUIRK_G305) {
+	if (rc && device->quirk == HIDPP20_QUIRK_G305) {
 		/* The G305 has a bug where it throws an ERR_INVALID_ARGUMENT
 		   if the sector has not been written to yet. If this happens
 		   we will read the ROM profiles.*/


### PR DESCRIPTION
Fixes: #833 
Fixes: #846 

The second patch is not well tested. But I think it should work. Linux kernel version 5.4 causes serious regression of my system and force me to switch back to an old kernel. 