### PR TITLE
data: add extra USB device ID for MX Vertical

### DIFF
--- a/data/devices/logitech-MX-Vertical.device
+++ b/data/devices/logitech-MX-Vertical.device
@@ -1,4 +1,4 @@
 [Device]
 Name=Logitech MX Vertical
-DeviceMatch=bluetooth:046d:b020;usb:046d:407b
+DeviceMatch=bluetooth:046d:b020;usb:046d:407b;usb:046d:c08a
 Driver=hidpp20


### PR DESCRIPTION
Fixes #1132, for my own model of MX Vertical at the least.