### PR TITLE
Fix enumeration of Logitech G5 (2007)

### DIFF
--- a/data/devices/logitech-g5-2007.device
+++ b/data/devices/logitech-g5-2007.device
@@ -7,3 +7,4 @@ Driver=hidpp10
 [Driver/hidpp10]
 DpiList=400;800;1600;2000
 Profiles=1
+ProfileType=G500

--- a/src/hidpp10.c
+++ b/src/hidpp10.c
@@ -807,8 +807,12 @@ hidpp10_get_current_profile(struct hidpp10_device *dev, uint8_t *current_profile
 		      __CMD_PROFILE);
 
 	res = hidpp10_request_command(dev, &profile);
-	if (res)
-		return res;
+	if (res) {
+		/* Profiles not supported */
+		hidpp_log_debug(&dev->base, "Profiles not supported\n");
+		*current_profile = 0;
+		return 0;
+	}
 
 	type = profile.msg.parameters[0];
 	page = profile.msg.parameters[1];


### PR DESCRIPTION
Before this patch, ratbagd would abort initialization of the device because
no profiles are returned.

Once that was handled more gracefully, ratbagd would fail because it doesn't
read the DpiList from its own config file, as no ProfileType is specified.
Specifying G500 as the closest match.