### PR TITLE
data: add additional USB id for Logitech G915 TKL

### DIFF
--- a/data/devices/logitech-g915-tkl.device
+++ b/data/devices/logitech-g915-tkl.device
@@ -1,6 +1,6 @@
 [Device]
 Name=Logitech G915 TKL
-DeviceMatch=usb:046d:c343;bluetooth:046d:b35f
+DeviceMatch=usb:046d:c343;usb:046d:c545;bluetooth:046d:b35f
 LedTypes=logo;switches
 Driver=hidpp20
 


### PR DESCRIPTION
As discussed in Issue #1098, Logitech appears to have released both
black and white editions of this keyboard with another USB id. This adds
support for those units.