### PR TITLE
circleci: bump to use ubuntu 19.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,10 +209,10 @@ jobs:
     <<: *fedora_settings
     docker:
       - image: fedora:31
-  ubuntu_19_04:
+  ubuntu_19_10:
     <<: *ubuntu_settings
     docker:
-      - image: ubuntu:19.04
+      - image: ubuntu:19.10
   doc_build:
     <<: *doc_build
     docker:
@@ -228,7 +228,7 @@ workflows:
   compile_and_test:
     jobs:
       - fedora_cache
-      - ubuntu_19_04
+      - ubuntu_19_10
       - fedora_31:
           requires:
             - fedora_cache


### PR DESCRIPTION
The 19.04 repos give us 404s, so let's update to the next version.