### PR TITLE
ratbagd: switch Profile.Enabled to Profile.Disabled

### DIFF
--- a/doc/dbus.rst
+++ b/doc/dbus.rst
@@ -206,12 +206,12 @@ org.freedesktop.ratbag1.Profile
         The name of this profile. If the name is the empty string, the
         profile name cannot be changed.
 
-.. attribute:: Enabled
+.. attribute:: Disabled
 
         :type: b
         :flags: read-write, mutable
 
-        True if this is the profile is enabled, false otherwise.
+        True if this is the profile is disabled, false otherwise.
 
         Note that a disabled profile might not have correct bindings, so it's
         a good thing to rebind everything before calling

--- a/ratbagd/ratbagd-profile.c
+++ b/ratbagd/ratbagd-profile.c
@@ -301,27 +301,27 @@ static int ratbagd_profile_set_active(sd_bus_message *m,
 }
 
 static int
-ratbagd_profile_set_enabled(sd_bus *bus,
-			    const char *path,
-			    const char *interface,
-			    const char *property,
-			    sd_bus_message *m,
-			    void *userdata,
-			    sd_bus_error *error)
+ratbagd_profile_set_disabled(sd_bus *bus,
+			     const char *path,
+			     const char *interface,
+			     const char *property,
+			     sd_bus_message *m,
+			     void *userdata,
+			     sd_bus_error *error)
 {
 	struct ratbagd_profile *profile = userdata;
-	int enabled;
+	int disabled;
 	int r;
 
-	CHECK_CALL(sd_bus_message_read(m, "b", &enabled));
+	CHECK_CALL(sd_bus_message_read(m, "b", &disabled));
 
-	r = ratbag_profile_set_enabled(profile->lib_profile, enabled);
+	r = ratbag_profile_set_enabled(profile->lib_profile, !disabled);
 	if (r == 0) {
 		sd_bus *bus = sd_bus_message_get_bus(m);
 		sd_bus_emit_properties_changed(bus,
 					       profile->path,
 					       RATBAGD_NAME_ROOT ".Profile",
-					       "Enabled",
+					       "Disabled",
 					       NULL);
 	}
 
@@ -329,18 +329,18 @@ ratbagd_profile_set_enabled(sd_bus *bus,
 }
 
 static int
-ratbagd_profile_is_enabled(sd_bus *bus,
-			   const char *path,
-			   const char *interface,
-			   const char *property,
-			   sd_bus_message *reply,
-			   void *userdata,
-			   sd_bus_error *error)
+ratbagd_profile_is_disabled(sd_bus *bus,
+			    const char *path,
+			    const char *interface,
+			    const char *property,
+			    sd_bus_message *reply,
+			    void *userdata,
+			    sd_bus_error *error)
 {
 	struct ratbagd_profile *profile = userdata;
-	int enabled = ratbag_profile_is_enabled(profile->lib_profile) != 0;
+	int disabled = !ratbag_profile_is_enabled(profile->lib_profile);
 
-	CHECK_CALL(sd_bus_message_append(reply, "b", enabled));
+	CHECK_CALL(sd_bus_message_append(reply, "b", disabled));
 
 	return 0;
 }
@@ -531,9 +531,9 @@ const sd_bus_vtable ratbagd_profile_vtable[] = {
 				 ratbagd_profile_get_name,
 				 ratbagd_profile_set_name, 0,
 				 SD_BUS_VTABLE_UNPRIVILEGED|SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
-	SD_BUS_WRITABLE_PROPERTY("Enabled", "b",
-				 ratbagd_profile_is_enabled,
-				 ratbagd_profile_set_enabled, 0,
+	SD_BUS_WRITABLE_PROPERTY("Disabled", "b",
+				 ratbagd_profile_is_disabled,
+				 ratbagd_profile_set_disabled, 0,
 				 SD_BUS_VTABLE_UNPRIVILEGED|SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_PROPERTY("Index", "u", NULL, offsetof(struct ratbagd_profile, index), SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_PROPERTY("Capabilities", "au", ratbagd_profile_get_capabilities, 0, SD_BUS_VTABLE_PROPERTY_CONST),

--- a/tools/ratbagc.py.in
+++ b/tools/ratbagc.py.in
@@ -350,16 +350,16 @@ class RatbagdProfile(metaclass=MetaRatbag):
         return self._dirty
 
     @property
-    def enabled(self):
-        """tells if the profile is enabled."""
-        return libratbag.ratbag_profile_is_enabled(self._profile)
+    def disabled(self):
+        """tells if the profile is disabled."""
+        return !libratbag.ratbag_profile_is_enabled(self._profile)
 
     @enabled.setter
-    def enabled(self, enabled):
+    def disabled(self, disabled):
         """Enable/Disable this profile.
 
-        @param enabled The new state, as boolean"""
-        libratbag.ratbag_profile_set_enabled(self._profile, enabled)
+        @param disabled The new state, as boolean"""
+        libratbag.ratbag_profile_set_enabled(self._profile, !disabled)
 
     @property
     def report_rate(self):

--- a/tools/ratbagctl.in.in
+++ b/tools/ratbagctl.in.in
@@ -189,9 +189,10 @@ def print_resolution(d, p, r, level):
 
 def print_profile(d, p, level):
     print(" " * (level - 2) + "Profile {}:{}{}".format(p.index,
-                                                       " (disabled)" if not p.enabled else "",
+                                                       " (disabled)" if p.disabled else "",
                                                        " (active)" if p.is_active else ""))
-    if p.enabled:
+
+    if not p.disabled:
         print(" " * level + "Name: {}".format(p.name or 'n/a'))
         print(" " * level + "Report Rate: {}Hz".format(p.report_rate))
         print(" " * level + "Resolutions:")
@@ -476,13 +477,13 @@ def func_profile_active_set(r, args):
 
 def func_profile_enable(r, args):
     p, d = find_profile(r, args)
-    p.enabled = True
+    p.disabled = False
     commit(d, args)
 
 
 def func_profile_disable(r, args):
     p, d = find_profile(r, args)
-    p.enabled = False
+    p.disabled = True
     commit(d, args)
 
 

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -456,16 +456,16 @@ class RatbagdProfile(_RatbagdDBus):
         return self._dirty
 
     @GObject.Property
-    def enabled(self):
-        """tells if the profile is enabled."""
-        return self._get_dbus_property("Enabled")
+    def disabled(self):
+        """tells if the profile is disabled."""
+        return self._get_dbus_property("Disabled")
 
-    @enabled.setter
-    def enabled(self, enabled):
+    @disabled.setter
+    def disabled(self, disabled):
         """Enable/Disable this profile.
 
-        @param enabled The new state, as boolean"""
-        self._set_dbus_property("Enabled", "b", enabled)
+        @param disabled The new state, as boolean"""
+        self._set_dbus_property("Disabled", "b", disabled)
 
     @GObject.Property
     def report_rate(self):


### PR DESCRIPTION
Rebased single commit from whot/libratbag/wip/custom-vtables against master. Goal is to merge this before #870.
That being said, I think we should not just update the DBus API but also all the drivers, meaning replacing `ratbag_profile_set_enabled` with `ratbag_profile_set_enabled` so we don't have even more  confusion with negations. But for now this should be enough, maybe will do all the driver work in the future.