### PR TITLE
ratbag-command fixes

### DIFF
--- a/src/libratbag.i
+++ b/src/libratbag.i
@@ -52,6 +52,28 @@
 %typemap(freearg) (unsigned int *rates, size_t nrates) = (unsigned int *resolutions, size_t nres);
 /* END OF custom typemap for handling ratbag_resolution_get_report_rate_list */
 
+/* uintXX_t mapping: Python -> C */
+%typemap(in) uint8_t {
+    $1 = (uint8_t) PyInt_AsLong($input);
+}
+%typemap(in) uint16_t {
+    $1 = (uint16_t) PyInt_AsLong($input);
+}
+%typemap(in) uint32_t {
+    $1 = (uint32_t) PyInt_AsLong($input);
+}
+
+/* uintXX_t mapping: C -> Python */
+%typemap(out) uint8_t {
+    $result = PyInt_FromLong((long) $1);
+}
+%typemap(out) uint16_t {
+    $result = PyInt_FromLong((long) $1);
+}
+%typemap(out) uint32_t {
+    $result = PyInt_FromLong((long) $1);
+}
+
 /*  Parse the header file to generate wrappers */
 %include "libratbag.h"
 %include "libratbag-enums.h"

--- a/tools/ratbagc.py.in
+++ b/tools/ratbagc.py.in
@@ -137,7 +137,7 @@ class Ratbagd(object):
 
     """
 
-    def __init__(self):
+    def __init__(self, apiversion):
         os.environ['LIBRATBAG_DATA_DIR'] = LIBRATBAG_DATA_DIR
         self._ratbag = libratbag.ratbag_create_context(libratbag.interface, None)
         self._devices = {}
@@ -251,13 +251,13 @@ class RatbagdDevice(metaclass=MetaRatbag):
     @property
     def model(self):
         """The unique identifier for this device model."""
-        bus = libratbag.ratbag_device_get_bus(self._device)
+        bus = libratbag.ratbag_device_get_bustype(self._device)
         if not bus:
             return "unknown"
         vid = libratbag.ratbag_device_get_vendor_id(self._device)
         pid = libratbag.ratbag_device_get_product_id(self._device)
         version = libratbag.ratbag_device_get_product_version(self._device)
-        return "{}:{04x}:{04x}:{d}".format(bus, vid, pid, version)
+        return "{}:{:04x}:{:04x}:{:d}".format(bus, vid, pid, version)
 
     @property
     def name(self):


### PR DESCRIPTION
- File "./build/ratbag-command", line 2289, in open_ratbagd
    r = Ratbagd(1)
  TypeError: __init__() takes 1 positional argument but 2 were given
- AttributeError: module 'libratbag' has no attribute
  'ratbag_device_get_bus'
- File "./build/ratbag-command", line 267, in model
    return "{}:{04x}:{04x}:{d}".format(bus, vid, pid, version)
  KeyError: '04x'
- swig/python detected a memory leak of type 'uint32_t *', no destructor
  found.