### PR TITLE
hidpp20: allow setting a default report rate

### DIFF
--- a/data/devices/data-parse-test.py
+++ b/data/devices/data-parse-test.py
@@ -168,7 +168,7 @@ def check_section_hidpp10(section):
 
 
 def check_section_hidpp20(section):
-    permitted = ['DeviceIndex', 'Leds', 'Quirk']
+    permitted = ['DeviceIndex', 'Leds', 'ReportRate', 'Quirk']
     for key in section.keys():
         assertIn(key, permitted)
 

--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -957,7 +957,7 @@ hidpp20drv_read_resolution_dpi(struct ratbag_profile *profile)
 
 	if (drv_data->capabilities & HIDPP_CAP_ADJUSTIBLE_REPORT_RATE_8060) {
 		rc = hidpp20drv_read_report_rate_8060(device);
-		if (rc < 0)
+		if (rc < 0 && drv_data->report_rates[0] == 0)
 			return rc;
 
 		ratbag_profile_set_report_rate_list(profile,
@@ -1641,6 +1641,8 @@ hidpp20drv_init_device(struct ratbag_device *device,
 	num = ratbag_device_data_hidpp20_get_led_count(device->data);
 	if (num >= 0)
 		drv_data->num_leds = num;
+
+	drv_data->report_rates[0] = ratbag_device_data_hidpp20_get_report_rate(device->data);;
 
 	ratbag_device_init_profiles(device,
 				    drv_data->num_profiles,

--- a/src/libratbag-data.c
+++ b/src/libratbag-data.c
@@ -57,6 +57,7 @@ struct data_hidpp20 {
 	int index;
 	enum hidpp20_quirk quirk;
 	int led_count;
+	int report_rate;
 };
 
 struct data_hidpp10 {
@@ -170,6 +171,13 @@ init_data_hidpp20(struct ratbag *ratbag,
 	num = g_key_file_get_integer(keyfile, group, "Leds", &error);
 	if (!error)
 		data->hidpp20.led_count = num;
+	if (error)
+		g_error_free(error);
+
+	error = NULL;
+	num = g_key_file_get_integer(keyfile, group, "ReportRate", &error);
+	if (num > 0 || !error)
+		data->hidpp20.report_rate = num;
 	if (error)
 		g_error_free(error);
 
@@ -591,6 +599,14 @@ ratbag_device_data_hidpp20_get_led_count(const struct ratbag_device_data *data)
 	assert(data->drivertype == HIDPP20);
 
 	return data->hidpp20.led_count;
+}
+
+int
+ratbag_device_data_hidpp20_get_report_rate(const struct ratbag_device_data *data)
+{
+	assert(data->drivertype == HIDPP20);
+
+	return data->hidpp20.report_rate;
 }
 
 enum hidpp20_quirk

--- a/src/libratbag-data.h
+++ b/src/libratbag-data.h
@@ -83,6 +83,9 @@ ratbag_device_data_hidpp20_get_index(const struct ratbag_device_data *data);
 int
 ratbag_device_data_hidpp20_get_led_count(const struct ratbag_device_data *data);
 
+int
+ratbag_device_data_hidpp20_get_report_rate(const struct ratbag_device_data *data);
+
 enum hidpp20_quirk
 ratbag_device_data_hidpp20_get_quirk(const struct ratbag_device_data *data);
 


### PR DESCRIPTION
In case we can't get the report rate value from the device, allow
setting in the device file.

Signed-off-by: Filipe Laíns <lains@archlinux.org>