### PR TITLE
Fix some compile time warnings

### DIFF
--- a/ratbagd/ratbagd.c
+++ b/ratbagd/ratbagd.c
@@ -614,7 +614,7 @@ static void remove_ratbagd_devel_dbus_policy(void)
 int main(int argc, char *argv[])
 {
 	struct ratbagd *ctx = NULL;
-	int r;
+	int r = 0;
 
 #if DISABLE_COREDUMP
 	const struct rlimit corelimit = { 0, 0 };

--- a/src/driver-hidpp10.c
+++ b/src/driver-hidpp10.c
@@ -548,7 +548,7 @@ hidpp10_log(void *userdata, enum hidpp_log_priority priority, const char *format
 {
 	struct ratbag_device *device = userdata;
 
-	log_msg_va(device->ratbag, priority, format, args);
+	log_msg_va(device->ratbag, (enum ratbag_log_priority)priority, format, args);
 }
 
 static int

--- a/src/driver-hidpp10.c
+++ b/src/driver-hidpp10.c
@@ -448,7 +448,7 @@ hidpp10drv_read_profile(struct ratbag_profile *profile)
 		free(profile->name);
 		profile->name = NULL;
 	}
-	if (p.name && p.name[0] != '\0')
+	if (*p.name && p.name[0] != '\0')
 		profile->name = strdup_safe((char*)p.name);
 
 	rc = hidpp10_get_current_profile(hidpp10, &idx);

--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -1604,7 +1604,7 @@ hidpp20_log(void *userdata, enum hidpp_log_priority priority, const char *format
 {
 	struct ratbag_device *device = userdata;
 
-	log_msg_va(device->ratbag, priority, format, args);
+	log_msg_va(device->ratbag, (enum ratbag_log_priority)priority, format, args);
 }
 
 static void

--- a/src/hidpp20.h
+++ b/src/hidpp20.h
@@ -210,21 +210,21 @@ struct hidpp20_led_sw_ctrl_led_state {
 	uint8_t index;
 	uint16_t mode;
 	union {
-		struct {
+		struct hidpp20_led_breathing {
 			uint16_t brightness;
 			uint16_t period;
 			uint16_t timeout;
 		} breathing;
-		struct {
+		struct hidpp20_led_traveling {
 			uint16_t unused;
 			uint16_t delay;
 		} traveling;
-		struct {
+		struct hidpp20_led_blink {
 			uint16_t index;
 			uint16_t on_time;
 			uint16_t off_time;
 		} blink;
-		struct {
+		struct hidpp20_led_on {
 			/* Logical information to display on the LED
 			 * Meaning and value range depend on the LED
 			 */


### PR DESCRIPTION
There are still some warnings, however. Here they are: Clang and GCC's `unused-function` in `sinowealth` driver - will be fixed in #1065; Clang's `incompatible-pointer-types-discards-qualifiers`/GCC's `discarded-qualifiers` in `hidpp10` driver - it this would need an API change, as I understand; GCC's `address-of-packed-member` - don't know how to fix it properly. More details in #990.