### PR TITLE
Add support for rival 300

### DIFF
--- a/data/devices/steelseries-rival-300.device
+++ b/data/devices/steelseries-rival-300.device
@@ -1,0 +1,11 @@
+[Device]
+Name=SteelSeries Rival 300
+DeviceMatch=usb:1038:1710
+Driver=steelseries
+
+[Driver/steelseries]
+DeviceVersion=1
+Buttons=6
+Leds=2
+DpiRange=50:6500@50
+MacroLength=1

--- a/meson.build
+++ b/meson.build
@@ -356,6 +356,7 @@ data_files = files(
 	'data/devices/steelseries-rival-310.device',
 	'data/devices/steelseries-rival-600.device',
 	'data/devices/steelseries-rival.device',
+	'data/devices/steelseries-rival-300.device',
 	'data/devices/steelseries-sensei-310.device',
 	'data/devices/steelseries-sensei-raw.device',
 	'data/devices/glorious-model-d.device',


### PR DESCRIPTION
I personally don't own steel series rival 300 mice, but it seems like it's just a variation `steelseries-rival` driver.
And we have a user confirmation that it actually works, https://github.com/libratbag/libratbag/issues/804#issuecomment-619243638
So i am pretty confident making this change