### PR TITLE
Use EditorConfig instead of vim comments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,3 @@
-# vim: set expandtab shiftwidth=2 tabstop=8:
 libratbag_references:
   default_settings: &default_settings
     working_directory: ~/libratbag

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{c,h}]
+indent_style = tab
+tab_width = 8
+trim_trailing_whitespace = true
+
+[{*.{py,py.in},tools/ratbagctl.*.in}]
+indent_style = space
+indent_size = 4
+
+[*.{yml,xsl}]
+indent_style = space
+indent_size = 2

--- a/data/devices/data-parse-test.py
+++ b/data/devices/data-parse-test.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# vim: set expandtab shiftwidth=4 tabstop=4:
 #
 # Copyright © 2017 Red Hat, Inc.
 #

--- a/data/devices/duplicate-check.py
+++ b/data/devices/duplicate-check.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# vim: set expandtab shiftwidth=4 tabstop=4:
 #
 # Copyright © 2018 Red Hat, Inc.
 #

--- a/data/devices/receiver-check.py
+++ b/data/devices/receiver-check.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# vim: set expandtab shiftwidth=4 tabstop=4:
 #
 # Copyright © 2018 Red Hat, Inc.
 #

--- a/tools/merge_ratbagd.py
+++ b/tools/merge_ratbagd.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 #
-# vim: set expandtab shiftwidth=4 tabstop=4:
-#
 # Copyright 2017 Red Hat, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a

--- a/tools/ratbagc.py.in
+++ b/tools/ratbagc.py.in
@@ -1,5 +1,3 @@
-# vim: set expandtab shiftwidth=4 tabstop=4:
-#
 # Copyright 2017-2019 Red Hat, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a

--- a/tools/ratbagctl.devel.in
+++ b/tools/ratbagctl.devel.in
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 #
-# vim: set expandtab shiftwidth=4 tabstop=4:
-#
 # This file is part of libratbag.
 #
 # Copyright 2017 Red Hat, Inc.

--- a/tools/ratbagctl.in.in
+++ b/tools/ratbagctl.in.in
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 #
-# vim: set expandtab shiftwidth=4 tabstop=4:
-#
 # Copyright 2016 Red Hat, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a

--- a/tools/ratbagctl.test.in
+++ b/tools/ratbagctl.test.in
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 #
-# vim: set expandtab shiftwidth=4 tabstop=4:
-#
 # This file is part of libratbag.
 #
 # Copyright 2017 Red Hat, Inc.

--- a/tools/toolbox.py
+++ b/tools/toolbox.py
@@ -1,5 +1,3 @@
-# vim: set expandtab shiftwidth=4 tabstop=4:
-#
 # This file is part of libratbag.
 #
 # Copyright 2017 Red Hat, Inc.


### PR DESCRIPTION
Removed all `# vim:` lines, EditorConfig is available not just for [vim](https://github.com/editorconfig/editorconfig-vim), but basically any IDE: https://editorconfig.org/#download