### PR TITLE
sinowealth: implement poll rate changing

### DIFF
--- a/src/driver-sinowealth.c
+++ b/src/driver-sinowealth.c
@@ -443,6 +443,24 @@ sinowealth_commit(struct ratbag_device *device)
 	int rc;
 	uint8_t dpi_enabled = 0;
 
+	/* Update report rate. */
+	uint8_t reported_rate = 0;
+	if (profile->hz >= 1000) {
+		profile->hz = 1000;
+		reported_rate = 0x04;
+	} else if (profile->hz >= 375) {
+		profile->hz = 500;
+		reported_rate = 0x03;
+	} else if (profile->hz <= 125) {
+		profile->hz = 125;
+		reported_rate = 0x01;
+	} else {
+		profile->hz = 250;
+		reported_rate = 0x02;
+	}
+	config->config &= ~0b111U;
+	config->config |= reported_rate;
+
 	/* Check if any resolution requires independent XY DPIs */
 	config->config &= ~SINOWEALTH_XY_INDEPENDENT;
 	ratbag_profile_for_each_resolution(profile, resolution) {


### PR DESCRIPTION
@phomes and @enkore, sorry for the ping, but since you both own SinoWealth-based mice, I'd be really grateful if you could check this.

NOTE: at least on G-Wolves Hati when poll rate is set to a wrong value, the mouse stops moving. I guess official software may fix this, but I'm not too sure, so proceed with caution.