### PR TITLE
Add support for Glorious Model O Wireless

### DIFF
--- a/data/devices/glorious-model-o-wireless.device
+++ b/data/devices/glorious-model-o-wireless.device
@@ -1,0 +1,5 @@
+[Device]
+Name=Glorious Model O Wireless
+DeviceMatch=usb:258a:2022
+Driver=sinowealth
+

--- a/meson.build
+++ b/meson.build
@@ -354,6 +354,7 @@ data_files = files(
 	'data/devices/steelseries-sensei-raw.device',
 	'data/devices/glorious-model-d.device',
 	'data/devices/glorious-model-o.device',
+	'data/devices/glorious-model-o-wireless.device',
 	'data/devices/nubwo-x7-spectrum.device',
 )
 


### PR DESCRIPTION
- Update meson.build
- Add data/devices/glorious-model-o-wireless.device

Any pointers on how to test this would be appreciated. Also I have casually assumed that the drivers have not changed between model O vs model O wireless.