### PR TITLE
hidpp20: enable 0x8070 (ColorLedEffects) standalone use

### DIFF
--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -404,10 +404,10 @@ hidpp20drv_read_led_8070(struct ratbag_led *led, struct hidpp20drv_data* drv_dat
 			ratbag_led_set_mode_capability(led, RATBAG_LED_BREATHING);
 			break;
 		default:
-			log_bug_libratbag(led->profile->device->ratbag,
-					  "%s: Unknown effect id %d\n",
-					  led->profile->device->name,
-					  ei.effect_id);
+			log_debug(led->profile->device->ratbag,
+				  "%s: Unsupported effect (%d)\n",
+				  led->profile->device->name,
+				  ei.effect_id);
 			break;
 		}
 	}
@@ -479,10 +479,10 @@ hidpp20drv_read_led_8071(struct ratbag_led *led, struct hidpp20drv_data* drv_dat
 			ratbag_led_set_mode_capability(led, RATBAG_LED_BREATHING);
 			break;
 		default:
-			log_bug_libratbag(led->profile->device->ratbag,
-					  "%s: Unknown effect id %d\n",
-					  led->profile->device->name,
-					  ei.effect_id);
+			log_debug(led->profile->device->ratbag,
+				  "%s: Unsupported effect (%d)\n",
+				  led->profile->device->name,
+				  ei.effect_id);
 			break;
 		}
 	}

--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -347,7 +347,11 @@ hidpp20drv_read_led_8070(struct ratbag_led *led, struct hidpp20drv_data* drv_dat
 		profile = &drv_data->profiles->profiles[led->profile->index];
 		h_led = &profile->leds[led->index];
 	} else {
-		hidpp20_color_led_effects_get_zone_effect(drv_data->dev, led->index, h_led);
+		rc = hidpp20_color_led_effects_get_zone_effect(drv_data->dev, led->index, h_led);
+		if (rc) {
+			log_debug(led->profile->device->ratbag,
+				  "Failed to read led settings\n");
+		}
 	}
 
 	switch (h_led->mode) {

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -895,6 +895,7 @@ hidpp20_color_led_effects_get_info(struct hidpp20_device *device,
 		return rc;
 
 	*info = *(struct hidpp20_color_led_info *)msg.msg.parameters;
+	device->led_ext_caps = info->ext_caps;
 
 	return 0;
 }
@@ -1060,6 +1061,10 @@ hidpp20_color_led_effects_get_zone_effect(struct hidpp20_device *device,
 	};
 	struct hidpp20_internal_led *internal_led;
 	int rc;
+
+	/* hidpp20_color_led_effects_get_info() must be called first to set the capabilities */
+	if (!(device->led_ext_caps & HIDPP20_COLOR_LED_INFO_EXT_CAP_HAS_ZONE_EFFECT))
+		return -ENOTSUP;
 
 	feature_index = hidpp_root_get_feature_idx(device,
 						   HIDPP_PAGE_COLOR_LED_EFFECTS);
@@ -3021,6 +3026,8 @@ hidpp20_device_new(const struct hidpp_device *base, unsigned int idx, struct hid
 
 	dev->proto_major = 1;
 	dev->proto_minor = 0;
+
+	dev->led_ext_caps = 0;
 
 	hidpp_get_supported_report_types(&(dev->base), reports, num_reports);
 

--- a/src/hidpp20.h
+++ b/src/hidpp20.h
@@ -65,6 +65,7 @@ struct hidpp20_device {
 	unsigned feature_count;
 	struct hidpp20_feature *feature_list;
 	enum hidpp20_quirk quirk;
+	unsigned int led_ext_caps;
 };
 
 int hidpp20_request_command(struct hidpp20_device *dev, union hidpp20_message *msg);

--- a/src/hidpp20.h
+++ b/src/hidpp20.h
@@ -501,6 +501,18 @@ hidpp20_rgb_effects_get_effect_info(struct hidpp20_device *device,
 				    uint8_t effect_index,
 				    struct hidpp20_rgb_effect_info *info);
 
+struct hidpp20_led;
+
+int
+hidpp20_color_led_effects_set_zone_effect(struct hidpp20_device *device,
+					  uint8_t zone_index,
+					  struct hidpp20_led led);
+
+int
+hidpp20_color_led_effects_get_zone_effect(struct hidpp20_device *device,
+					  uint8_t zone_index,
+					  struct hidpp20_led *led);
+
 enum hidpp20_color_led_location {
 	HIDPP20_COLOR_LED_LOCATION_UNDEFINED = 0,
 	HIDPP20_COLOR_LED_LOCATION_PRIMARY,
@@ -924,6 +936,14 @@ hidpp20_onboard_profiles_allocate_sector(struct hidpp20_profiles *profiles)
 {
 	return zalloc(profiles->sector_size);
 }
+
+void
+hidpp20_onboard_profiles_read_led(struct hidpp20_led *led,
+				  struct hidpp20_internal_led internal_led);
+
+void
+hidpp20_onboard_profiles_write_led(struct hidpp20_internal_led *internal_led,
+				   struct hidpp20_led *led);
 
 /* -------------------------------------------------------------------------- */
 /* 0x8110 - Mouse Button Spy                                                  */


### PR DESCRIPTION
0x8071 is still missing but as of now we don't have any device that
needs it.

Signed-off-by: Filipe Laíns <lains@archlinux.org>