### PR TITLE
github: add device info to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,6 +13,12 @@ assignees: ''
 - Distribution: 
 - Kernel version (ex. `uname -srmo`): `KERNEL VERSION HERE`
 
+Device info (if applicable):
+```
+$ ratbagctl <device> info
+OUTPUT HERE
+```
+
 **Describe the bug**
 A clear and concise description of what the bug is.
 


### PR DESCRIPTION
Signed-off-by: Filipe Laíns <lains@archlinux.org>