### PR TITLE
data: add additional USB-ID for the M720 Thriatlon

### DIFF
--- a/data/devices/logitech-M720.device
+++ b/data/devices/logitech-M720.device
@@ -1,4 +1,4 @@
 [Device]
 Name=Logitech M720
-DeviceMatch=usb:046d:405e
+DeviceMatch=usb:046d:405e;bluetooth:046d:b015
 Driver=hidpp20


### PR DESCRIPTION
Closes #1012.