### PR TITLE
libratbag-private.h: Ensure that _GNU_SOURCE is defined early enough

### DIFF
--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include "config.h"
 #include <linux/input.h>
 #include <stdint.h>
 #include <stdbool.h>


### PR DESCRIPTION
When compiling on Ubuntu 20.04 with GCC 9.3.0 and glibc 2.31, I get:

In file included from ../src/libratbag-private.h:32,
                 from ../src/driver-sinowealth.c:24:
../src/libratbag-util.h: In function ‘asprintf_safe’:
../src/libratbag-util.h:154:7: warning: implicit declaration of function ‘vasprintf’; did you mean ‘vsprintf’? [-Wimplicit-function-declaration]
  154 |  rc = vasprintf(&result, fmt, args);
      |       ^~~~~~~~~
      |       vsprintf

This appears to be because <features.h> is being included by another
header before config.h has been included. If _GNU_SOURCE has not been
defined at that point, then the other macros that control whether
vasprintf is declared are not set correctly.

Include config.h right at the top of libratbag-private.h to ensure
that _GNU_SOURCE is defined before any system headers are included to
avoid this problem.