### PR TITLE
Added Logitech G915 TKL (USB)

### DIFF
--- a/data/devices/logitech-g915-tkl.device
+++ b/data/devices/logitech-g915-tkl.device
@@ -1,0 +1,8 @@
+[Device]
+Name=Logitech G915 TKL
+DeviceMatch=usb:046d:c343
+LedTypes=logo;switches
+Driver=hidpp20
+
+[Driver/hidpp20]
+DeviceIndex=1


### PR DESCRIPTION
Added device profile for G915 TKL.
Verified that it is working on ubuntu 20.04 using piper (no graphics)

Copy of G915 device file.