### PR TITLE
data: add additional identifier for MX Anywhere 2

### DIFF
--- a/data/devices/logitech-MX-Anywhere2.device
+++ b/data/devices/logitech-MX-Anywhere2.device
@@ -1,4 +1,4 @@
 [Device]
 Name=Logitech MX Anywhere 2
-DeviceMatch=usb:046d:404a;usb:046d:4072;usb:046d:4063;bluetooth:046d:b013;bluetooth:046d:b018;bluetooth:046d:b01f
+DeviceMatch=usb:046d:404a;usb:046d:4072;usb:046d:4063;usb:046d:c52b;bluetooth:046d:b013;bluetooth:046d:b018;bluetooth:046d:b01f
 Driver=hidpp20


### PR DESCRIPTION
```bash
$ egrep "Name|Handlers" /proc/bus/input/devices | egrep -B1 'Handlers.*mouse'
N: Name="Logitech MX Anywhere 2"
H: Handlers=sysrq kbd mouse1 event12 leds

$ lsusb
Bus 001 Device 005: ID 046d:c52b Logitech, Inc. Unifying Receiver
```