### PR TITLE
ci: arch: install git

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ libratbag_references:
     FEDORA_DEP_DOC: python3-sphinx python3-sphinx_rtd_theme
     UBUNTU_DEP_BUILD: gcc g++ meson pkg-config systemd libevdev-dev libglib2.0-dev libjson-glib-dev libsystemd-dev libudev-dev libunistring-dev python3-dev python3-evdev swig
     UBUNTU_DEP_TEST: check python3-gi python3-lxml valgrind
-    ARCH_DEP_BUILD: meson swig glib2 libevdev libudev.so libunistring json-glib python python-evdev python-gobject
+    ARCH_DEP_BUILD: git meson swig glib2 libevdev libudev.so libunistring json-glib python python-evdev python-gobject
     ARCH_DEP_TEST: check valgrind python-lxml
   default_settings: &default_settings
     working_directory: ~/libratbag


### PR DESCRIPTION
CircleCI complains:

Either git or ssh (required by git to clone through SSH) is not installed in the
image. Falling back to CircleCI's native git client but the behavior may be
different from official git. If this is an issue, please use an image that has
official git and ssh installed.

Using arch's git client would be better.

Signed-off-by: Filipe Laíns <lains@archlinux.org>