### PR TITLE
data: add device IDs for Logitech MX Anywhere 3

### DIFF
--- a/data/devices/logitech-MX-Anywhere-3.device
+++ b/data/devices/logitech-MX-Anywhere-3.device
@@ -1,0 +1,5 @@
+# Logitech MX Anywhere 3
+[Device]
+Name=Logitech MX Anywhere 3
+DeviceMatch=bluetooth:046d:b025;usb:046d:4090
+Driver=hidpp20

--- a/meson.build
+++ b/meson.build
@@ -338,6 +338,7 @@ data_files = files(
 	'data/devices/logitech-Marathon-M705.device',
 	'data/devices/logitech-MX-Anywhere2.device',
 	'data/devices/logitech-MX-Anywhere2S.device',
+	'data/devices/logitech-MX-Anywhere-3.device',
 	'data/devices/logitech-MX-Vertical.device',
 	'data/devices/roccat-kone-pure.device',
 	'data/devices/roccat-kone-xtd.device',


### PR DESCRIPTION
I've confirmed that the device shows up both when connected using unifying receiver and bluetooth.