### PR TITLE
Declare a bunch of structs as extern

### DIFF
--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -585,14 +585,14 @@ ratbag_led_set_mode_capability(struct ratbag_led *led,
 }
 
 /* list of all supported drivers */
-struct ratbag_driver etekcity_driver;
-struct ratbag_driver hidpp20_driver;
-struct ratbag_driver hidpp10_driver;
-struct ratbag_driver logitech_g300_driver;
-struct ratbag_driver logitech_g600_driver;
-struct ratbag_driver roccat_driver;
-struct ratbag_driver gskill_driver;
-struct ratbag_driver steelseries_driver;
+extern struct ratbag_driver etekcity_driver;
+extern struct ratbag_driver hidpp20_driver;
+extern struct ratbag_driver hidpp10_driver;
+extern struct ratbag_driver logitech_g300_driver;
+extern struct ratbag_driver logitech_g600_driver;
+extern struct ratbag_driver roccat_driver;
+extern struct ratbag_driver gskill_driver;
+extern struct ratbag_driver steelseries_driver;
 
 struct ratbag_device*
 ratbag_device_new(struct ratbag *ratbag, struct udev_device *udev_device,

--- a/src/libratbag-test.c
+++ b/src/libratbag-test.c
@@ -31,7 +31,7 @@
 #include "libratbag-util.h"
 #include "libratbag-test.h"
 
-struct ratbag_driver test_driver;
+extern struct ratbag_driver test_driver;
 
 static inline void
 ratbag_register_test_drivers(struct ratbag *ratbag)

--- a/tools/shared.h
+++ b/tools/shared.h
@@ -88,4 +88,4 @@ str_to_special_action(const char *str);
 struct ratbag_device *
 ratbag_cmd_open_device(struct ratbag *ratbag, const char *path);
 
-const struct ratbag_interface interface;
+extern const struct ratbag_interface interface;


### PR DESCRIPTION
gcc 10 complains about multiple definitions of these when linking.

```
/usr/bin/ld: libhidpp.a(src_hidpp-generic.c.o):/builddir/build/BUILD/libratbag-0.12/x86_64-redhat-linux-gnu/../src/libratbag-private.h:588:
multiple definition of `etekcity_driver';
libutil.a(src_libratbag-util.c.o):/builddir/build/BUILD/libratbag-0.12/x86_64-redhat-linux-gnu/../src/libratbag-private.h:588:
first defined here
```

Special case here is the test_driver struct, without the extern gcc seems to
think it's a new struct with all zeros, causing a segfault when we then try to
strcmp the test driver name.