### PR TITLE
libratbag-hidraw: add filter to hidraw read

### DIFF
--- a/src/driver-openinput.c
+++ b/src/driver-openinput.c
@@ -159,6 +159,22 @@ openinput_get_report_size(unsigned int report)
 	}
 }
 
+static bool
+openinput_report_filter(uint8_t *buf, size_t len)
+{
+	if (len < 1)
+		return false;
+
+	switch(buf[0]) {
+	case OI_REPORT_SHORT:
+		return len == OI_REPORT_SHORT_SIZE;
+	case OI_REPORT_LONG:
+		return len == OI_REPORT_LONG_SIZE;
+	default:
+		return false;
+	}
+}
+
 static int
 openinput_send_report(struct ratbag_device *device, struct oi_report_t *report)
 {
@@ -175,7 +191,7 @@ openinput_send_report(struct ratbag_device *device, struct oi_report_t *report)
 		return ret;
 	}
 
-	ret = ratbag_hidraw_read_input_report(device, buffer, OI_REPORT_MAX_SIZE);
+	ret = ratbag_hidraw_read_input_report(device, buffer, OI_REPORT_MAX_SIZE, openinput_report_filter);
 	if (ret < 0) {
 		log_error(device->ratbag, "openinput: failed to read data from device (%s)\n",
 			  strerror(-ret));

--- a/src/driver-steelseries.c
+++ b/src/driver-steelseries.c
@@ -234,7 +234,7 @@ steelseries_get_firmware_version(struct ratbag_device *device)
 	if (ret < 0)
 		return ret;
 
-	ret = ratbag_hidraw_read_input_report_index(device, buf, sizeof(buf), STEELSERIES_INPUT_HIDRAW);
+	ret = ratbag_hidraw_read_input_report_index(device, buf, sizeof(buf), STEELSERIES_INPUT_HIDRAW, NULL);
 	if (ret < 0)
 		return ret;
 
@@ -278,7 +278,7 @@ steelseries_read_settings(struct ratbag_device *device)
 	if (ret < 0)
 		return ret;
 
-	ret = ratbag_hidraw_read_input_report_index(device, buf, STEELSERIES_REPORT_SIZE, STEELSERIES_INPUT_HIDRAW);
+	ret = ratbag_hidraw_read_input_report_index(device, buf, STEELSERIES_REPORT_SIZE, STEELSERIES_INPUT_HIDRAW, NULL);
 	if (ret < 0)
 		return ret;
 

--- a/src/libratbag-hidraw.h
+++ b/src/libratbag-hidraw.h
@@ -47,6 +47,8 @@ struct ratbag_hidraw {
 	char *sysname;
 };
 
+typedef bool (*ratbagd_hidraw_filter_t)(uint8_t *buf, size_t len);
+
 /**
  * Open the hidraw device associated with the device.
  *
@@ -162,27 +164,32 @@ int ratbag_hidraw_output_report(struct ratbag_device *device, uint8_t *buf, size
 
 /**
  * Read an input report from the device
+ * Optional filter function can be provided, when the filter returns false the packet is ignored
  *
  * @param device the ratbag device
  * @param[out] buf resulting raw data
  * @param len length of buf
+ * @param filter filter function
  *
  * @return count of data transfered, or a negative errno on error
  */
-int ratbag_hidraw_read_input_report(struct ratbag_device *device, uint8_t *buf, size_t len);
+int ratbag_hidraw_read_input_report(struct ratbag_device *device, uint8_t *buf, size_t len,
+				 ratbagd_hidraw_filter_t filter);
 
 /**
  * Read an input report from the device from a specific hidraw index
+ * Optional filter function can be provided, when the filter returns false the packet is ignored
  *
  * @param device the ratbag device
  * @param[out] buf resulting raw data
  * @param len length of buf
- * @param interal index of hidraw array
+ * @param hidrawno index of hidraw array
+ * @param filter filter function
  *
  * @return count of data transfered, or a negative errno on error
  */
-int ratbag_hidraw_read_input_report_index(struct ratbag_device *device, uint8_t *buf, size_t len, int hidrawno);
-
+int ratbag_hidraw_read_input_report_index(struct ratbag_device *device, uint8_t *buf, size_t len, int hidrawno,
+				 ratbagd_hidraw_filter_t filter);
 
 /**
  * Tells if a given device has the specified report ID.


### PR DESCRIPTION
Currently, we only have functions that will read and timeout after 1s if
no packets were received. The issue with this is that a lot of times we
may catch unrelated packets, such as mouse or keyboard changes.
To solve this, this patch adds a new set of functions suffixed with
_filter, that will keep reading packets until a valid packet if found.
Users define a filter function and pass it as an argument.

Signed-off-by: Filipe Laíns <lains@riseup.net>