### PR TITLE
data: Add configuration for SteelSeries Kinzu V2 Pro Edition

### DIFF
--- a/data/devices/steelseries-kinzu-v2-pro.device
+++ b/data/devices/steelseries-kinzu-v2-pro.device
@@ -1,0 +1,11 @@
+[Device]
+Name=SteelSeries Kinzu V2 Pro Edition
+DeviceMatch=usb:1038:1366
+Driver=steelseries
+
+[Driver/steelseries]
+DeviceVersion=1
+Buttons=3
+Leds=0
+DpiList=400;800;1600;3200
+MacroLength=0

--- a/meson.build
+++ b/meson.build
@@ -342,6 +342,7 @@ data_files = files(
 	'data/devices/roccat-kone-pure.device',
 	'data/devices/roccat-kone-xtd.device',
 	'data/devices/steelseries-kinzu-v2.device',
+	'data/devices/steelseries-kinzu-v2-pro.device',
 	'data/devices/steelseries-kinzu-v3.device',
 	'data/devices/steelseries-rival-310.device',
 	'data/devices/steelseries-rival-600.device',


### PR DESCRIPTION
Appears to be basically the same as the V2 - the differences were
mostly in hardware (upgraded switches & image sensor). I've verified
that the list of DPI settings is correct and matches the Windows
software. Adjusting DPI config in both profiles works correctly.