### PR TITLE
tests: fix data parse for hidpp index

### DIFF
--- a/data/devices/data-parse-test.py
+++ b/data/devices/data-parse-test.py
@@ -138,9 +138,8 @@ def check_section_hidpp10(section):
         pass
 
     try:
-        index = int(section['DeviceIndex'])
-        # 10 is arbitrarily chosen
-        assert(index > 0 and index < 10)
+        index = int(section['DeviceIndex'], 16)
+        assert(index > 0 and index <= 0xff)
     except KeyError:
         pass
 
@@ -175,9 +174,8 @@ def check_section_hidpp20(section):
         assertIn(key, permitted)
 
     try:
-        index = int(section['DeviceIndex'])
-        # 10 is arbitrarily chosen
-        assert(index > 0 and index < 10)
+        index = int(section['DeviceIndex'], 16)
+        assert(index > 0 and index <= 0xff)
     except KeyError:
         pass
 


### PR DESCRIPTION
So I merged #879 without waiting for the CI because it just added a device file but it turns out our test to verify the HID++ index is wrong.