### PR TITLE
data: add extra id for g602

### DIFF
--- a/data/devices/logitech-g602.device
+++ b/data/devices/logitech-g602.device
@@ -1,7 +1,7 @@
 # Logitech G602 over wireless USB
 [Device]
 Name=Logitech G602
-DeviceMatch=usb:046d:402c
+DeviceMatch=usb:046d:402c;usb:046d:c537
 Driver=hidpp20
 
 [Driver/hidpp20]


### PR DESCRIPTION
Plugging in both of my Logitech G602's (one bought a few years back, one bought yesterday, both bought in Canada) gives:
```
λ › sudo ratbagd --verbose
Initializing libratbag
ratbag debug: New device: Logitech USB Receiver
ratbag debug: Using data directory '/usr/share/libratbag'
ratbag debug: No data file found for 046d:c537
ratbag debug: New device: Logitech USB Receiver
ratbag debug: Using data directory '/usr/share/libratbag'
ratbag debug: No data file found for 046d:c537
```