### PR TITLE
ratbagd-json: fix compilation with clang

### DIFF
--- a/ratbagd/ratbagd-json.c
+++ b/ratbagd/ratbagd-json.c
@@ -515,6 +515,7 @@ int ratbagd_parse_json(const char *data, struct ratbag_test_device *device)
 	JsonArray *arr;
 	int r = -EINVAL;
 	g_autoptr(GError) error = NULL;
+	g_autoptr(GList) list = NULL;
 
 	error = 0;
 	parser = json_parser_new();
@@ -540,7 +541,7 @@ int ratbagd_parse_json(const char *data, struct ratbag_test_device *device)
 	num_buttons = device->num_buttons;
 	num_leds = device->num_leds;
 
-	g_autoptr(GList) list = json_array_get_elements(arr);
+	list = json_array_get_elements(arr);
 	GList *l = list;
 	int idx = 0;
 	while (l != NULL) {


### PR DESCRIPTION
Compilation on clang failed as we would try to jump to the 'out' label and then jump over the initialization of a variable with __attribute__((cleanup)).

We move the initialization up to make sure it happens before the goto.