### PR TITLE
Additional identifier for MX Vertical

### DIFF
--- a/data/devices/logitech-MX-Vertical.device
+++ b/data/devices/logitech-MX-Vertical.device
@@ -1,4 +1,4 @@
 [Device]
 Name=Logitech MX Vertical
-DeviceMatch=bluetooth:046d:b020;usb:046d:407b;usb:046d:c08a
+DeviceMatch=bluetooth:046d:b020;usb:046d:407b;usb:046d:c08a;usb:046d:c52b
 Driver=hidpp20


### PR DESCRIPTION
```sh
$ egrep "Name|Handlers" /proc/bus/input/devices | egrep -B1 'Handlers.*mouse'
N: Name="Logitech MX Vertical"
H: Handlers=sysrq kbd leds event22 mouse0

$ lsusb
Bus 001 Device 005: ID 046d:c52b Logitech, Inc. Unifying Receiver
```