### PR TITLE
steelseries: fix report rate changing for version 1 devices

### DIFF
--- a/src/driver-steelseries.c
+++ b/src/driver-steelseries.c
@@ -443,9 +443,24 @@ steelseries_write_report_rate(struct ratbag_profile *profile)
 	uint8_t buf[STEELSERIES_REPORT_SIZE] = {0};
 
 	if (device_version == 1) {
+		uint8_t reported_rate = 0;
+		if (profile->hz >= 1000) {
+			profile->hz = 1000;
+			reported_rate = 0x01;
+		} else if (profile->hz >= 375) {
+			profile->hz = 500;
+			reported_rate = 0x02;
+		} else if (profile->hz <= 125) {
+			profile->hz = 125;
+			reported_rate = 0x04;
+		} else {
+			profile->hz = 250;
+			reported_rate = 0x03;
+		}
+
 		buf_len = STEELSERIES_REPORT_SIZE_SHORT;
 		buf[0] = STEELSERIES_ID_REPORT_RATE_SHORT;
-		buf[2] = 1000 / profile->hz;
+		buf[2] = reported_rate;
 	} else if (device_version == 2) {
 		buf_len = STEELSERIES_REPORT_SIZE;
 		buf[0] = STEELSERIES_ID_REPORT_RATE;


### PR DESCRIPTION
Judging by rivalcfg's data for Sensei Raw, Rival 100, Rival (300) and Kinzu v2 (all are version 1 devices in our data), it should have been like that from the beginning.
Confirmed on Rival 100.