### PR TITLE
data: add G Pro X Wireless Superlight

### DIFF
--- a/data/devices/logitech-g-pro-x-wireless-superlight.device
+++ b/data/devices/logitech-g-pro-x-wireless-superlight.device
@@ -1,0 +1,5 @@
+[Device]
+Name=Logitech G Pro X Wireless Superlight
+DeviceMatch=usb:046d:4093;usb:046d:c094
+LedTypes=logo;battery;dpi;
+Driver=hidpp20

--- a/meson.build
+++ b/meson.build
@@ -297,6 +297,7 @@ data_files = files(
 	'data/devices/logitech-Wireless-Touchpad.device',
 	'data/devices/logitech-g-powerplay.device',
 	'data/devices/logitech-g-pro-wireless.device',
+	'data/devices/logitech-g-pro-x-wireless-superlight.device',
 	'data/devices/logitech-g-pro.device',
 	'data/devices/logitech-g102-g203.device',
 	'data/devices/logitech-g300.device',


### PR DESCRIPTION
Support for this receiver, and for the device using the powerplay
receiver, still needs to be added to the kernel driver. For now, you can
used the wired connection to configure the device.

You should also not try to use with the powerplay receiver as the kernel
driver does not support the connection and won't forward any input
events to userspace.

Signed-off-by: Filipe Laíns <lains@riseup.net>