### PR TITLE
Misc fixes for HID++ 2.0 keyboards

### DIFF
--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -1482,7 +1482,6 @@ hidpp20drv_commit(struct ratbag_device *device)
 	struct ratbag_led *led;
 	struct ratbag_resolution *resolution;
 	int rc;
-	unsigned int dpi_index = 0;
 
 	list_for_each(profile, &device->profiles, link) {
 		if (!profile->dirty)
@@ -1544,10 +1543,9 @@ hidpp20drv_commit(struct ratbag_device *device)
 			if (profile->is_active) {
 				ratbag_profile_for_each_resolution(profile, resolution) {
 					if (resolution->is_active)
-						dpi_index = resolution->index;
+						hidpp20_onboard_profiles_set_current_dpi_index(drv_data->dev,
+											       resolution->index);
 				}
-				hidpp20_onboard_profiles_set_current_dpi_index(drv_data->dev,
-									       dpi_index);
 			}
 		}
 	}

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -2664,12 +2664,20 @@ hidpp20_onboard_profiles_read_led(struct hidpp20_led *led,
 		if (brightness == 0)
 			brightness = 100;
 		break;
+	case HIDPP20_LED_STARLIGHT:
+		led->color = internal_led.effect.starlight.color_sky;
+		led->extra_color = internal_led.effect.starlight.color_star;
+		break;
 	case HIDPP20_LED_BREATHING:
 		period = hidpp_be_u16_to_cpu(internal_led.effect.breath.period_or_speed);
 		brightness = internal_led.effect.breath.intensity;
 		if (brightness == 0)
 			brightness = 100;
 		led->color = internal_led.effect.breath.color;
+		break;
+	case HIDPP20_LED_RIPPLE:
+		period = hidpp_be_u16_to_cpu(internal_led.effect.breath.period_or_speed);
+		led->color = internal_led.effect.ripple.color;
 		break;
 	case HIDPP20_LED_ON:
 		led->color = internal_led.effect.fixed.color;
@@ -2870,6 +2878,10 @@ hidpp20_onboard_profiles_write_led(struct hidpp20_internal_led *internal_led,
 		else
 			internal_led->effect.cycle.intensity = 0;
 		break;
+	case HIDPP20_LED_STARLIGHT:
+		internal_led->effect.starlight.color_sky = led->color;
+		internal_led->effect.starlight.color_star = led->extra_color;
+		break;
 	case HIDPP20_LED_BREATHING:
 		internal_led->effect.breath.color.red = led->color.red;
 		internal_led->effect.breath.color.blue = led->color.blue;
@@ -2879,6 +2891,10 @@ hidpp20_onboard_profiles_write_led(struct hidpp20_internal_led *internal_led,
 			internal_led->effect.breath.intensity = brightness;
 		else
 			internal_led->effect.breath.intensity = 0;
+		break;
+	case HIDPP20_LED_RIPPLE:
+		internal_led->effect.ripple.color = led->color;
+		internal_led->effect.ripple.period = hidpp_cpu_to_be_u16(period);
 		break;
 	case HIDPP20_LED_ON:
 		internal_led->effect.fixed.color.red = led->color.red;

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -2532,6 +2532,9 @@ hidpp20_onboard_profiles_write_dict(struct hidpp20_device *device,
 						   sector_size,
 						   data,
 						   true);
+	if (rc)
+		hidpp_log_error(&device->base, "failed to write profile dictionary\n");
+
 	return rc;
 }
 
@@ -2930,8 +2933,10 @@ hidpp20_onboard_profiles_write_profile(struct hidpp20_device *device,
 	memcpy(pdata->profile.name.txt, profile->name, sizeof(profile->name));
 
 	rc = hidpp20_onboard_profiles_write_sector(device, sector, sector_size, data, true);
-	if (rc < 0)
+	if (rc < 0) {
+		hidpp_log_error(&device->base, "failed to write profile\n");
 		return rc;
+	}
 
 	return 0;
 }

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -2572,6 +2572,7 @@ hidpp20_buttons_to_cpu(struct hidpp20_device *device,
 			break;
 		case HIDPP20_BUTTON_SPECIAL:
 			button->special.special = b->special.special;
+			button->special.profile = b->special.profile;
 			break;
 		case HIDPP20_BUTTON_MACRO:
 			if (profile->macros[i]) {
@@ -2631,6 +2632,7 @@ hidpp20_buttons_from_cpu(struct hidpp20_profile *profile,
 			break;
 		case HIDPP20_BUTTON_SPECIAL:
 			button->special.special = b->special.special;
+			button->special.profile = b->special.profile;
 			break;
 		case HIDPP20_BUTTON_DISABLED:
 			break;

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -2684,6 +2684,9 @@ hidpp20_onboard_profiles_read_led(struct hidpp20_led *led,
 		break;
 	case HIDPP20_LED_OFF:
 		break;
+	default:
+		memcpy(led->original, &internal_led, sizeof(internal_led));
+		break;
 	}
 
 	led->period = period;
@@ -2899,6 +2902,9 @@ hidpp20_onboard_profiles_write_led(struct hidpp20_internal_led *internal_led,
 		internal_led->effect.fixed.effect = 0;
 		break;
 	case HIDPP20_LED_OFF:
+		break;
+	default:
+		memcpy(internal_led, led->original, sizeof(*internal_led));
 		break;
 	}
 }

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -2883,9 +2883,7 @@ hidpp20_onboard_profiles_write_led(struct hidpp20_internal_led *internal_led,
 		internal_led->effect.starlight.color_star = led->extra_color;
 		break;
 	case HIDPP20_LED_BREATHING:
-		internal_led->effect.breath.color.red = led->color.red;
-		internal_led->effect.breath.color.blue = led->color.blue;
-		internal_led->effect.breath.color.green = led->color.green;
+		internal_led->effect.breath.color = led->color;
 		internal_led->effect.breath.period_or_speed = hidpp_cpu_to_be_u16(period);
 		if (brightness < 100)
 			internal_led->effect.breath.intensity = brightness;
@@ -2897,9 +2895,7 @@ hidpp20_onboard_profiles_write_led(struct hidpp20_internal_led *internal_led,
 		internal_led->effect.ripple.period = hidpp_cpu_to_be_u16(period);
 		break;
 	case HIDPP20_LED_ON:
-		internal_led->effect.fixed.color.red = led->color.red;
-		internal_led->effect.fixed.color.blue = led->color.blue;
-		internal_led->effect.fixed.color.green = led->color.green;
+		internal_led->effect.fixed.color = led->color;
 		internal_led->effect.fixed.effect = 0;
 		break;
 	case HIDPP20_LED_OFF:

--- a/src/hidpp20.h
+++ b/src/hidpp20.h
@@ -789,6 +789,7 @@ struct hidpp20_led {
 	struct hidpp20_color extra_color;
 	uint16_t period;
 	percent_t brightness;
+	uint8_t original[sizeof(struct hidpp20_internal_led)];
 };
 
 #define HIDPP20_MACRO_NOOP			0x01

--- a/src/hidpp20.h
+++ b/src/hidpp20.h
@@ -719,7 +719,11 @@ enum hidpp20_led_mode {
 	HIDPP20_LED_OFF = 0x00,
 	HIDPP20_LED_ON = 0x01,
 	HIDPP20_LED_CYCLE = 0x03,
+	HIDPP20_LED_COLOR_WAVE = 0x04,
+	HIDPP20_LED_STARLIGHT = 0x05,
 	HIDPP20_LED_BREATHING = 0x0a,
+	HIDPP20_LED_RIPPLE = 0x0b,
+	HIDPP20_LED_CUSTOM = 0x0c,
 };
 
 enum hidpp20_led_waveform {
@@ -744,25 +748,45 @@ struct hidpp20_internal_led {
 			uint16_t period_or_speed; /* period in ms, speed is device dependent */
 			uint8_t intensity; /* 1 - 100 percent, 0 means 100 */
 		} __attribute__((packed)) cycle;
+		struct hidpp20_led_starlight {
+			struct hidpp20_color color_sky;
+			struct hidpp20_color color_star;
+		} __attribute__((packed)) starlight;
 		struct hidpp20_led_breath {
 			struct hidpp20_color color;
 			uint16_t period_or_speed; /* period in ms, speed is device dependent */
 			uint8_t waveform; /* enum hidpp20_led_waveform */
 			uint8_t intensity; /* 1 - 100 percent, 0 means 100 */
 		} __attribute__((packed)) breath;
+		struct hidpp20_led_ripple {
+			struct hidpp20_color color;
+			uint8_t reserved;
+			uint16_t period;
+		} __attribute__((packed)) ripple;
+		struct hidpp20_led_custom {
+			uint8_t slot;
+			uint16_t init_frame;
+			uint16_t lenght;
+			uint16_t frame_period;
+			uint8_t intensity;
+		} __attribute__((packed)) custom;
 		uint8_t padding[10];
 	} __attribute__((packed)) effect;
 };
 _Static_assert(sizeof(struct hidpp20_led_fixed) == 4, "Invalid size");
 _Static_assert(sizeof(struct hidpp20_led_cycle) == 8, "Invalid size");
+_Static_assert(sizeof(struct hidpp20_led_starlight) == 6, "Invalid size");
 _Static_assert(sizeof(struct hidpp20_led_breath) == 7, "Invalid size");
 _Static_assert(sizeof(struct hidpp20_internal_led) == 11, "Invalid size");
+_Static_assert(sizeof(struct hidpp20_led_ripple) == 6, "Invalid size");
+_Static_assert(sizeof(struct hidpp20_led_custom) == 8, "Invalid size");
 
 typedef uint8_t percent_t;
 
 struct hidpp20_led {
 	enum hidpp20_led_mode mode;
 	struct hidpp20_color color;
+	struct hidpp20_color extra_color;
 	uint16_t period;
 	percent_t brightness;
 };

--- a/src/hidpp20.h
+++ b/src/hidpp20.h
@@ -618,6 +618,8 @@ union hidpp20_button_binding {
 	struct {
 		uint8_t type; /* HIDPP20_BUTTON_SPECIAL */
 		uint8_t special;
+		uint8_t reserved;
+		uint8_t profile;
 	} __attribute__((packed)) special;
 	struct {
 		uint8_t type; /* HIDPP20_BUTTON_MACRO */


### PR DESCRIPTION
Now we should be ready for a new release. This fixes the error described in #903 and makes sure we don't overwrite the effects saved in the keyboard if they're not supported.