### PR TITLE
ratbagd: register task to run as soon as possible

### DIFF
--- a/ratbagd/ratbagd.c
+++ b/ratbagd/ratbagd.c
@@ -697,5 +697,5 @@ void ratbagd_schedule_task(struct ratbagd *ctx,
 	cb->callback = callback;
 	cb->userdata = userdata;
 
-	sd_event_add_post(ctx->event, &source, ratbagd_callback_handler, cb);
+	sd_event_add_defer(ctx->event, &source, ratbagd_callback_handler, cb);
 }


### PR DESCRIPTION
Previously the scheduled task would only have been executed after some
other event woke up the mainloop.
If no such event happens, the task will be delayed significantly.

Fixes #1121