### PR TITLE
Add further device identificator for Logitech G915

### DIFF
--- a/data/devices/logitech-g915.device
+++ b/data/devices/logitech-g915.device
@@ -1,6 +1,6 @@
 [Device]
 Name=Logitech G915
-DeviceMatch=usb:046d:c33e
+DeviceMatch=usb:046d:c33e;usb:046d:c541
 LedTypes=logo;switches
 Driver=hidpp20
 


### PR DESCRIPTION
This is the output of lsusb:

`Bus 001 Device 003: ID 046d:c541 Logitech, Inc. USB Receiver`

It seems like Logietch might use different USB receivers on newer samples of this product.  