### PR TITLE
Use macro in favor of the deprecated key button type in HID++ 1.0

### DIFF
--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -575,7 +575,7 @@ hidpp20drv_update_button_8100(struct ratbag_button *button)
 		code = ratbag_hidraw_get_keyboard_usage_from_keycode(device, key);
 		if (code == 0) {
 			subtype = HIDPP20_BUTTON_HID_TYPE_CONSUMER_CONTROL;
-			code = ratbag_hidraw_get_consumer_usage_from_keycode(device, action->action.key.key);
+			code = ratbag_hidraw_get_consumer_usage_from_keycode(device, key);
 			if (code == 0)
 				return -EINVAL;
 		}


### PR DESCRIPTION
Should fix #900

I also sneaked in a fix for HID++ 2.0.