### PR TITLE
ci: temporarily disable arch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,7 +258,7 @@ workflows:
   compile_and_test:
     jobs:
       - ubuntu_20_04
-      - arch
+#      - arch
       - fedora_32
       - doc_build
       - doc_deploy:


### PR DESCRIPTION
See my description of the problem in [1].
Essentially, docker is mishandling the failuire when a syscall is not
available, returning EPERM instead of ENOSYS, and making code misbehave.
The current issue with arch is glibc, which explodes on EPERM, causing
pacman to misbehave.

Once the fix hits CircleCI, we will re-enable.

[1] https://github.com/fwupd/fwupd/issues/2894

Signed-off-by: Filipe Laíns <lains@riseup.net>