### PR TITLE
Minor fixes

### DIFF
--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -2378,7 +2378,7 @@ hidpp20_onboard_profiles_write_dict(struct hidpp20_device *device,
 
 	memset(data + buffer_index, 0xff, sector_size - buffer_index);
 
-	hidpp_log_buf_debug(&device->base,
+	hidpp_log_buf_raw(&device->base,
 			   "dictionary: ",
 			   data,
 			   hidpp20_onboard_profiles_compute_dict_size(device,

--- a/tools/ratbagc.py.in
+++ b/tools/ratbagc.py.in
@@ -1,6 +1,6 @@
 # vim: set expandtab shiftwidth=4 tabstop=4:
 #
-# Copyright 2017 Red Hat, Inc.
+# Copyright 2017-2019 Red Hat, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -324,7 +324,7 @@ class RatbagdProfile(metaclass=MetaRatbag):
         """The capabilities of this profile as an array. Capabilities not
         present on the profile are not in the list. Thus use e.g.
 
-        if RatbagdProfile.CAP_WRITABLE_NAME is in profile.capabilities:
+        if RatbagdProfile.CAP_WRITABLE_NAME in profile.capabilities:
             do something
         """
         return self._capabilities

--- a/tools/ratbagctl.test.in
+++ b/tools/ratbagctl.test.in
@@ -374,6 +374,7 @@ class TestRatbagCtlDPI(TestRatbagCtl):
         { "is_active": false,
           "resolutions": [
             { "xres": 1000, "yres": 1100,
+              "capabilities": [1],
               "is_active": false },
             { "xres": 1300, "yres": 1400,
               "capabilities": [1],

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -1,6 +1,4 @@
-# vim: set expandtab shiftwidth=4 tabstop=4:
-#
-# Copyright 2016 Red Hat, Inc.
+# Copyright 2016-2019 Red Hat, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -428,7 +426,7 @@ class RatbagdProfile(_RatbagdDBus):
         """The capabilities of this profile as an array. Capabilities not
         present on the profile are not in the list. Thus use e.g.
 
-        if RatbagdProfile.CAP_WRITABLE_NAME is in profile.capabilities:
+        if RatbagdProfile.CAP_WRITABLE_NAME in profile.capabilities:
             do something
         """
         return self._get_dbus_property("Capabilities") or []


### PR DESCRIPTION
Minor ratbagd/ratbagc adjustments:
- Bumped copyright to 2019.
- Fixed typo in profile.capabilities description.
- only ratbagd.py: Removed vim helper line since the file has a proper file extension.

Fix missing capability in ratbagctl.test
hidpp20: set dictionary output to raw