### PR TITLE
update and merge logitech g9x

### DIFF
--- a/data/devices/logitech-g9x-Original.device
+++ b/data/devices/logitech-g9x-Original.device
@@ -4,8 +4,10 @@
 Name=G9x [Original]
 DeviceMatch=usb:046d:c066
 Driver=hidpp10
+LedTypes=dpi
 
 [Driver/hidpp10]
 DpiRange=0:5700@23.53
 ProfileType=G500
 Profiles=5
+Leds=1

--- a/data/devices/logitech-g9x-Original.device
+++ b/data/devices/logitech-g9x-Original.device
@@ -7,7 +7,7 @@ Driver=hidpp10
 LedTypes=dpi
 
 [Driver/hidpp10]
-DpiRange=0:5700@23.53
+DpiRange=200:5700@50
 ProfileType=G500
 Profiles=5
 Leds=1


### PR DESCRIPTION
Merged G9x with Call of Duty edition.
Updated with DPI LED
also updated min DPI (200) and increments (50), although I can't confirm if CoD edition is the same.
updated support links