### PR TITLE
steelseries: only use the HID vendor device

### DIFF
--- a/src/driver-steelseries.c
+++ b/src/driver-steelseries.c
@@ -117,6 +117,13 @@ steelseries_test_hidraw(struct ratbag_device *device)
 {
 	int device_version = ratbag_device_data_steelseries_get_device_version(device->data);
 
+	/* Rival mice are composite devices with multiple HID devices
+	 * and only the HID vendor device can be used to configure the
+	 * device.
+	 */
+	if (!ratbag_hidraw_has_vendor_page(device))
+		return false;
+
 	if (device_version > 1)
 		return ratbag_hidraw_has_report(device, STEELSERIES_REPORT_ID_1);
 	else

--- a/src/libratbag-hidraw.c
+++ b/src/libratbag-hidraw.c
@@ -1520,6 +1520,21 @@ ratbag_hidraw_get_usage(struct ratbag_device *device, unsigned int report_id)
 	return report->usage;
 }
 
+unsigned int
+ratbag_hidraw_has_vendor_page(struct ratbag_device *device)
+{
+	unsigned i;
+
+	if (ratbag_hidraw_get_usage_page(device, 0) >= 0xff00)
+		return 1;
+
+	for (i = 0; i < device->hidraw[0].num_reports; i++) {
+		if (ratbag_hidraw_get_usage_page(device, device->hidraw[0].reports[i].report_id) >= 0xff00)
+			return 1;
+	}
+	return 0;
+}
+
 void
 ratbag_close_hidraw(struct ratbag_device *device)
 {

--- a/src/libratbag-hidraw.h
+++ b/src/libratbag-hidraw.h
@@ -220,6 +220,16 @@ unsigned int
 ratbag_hidraw_get_usage(struct ratbag_device *device, unsigned int report_id);
 
 /**
+ * Tells if a given device has a vendor usage page
+ *
+ * @param device the ratbag device which hidraw node is opened
+ *
+ * @return 1 if the device has a vendor usage page, 0 otherwise
+ */
+unsigned int
+ratbag_hidraw_has_vendor_page(struct ratbag_device *device);
+
+/**
  * Gives the input key code associated to the keyboard HID usage.
  *
  * @return the key code of the HID usage or 0.


### PR DESCRIPTION
Rival mice are composite devices with multiple HID devices and only the
HID vendor device can be used to configure the device.

Tested with a SteelSeries Rival 300 (1038:1710).

Fix #888