### PR TITLE
sinowealth-nubwo: fix implicit declaration of function ‘vasprintf’

### DIFF
--- a/src/driver-sinowealth-nubwo.c
+++ b/src/driver-sinowealth-nubwo.c
@@ -21,6 +21,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
+#include "config.h"
 #include "libratbag-enums.h"
 #include "libratbag-hidraw.h"
 #include "libratbag-private.h"


### PR DESCRIPTION
driver-sinowealth-nubwo.c was missing to include "config.h" so
_GNU_SOURCE wasn't defined soon enough.