### PR TITLE
added another variation

### DIFF
--- a/data/devices/logitech-MX-Anywhere2.device
+++ b/data/devices/logitech-MX-Anywhere2.device
@@ -1,4 +1,4 @@
 [Device]
 Name=Logitech MX Anywhere 2
-DeviceMatch=usb:046d:404a;bluetooth:046d:b013;bluetooth:046d:b018
+DeviceMatch=usb:046d:404a;bluetooth:046d:b013;bluetooth:046d:b018;bluetooth:046d:b01f
 Driver=hidpp20


### PR DESCRIPTION
added another variation of MX Anywhere 2. (Meteoric color - not sure if this matters)
$ sudo dmesg
[   54.034703] input: MX Anywhere 2 Keyboard as /devices/virtual/misc/uhid/0005:046D:B01F.0002/input/input23
[   54.034879] input: MX Anywhere 2 Mouse as /devices/virtual/misc/uhid/0005:046D:B01F.0002/input/input24
[   54.035005] hid-generic 0005:046D:B01F.0002: input,hidraw0: BLUETOOTH HID v0.03 Keyboard [MX Anywhere 2] on 48:45:20:f3:ca:d1