### PR TITLE
driver-hidpp10: fix segfault when committing unnamed profiles

### DIFF
--- a/src/driver-hidpp10.c
+++ b/src/driver-hidpp10.c
@@ -573,7 +573,8 @@ hidpp10drv_commit(struct ratbag_device *device)
 			return rc;
 
 		p.enabled = profile->is_enabled;
-		strncpy_safe((char*)p.name, profile->name, 24);
+		if (profile->name != NULL)
+			strncpy_safe((char*)p.name, profile->name, 24);
 
 		ratbag_profile_for_each_resolution(profile, resolution) {
 			p.dpi_modes[resolution->index].xres = resolution->dpi_x;


### PR DESCRIPTION
`profile->name` is a null pointer with my G500s, which causes the strncpy to segfault.

Fixes #1031  