### PR TITLE
remove unused string format to fix flake8

### DIFF
--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -193,7 +193,7 @@ class _RatbagdDBus(GObject.GObject):
         # args to .Set are "interface name", "function name",  value-variant
         val = GLib.Variant("{}".format(type), value)
         if readwrite:
-            pval = GLib.Variant("(ssv)".format(type), (self._interface, property, val))
+            pval = GLib.Variant("(ssv)", (self._interface, property, val))
             self._proxy.call_sync("org.freedesktop.DBus.Properties.Set",
                                   pval, Gio.DBusCallFlags.NO_AUTO_START,
                                   2000, None)


### PR DESCRIPTION
Same as https://github.com/libratbag/piper/commit/39d6cec5004f95574483b09d4a9ae0682db76cbe from https://github.com/libratbag/piper/pull/549.
Closes #1017.