### PR TITLE
Add basic support for SteelSeries Rival 100

### DIFF
--- a/data/devices/steelseries-rival-100.device
+++ b/data/devices/steelseries-rival-100.device
@@ -1,0 +1,15 @@
+[Device]
+# 100; 100 (Dell China); 100 Dota 2 Edition (retail); 100 Dota 2 Edition (Lenovo); 105.
+DeviceMatch=usb:1038:1702;usb:1038:170a;usb:1038:170b;usb:1038:170c;usb:1038:1814
+Driver=steelseries
+Name=SteelSeries Rival 100/105
+
+[Driver/steelseries]
+AlternateLed=1
+# Actually 6.
+Buttons=0
+DeviceVersion=1
+DpiList=250;500;1000;1250;1500;1750;2000;4000
+Leds=1
+# Not sure what this is needed for.
+MacroLength=0

--- a/meson.build
+++ b/meson.build
@@ -351,6 +351,7 @@ data_files = files(
 	'data/devices/steelseries-kinzu-v2.device',
 	'data/devices/steelseries-kinzu-v2-pro.device',
 	'data/devices/steelseries-kinzu-v3.device',
+	'data/devices/steelseries-rival-100.device',
 	'data/devices/steelseries-rival-310.device',
 	'data/devices/steelseries-rival-600.device',
 	'data/devices/steelseries-rival.device',

--- a/src/driver-steelseries.c
+++ b/src/driver-steelseries.c
@@ -611,10 +611,10 @@ steelseries_write_led_v1(struct ratbag_led *led)
 	uint8_t buf[STEELSERIES_REPORT_SIZE_SHORT] = {0};
 	int ret;
 
+	const int alternate_led = ratbag_device_data_steelseries_get_alternate_led(device->data);
+
 	buf[0] = STEELSERIES_ID_LED_EFFECT_SHORT;
-	// FIXME: add an option to device settings.
-	if (false) {
-		// This is for Rival 100.
+	if (alternate_led) {
 		buf[1] = 0x00;
 	} else {
 		buf[1] = led->index + 1;
@@ -651,9 +651,7 @@ steelseries_write_led_v1(struct ratbag_led *led)
 			buf[2] = (led->brightness / 86) + 2;
 		}
 	} else {
-		// FIXME: add an option to device settings.
-		if (false) {
-			// This is for Rival 100.
+		if (alternate_led) {
 			buf[0] = 0x05;
 			buf[1] = 0x00;
 		} else {

--- a/src/driver-steelseries.c
+++ b/src/driver-steelseries.c
@@ -443,9 +443,29 @@ steelseries_write_report_rate(struct ratbag_profile *profile)
 	uint8_t buf[STEELSERIES_REPORT_SIZE] = {0};
 
 	if (device_version == 1) {
+		char reported_rate;
+		switch (profile->hz) {
+			case 125:
+				reported_rate = 0x04;
+				break;
+			case 250:
+				reported_rate = 0x03;
+				break;
+			case 500:
+				reported_rate = 0x02;
+				break;
+			case 1000:
+				reported_rate = 0x01;
+				break;
+			default:
+				log_info(device->ratbag, "invalid report rate (%d); falling back to 1000 hz.\n", profile->hz);
+				reported_rate = 0x01;
+				break;
+		}
+
 		buf_len = STEELSERIES_REPORT_SIZE_SHORT;
 		buf[0] = STEELSERIES_ID_REPORT_RATE_SHORT;
-		buf[2] = 1000 / profile->hz;
+		buf[2] = reported_rate;
 	} else if (device_version == 2) {
 		buf_len = STEELSERIES_REPORT_SIZE;
 		buf[0] = STEELSERIES_ID_REPORT_RATE;

--- a/src/driver-steelseries.c
+++ b/src/driver-steelseries.c
@@ -612,7 +612,13 @@ steelseries_write_led_v1(struct ratbag_led *led)
 	int ret;
 
 	buf[0] = STEELSERIES_ID_LED_EFFECT_SHORT;
-	buf[1] = led->index + 1;
+	// FIXME: add an option to device settings.
+	if (false) {
+		// This is for Rival 100.
+		buf[1] = 0x00;
+	} else {
+		buf[1] = led->index + 1;
+	}
 
 	switch(led->mode) {
 	case RATBAG_LED_OFF:
@@ -645,8 +651,15 @@ steelseries_write_led_v1(struct ratbag_led *led)
 			buf[2] = (led->brightness / 86) + 2;
 		}
 	} else {
-		buf[0] = STEELSERIES_ID_LED_COLOR_SHORT;
-		buf[1] = led->index + 1;
+		// FIXME: add an option to device settings.
+		if (false) {
+			// This is for Rival 100.
+			buf[0] = 0x05;
+			buf[1] = 0x00;
+		} else {
+			buf[0] = STEELSERIES_ID_LED_COLOR_SHORT;
+			buf[1] = led->index + 1;
+		}
 		buf[2] = led->color.red;
 		buf[3] = led->color.green;
 		buf[4] = led->color.blue;

--- a/src/libratbag-data.c
+++ b/src/libratbag-data.c
@@ -206,13 +206,13 @@ init_data_steelseries(struct ratbag *ratbag,
 	data->steelseries.mono_led = 0;
 	data->steelseries.short_button = 0;
 
-	error = NULL;
 	num = g_key_file_get_integer(keyfile, group, "AlternateLed", &error);
 	if (num > 0 || !error)
 		data->steelseries.alternate_led = num;
 	if (error)
 		g_error_free(error);
 
+	error = NULL;
 	num = g_key_file_get_integer(keyfile, group, "Buttons", &error);
 	if (num != 0 || !error)
 		data->steelseries.button_count = num;

--- a/src/libratbag-data.c
+++ b/src/libratbag-data.c
@@ -82,6 +82,7 @@ struct data_steelseries {
 	int macro_length;
 	int mono_led;
 	int short_button;
+	int alternate_led;
 };
 
 struct ratbag_device_data {
@@ -204,6 +205,13 @@ init_data_steelseries(struct ratbag *ratbag,
 	data->steelseries.dpi_range = NULL;
 	data->steelseries.mono_led = 0;
 	data->steelseries.short_button = 0;
+
+	error = NULL;
+	num = g_key_file_get_integer(keyfile, group, "AlternateLed", &error);
+	if (num > 0 || !error)
+		data->steelseries.alternate_led = num;
+	if (error)
+		g_error_free(error);
 
 	num = g_key_file_get_integer(keyfile, group, "Buttons", &error);
 	if (num != 0 || !error)
@@ -674,4 +682,12 @@ ratbag_device_data_steelseries_get_short_button(const struct ratbag_device_data 
 	assert(data->drivertype == STEELSERIES);
 
 	return data->steelseries.short_button;
+}
+
+int
+ratbag_device_data_steelseries_get_alternate_led(const struct ratbag_device_data *data)
+{
+	assert(data->drivertype == STEELSERIES);
+
+	return data->steelseries.alternate_led;
 }

--- a/src/libratbag-data.c
+++ b/src/libratbag-data.c
@@ -198,6 +198,7 @@ init_data_steelseries(struct ratbag *ratbag,
 	_cleanup_(freep) char *str = NULL;
 	int num;
 
+	data->steelseries.alternate_led = 0;
 	data->steelseries.device_version = -1;
 	data->steelseries.button_count = -1;
 	data->steelseries.led_count = -1;

--- a/src/libratbag-data.h
+++ b/src/libratbag-data.h
@@ -101,6 +101,12 @@ int
 ratbag_device_data_steelseries_get_button_count(const struct ratbag_device_data *data);
 
 /**
+ * @return 1 if alternate LED mode or 0
+ */
+int
+ratbag_device_data_steelseries_get_alternate_led(const struct ratbag_device_data *data);
+
+/**
  * @return The led count or -1 if not set
  */
 int


### PR DESCRIPTION
First commit fixes report rate changing for version 1 devices.
Second commit adds support for Rival 100. As stated in the commit message, neither button nor LED configuration changing doesn't work. DPI changing works almost flawlessly (can't switch between first and second resolution), but polling rate changing doesn't work fully for now because of #1126.

Edit: forgot to mention: it doesn't support reading any data, including report rate and resolutions.