### PR TITLE
libratbag-data: add missing header entry

### DIFF
--- a/src/libratbag-data.h
+++ b/src/libratbag-data.h
@@ -80,6 +80,9 @@ ratbag_device_data_hidpp10_get_led_count(const struct ratbag_device_data *data);
 int
 ratbag_device_data_hidpp20_get_index(const struct ratbag_device_data *data);
 
+int
+ratbag_device_data_hidpp20_get_led_count(const struct ratbag_device_data *data);
+
 enum hidpp20_quirk
 ratbag_device_data_hidpp20_get_quirk(const struct ratbag_device_data *data);
 


### PR DESCRIPTION
Dicovered in #957

Signed-off-by: Filipe Laíns <lains@archlinux.org>