### PR TITLE
data: add support for Logitech G413 keyboard

### DIFF
--- a/data/devices/logitech-g413.device
+++ b/data/devices/logitech-g413.device
@@ -1,0 +1,5 @@
+[Device]
+DeviceMatch=usb:046d:c33a
+DeviceType=keyboard
+Driver=hidpp20
+Name=Logitech G413


### PR DESCRIPTION
I visited a friend with a G413 (basically a G513 without RGB), and checked the USB-ID. I can't tell you if it works, so I don't know if this should even be merged, just wanted to note it.