### PR TITLE
circleci: add diffutils dependency for fedora

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 libratbag_references:
   build_dependencies: &build_dependencies
     FEDORA_DEP_BUILD: gcc gcc-c++ meson dbus-daemon glib2-devel json-glib-devel libevdev-devel libudev-devel libunistring-devel python3-devel python3-evdev swig
-    FEDORA_DEP_TEST: check-devel python3-gobject python3-lxml valgrind
+    FEDORA_DEP_TEST: check-devel python3-gobject python3-lxml valgrind diffutils
     FEDORA_DEP_DOC: python3-sphinx python3-sphinx_rtd_theme
     UBUNTU_DEP_BUILD: gcc g++ meson pkg-config systemd libevdev-dev libglib2.0-dev libjson-glib-dev libsystemd-dev libudev-dev libunistring-dev python3-dev python3-evdev swig
     UBUNTU_DEP_TEST: check python3-gi python3-lxml valgrind


### PR DESCRIPTION
I noticed that #926 failed (https://app.circleci.com/jobs/github/stephanlachnit/libratbag/286), because `diff` is missing. I checked it and it looks like it went lost in af30fc28cd51534ea5043b18a73ec66a9eee6799, after it was added in f6546b3222dc7e888d5e88c00e55136716eddfab.