### PR TITLE
Firmware version

### DIFF
--- a/doc/dbus.rst
+++ b/doc/dbus.rst
@@ -151,6 +151,20 @@ known to ratbagd.
         Vendor or product IDs of 0 are valid IDs (e.g. used used by test
         devices).
 
+.. attribute:: FirmwareMajor
+
+        :type: i
+        :flags: read-only, constant
+
+        The device's firmware major version.
+
+.. attribute:: FirmwareMinor
+
+        :type: i
+        :flags: read-only, constant
+
+        The device's firmware minor version.
+
 .. attribute:: Name
 
         :type: s

--- a/ratbagd/ratbagd-device.c
+++ b/ratbagd/ratbagd-device.c
@@ -220,9 +220,45 @@ ratbag_device_get_model(sd_bus *bus,
 	return sd_bus_message_append(reply, "s", model);
 }
 
+static int
+ratbag_device_get_firmware_major(sd_bus *bus,
+					  const char *path,
+					  const char *interface,
+					  const char *property,
+					  sd_bus_message *reply,
+					  void *userdata,
+					  sd_bus_error *error)
+{
+	struct ratbagd_device *device = userdata;
+	int version = ratbag_device_get_firmware_major_version(device->lib_device);
+
+	CHECK_CALL(sd_bus_message_append(reply, "i", version));
+
+	return 0;
+}
+
+static int
+ratbag_device_get_firmware_minor(sd_bus *bus,
+					  const char *path,
+					  const char *interface,
+					  const char *property,
+					  sd_bus_message *reply,
+					  void *userdata,
+					  sd_bus_error *error)
+{
+	struct ratbagd_device *device = userdata;
+	int version = ratbag_device_get_firmware_minor_version(device->lib_device);
+
+	CHECK_CALL(sd_bus_message_append(reply, "i", version));
+
+	return 0;
+}
+
 const sd_bus_vtable ratbagd_device_vtable[] = {
 	SD_BUS_VTABLE_START(0),
 	SD_BUS_PROPERTY("Model", "s", ratbag_device_get_model, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+	SD_BUS_PROPERTY("FirmwareMajor", "i", ratbag_device_get_firmware_major, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+	SD_BUS_PROPERTY("FirmwareMinor", "i", ratbag_device_get_firmware_minor, 0, SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_PROPERTY("Name", "s", ratbagd_device_get_device_name, 0, SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_PROPERTY("Profiles", "ao", ratbagd_device_get_profiles, 0, SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_METHOD("Commit", "", "u", ratbagd_device_commit, SD_BUS_VTABLE_UNPRIVILEGED),

--- a/src/driver-steelseries.c
+++ b/src/driver-steelseries.c
@@ -78,11 +78,6 @@
 #define STEELSERIES_BUTTON_KBD			0x51
 #define STEELSERIES_BUTTON_CONSUMER		0x61
 
-struct steelseries_data {
-	int firmware_major;
-	int firmware_minor;
-};
-
 struct steelseries_point {
 	struct list link;
 
@@ -177,7 +172,6 @@ button_defaults_for_layout(struct ratbag_button *button, int button_count)
 static int
 steelseries_get_firmware_version(struct ratbag_device *device)
 {
-	struct steelseries_data *drv_data = device->drv_data;
 	int device_version = ratbag_device_data_steelseries_get_device_version(device->data);
 	size_t buf_len = STEELSERIES_REPORT_SIZE;
 	uint8_t buf[STEELSERIES_REPORT_SIZE] = {0};
@@ -199,8 +193,8 @@ steelseries_get_firmware_version(struct ratbag_device *device)
 	if (ret < 0)
 		return ret;
 
-	drv_data->firmware_major = buf[1];
-	drv_data->firmware_minor = buf[0];
+	device->firmware_major = buf[1];
+	device->firmware_minor = buf[0];
 
 	return 0;
 }
@@ -265,7 +259,6 @@ steelseries_read_settings(struct ratbag_device *device)
 static int
 steelseries_probe(struct ratbag_device *device)
 {
-	struct steelseries_data *drv_data = NULL;
 	struct ratbag_profile *profile = NULL;
 	struct ratbag_resolution *resolution;
 	struct ratbag_button *button;
@@ -363,14 +356,11 @@ steelseries_probe(struct ratbag_device *device)
 		}
 	}
 
-	drv_data = zalloc(sizeof(*drv_data));
-	ratbag_set_drv_data(device, drv_data);
-
 	rc = steelseries_get_firmware_version(device);
 	if(rc == 0)
 		log_debug(device->ratbag, "SteelSeries firmware version %d.%d\n",
-			drv_data->firmware_major,
-			drv_data->firmware_minor);
+			device->firmware_major,
+			device->firmware_minor);
 
 	steelseries_read_settings(device);
 
@@ -960,7 +950,6 @@ steelseries_remove(struct ratbag_device *device)
 {
 	ratbag_close_hidraw_index(device, 0);
 	ratbag_close_hidraw_index(device, 1);
-	free(ratbag_get_drv_data(device));
 }
 
 struct ratbag_driver steelseries_driver = {

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -147,6 +147,9 @@ struct ratbag_device {
 	unsigned num_buttons;
 	unsigned num_leds;
 
+	int firmware_major;
+	int firmware_minor;
+
 	void *drv_data;
 
 	struct list link;

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -545,6 +545,18 @@ ratbag_device_get_product_id(const struct ratbag_device *device)
 	return device->ids.product;
 }
 
+LIBRATBAG_EXPORT int32_t
+ratbag_device_get_firmware_major_version(const struct ratbag_device *device)
+{
+	return device->firmware_major;
+}
+
+LIBRATBAG_EXPORT int32_t
+ratbag_device_get_firmware_minor_version(const struct ratbag_device *device)
+{
+	return device->firmware_minor;
+}
+
 LIBRATBAG_EXPORT uint32_t
 ratbag_device_get_product_version(const struct ratbag_device *device)
 {

--- a/src/libratbag.h
+++ b/src/libratbag.h
@@ -425,6 +425,24 @@ ratbag_device_get_user_data(const struct ratbag_device *device);
  * @ingroup device
  *
  * @param device A previously initialized ratbag device
+ * @return The firmware major version of the device.
+ */
+int32_t
+ratbag_device_get_firmware_major_version(const struct ratbag_device *device);
+
+/**
+ * @ingroup device
+ *
+ * @param device A previously initialized ratbag device
+ * @return The firmware minor version of the device.
+ */
+int32_t
+ratbag_device_get_firmware_minor_version(const struct ratbag_device *device);
+
+/**
+ * @ingroup device
+ *
+ * @param device A previously initialized ratbag device
  * @return The name of the device associated with the given ratbag.
  */
 const char *

--- a/tools/ratbagctl.in.in
+++ b/tools/ratbagctl.in.in
@@ -212,6 +212,8 @@ def print_device(d, level):
 
     print(" " * level + "{} - {}".format(d.id, d.name))
     print(" " * level + "             Model: {}".format(d.model))
+    if d.firmware_major > 0 or d.firmware_minor > 0:
+        print(" " * level + "  Firmware version: {}.{}".format(d.firmware_major, d.firmware_minor))
     print(" " * level + " Number of Buttons: {}".format(len(p.buttons)))
     print(" " * level + "    Number of Leds: {}".format(len(p.leds)))
     print(" " * level + "Number of Profiles: {}".format(len(d.profiles)))

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -343,6 +343,16 @@ class RatbagdDevice(_RatbagdDBus):
         return self._get_dbus_property("Model")
 
     @GObject.Property
+    def firmware_major(self):
+        """The firmware major version."""
+        return self._get_dbus_property("FirmwareMajor")
+
+    @GObject.Property
+    def firmware_minor(self):
+        """The firmware minor version."""
+        return self._get_dbus_property("FirmwareMinor")
+
+    @GObject.Property
     def name(self):
         """The device name, usually provided by the kernel."""
         return self._get_dbus_property("Name")


### PR DESCRIPTION
This adds fields to the device struct to store the firmware version on the device. It is also exposed over dbus to the clients.

The firmware of a device can define the protocol or memory layout that should be used to talk to the device. Several devices can query the firmware version via separate commands and we can use this information in the drivers to change behavior of the driver based on the device firmware.

The firmware version is also exposed over dbus so that it is easily available for users via e.g. ratbagctl. It can also be used in piper to warn users that a known bug in a firmware version can cause problems when trying to configure with libratbag.