### PR TITLE
meson: make finding python more robust

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -538,12 +538,28 @@ configure_file(input : 'dbus/org.freedesktop.ratbag1.conf.in',
 
 #### tools ####
 
+# This is a special idiomatic construct in meson to get a fast dependency that
+# doesn't exist and isn't logged as "not found".
+dep_python3 = dependency('', required : false)
 if meson.version().version_compare('<0.48.0')
   python = import('python3')
   py3 = python.find_python()
 else
   pymod = import('python')
   py3 = pymod.find_installation()
+  if meson.version().version_compare('>= 0.53.0')
+    dep_python3 = py3.dependency(embed : true)
+  endif
+endif
+
+# From python 3.8 we neeed python3-embed
+py_version = py3.language_version()
+embed = py_version.version_compare('>= 3.8') ? '-embed' : ''
+if not dep_python3.found()
+  dep_python3 = dependency('python-@0@@1@'.format(py_version, embed), required : false)
+  if not dep_python3.found()
+    dep_python3 = dependency('python3@0@'.format(embed))
+  endif
 endif
 
 config_ratbagctl = configuration_data()
@@ -606,12 +622,6 @@ swig_gen = generator(
                 '-I' + join_paths(meson.source_root(), 'tools'),
                 '@INPUT@'],
 )
-
-# From python 3.8 we neeed python3-embed
-dep_python3 = dependency('python3-embed', required: false)
-if not dep_python3.found()
-	dep_python3 = dependency('python3')
-endif
 
 wrapper_deps = [
     dep_python3,


### PR DESCRIPTION
This code assumes that there is a python3 or python3-embed pkg-config
file on the system, which may or may not be true. On Gentoo for example,
only python-X.Y pkg-config files are available and this will fail to
build.

This makes use of the new py_installation.dependency(embed : true) if
possible, and falls back to trying to find a python that matches the
version of python found by the python3 or python module.