### PR TITLE
man: add both variants in ratbagctl.1 synopsis

### DIFF
--- a/tools/ratbagctl.1
+++ b/tools/ratbagctl.1
@@ -2,7 +2,13 @@
 .SH NAME
 ratbagctl \- inspect and modify configurable mice
 .SH SYNOPSIS
-.B ratbagctl [OPTIONS] {COMMAND} ... device
+.B ratbagctl
+.RI [< options >]
+.B list
+.br
+.B ratbagctl
+.RI [< options >]
+.RI < device "> <" command "> ..."
 .SH DESCRIPTION
 .PP
 The
@@ -21,8 +27,8 @@ Print debugging output. Multiple -v options increase the verbosity. For example,
 will show the protocol output.
 .TP 8
 .B \-\-nocommit
-Do not immediately write the settings to the mouse. This allows to set
-multiple parameters in a script, and the last call to
+Do not immediately write the settings to the mouse. This allows
+multiple parameters to be set in a script, and the last call to
 .B ratbagctl
 will write them all.
 .TP 8


### PR DESCRIPTION
This distinguishes the command variants in the synopsis.

While we're at it, tweak the grammar for the --no-commit
description.

Signed-off-by: Stephen Kitt <steve@sk2.org>