### PR TITLE
Add a GitHub Workflow as CI run

### DIFF
--- a/.github/actions/meson/action.yml
+++ b/.github/actions/meson/action.yml
@@ -1,0 +1,41 @@
+# A Github Action to build a repository with meson
+name: "Setup and run meson"
+description: "Setup and run meson"
+inputs:
+  builddir:
+    description: "The build directory"
+    default: "builddir"
+  srcdir:
+    description: "The source directory"
+    default: "."
+  meson_args:
+    description: "Arguments passed to meson setup"
+    default: ""
+  meson_skip_test:
+    description: "Set to a nonempty string to skip meson test"
+    default: ""
+  meson_test_args:
+    description: "Arguments passed to meson test"
+    default: ""
+  meson_precmd:
+    description: "Set to 'sudo' to run with sudo"
+    default: ""
+  ninja_args:
+    description: "Arguments passed to ninja"
+    default: ""
+  ninja_precmd:
+    description: "Set to 'sudo' to run with sudo"
+    default: ""
+runs:
+  using: "composite"
+  steps:
+    - run: |
+        pushd ${{inputs.srcdir}}
+        ${{inputs.meson_precmd}} meson setup ${{inputs.builddir}} ${{inputs.meson_args}}
+        ${{inputs.meson_precmd}} meson configure ${{inputs.builddir}}
+        ${{inputs.ninja_precmd}} ninja -C ${{inputs.builddir}} ${{inputs.ninja_args}}
+        if [[ -z "${{inputs.meson_skip_test}}" ]]; then
+          ${{inputs.meson_precmd}} meson test -C ${{inputs.builddir}} --print-errorlogs ${{inputs.meson_test_args}};
+        fi
+        popd
+      shell: bash

--- a/.github/actions/meson/action.yml
+++ b/.github/actions/meson/action.yml
@@ -30,12 +30,10 @@ runs:
   using: "composite"
   steps:
     - run: |
-        pushd ${{inputs.srcdir}}
-        ${{inputs.meson_precmd}} meson setup ${{inputs.builddir}} ${{inputs.meson_args}}
+        ${{inputs.meson_precmd}} meson setup ${{inputs.builddir}} ${{inputs.srcdir}} ${{inputs.meson_args}}
         ${{inputs.meson_precmd}} meson configure ${{inputs.builddir}}
         ${{inputs.ninja_precmd}} ninja -C ${{inputs.builddir}} ${{inputs.ninja_args}}
         if [[ -z "${{inputs.meson_skip_test}}" ]]; then
           ${{inputs.meson_precmd}} meson test -C ${{inputs.builddir}} --print-errorlogs ${{inputs.meson_test_args}};
         fi
-        popd
       shell: bash

--- a/.github/actions/pkginstall/action.yml
+++ b/.github/actions/pkginstall/action.yml
@@ -1,0 +1,17 @@
+name: "Install packages"
+description: "Install a set of packages from sources"
+inputs:
+  apt:
+    description: "The package list to install with apt"
+  pip:
+    description: "The package list to install with pip"
+  pip_precmd:
+    description: "Set to the string 'sudo' to run through sudo"
+    default: ""
+runs:
+  using: "composite"
+  steps:
+    - run: sudo ${{ github.action_path }}/install-apt.sh ${{ inputs.apt }}
+      shell: bash
+    - run: ${{inputs.pip_precmd}} ${{ github.action_path }}/install-pip.sh ${{ inputs.pip }}
+      shell: bash

--- a/.github/actions/pkginstall/install-apt.sh
+++ b/.github/actions/pkginstall/install-apt.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -x
+
+# If called without arguments, just skip the rest
+if [[ -z "$@" ]]; then
+	exit
+fi
+
+# Don't care about these bits
+echo 'path-exclude=/usr/share/doc/*' > /etc/dpkg/dpkg.cfg.d/99-exclude-cruft
+echo 'path-exclude=/usr/share/locale/*' >> /etc/dpkg/dpkg.cfg.d/99-exclude-cruft
+echo 'path-exclude=/usr/share/man/*' >> /etc/dpkg/dpkg.cfg.d/99-exclude-cruft
+
+apt-get update
+apt-get install -yq --no-install-suggests --no-install-recommends $@

--- a/.github/actions/pkginstall/install-pip.sh
+++ b/.github/actions/pkginstall/install-pip.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -x
+
+# If called without arguments, just skip the rest
+if [[ -z "$@" ]]; then
+	exit
+fi
+
+python -m pip install --upgrade pip
+python -m pip install --upgrade "$@"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,47 @@
+name: linux
+
+on: [ push, pull_request ]
+
+env:
+  UBUNTU_DEP_BUILD: gcc g++ pkg-config systemd libevdev-dev libglib2.0-dev libjson-glib-dev libsystemd-dev libudev-dev libunistring-dev python3-dev python3-evdev swig
+  UBUNTU_DEP_TEST: check python3-gi python3-lxml valgrind
+  PIP_PACKAGES: meson ninja libevdev pyudev pytest
+
+jobs:
+  build-and-dist:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        meson_args:
+          - ''
+          - '-Dbuildtype=plain'
+          - '-Dbuildtype=release'
+          - '-Ddocumentation=true'
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/pkginstall
+        with:
+          apt: $UBUNTU_DEP_BUILD $UBUNTU_DEP_TEST
+          pip: $PIP_PACKAGES
+      - name: meson test ${{matrix.meson_options}}
+        uses: ./.github/actions/meson
+        with:
+          meson_args: --prefix=$PWD/_instdir ${{matrix.meson_options}}
+          ninja_args: install
+      - name: check installation of data files
+        run:  diff -u <(cd data/devices; ls *.device) <(cd _instdir/share/libratbag; ls *.device)
+      - name: ninja uninstall
+        uses: ./.github/actions/meson
+        with:
+          meson_args: --prefix=$PWD/_instdir
+          ninja_args: uninstall
+      - name: check if any files are left after uninstall
+        run: (test -d _instdir && tree _instdir && exit 1) || exit 0
+      # Capture all the meson logs, even if we failed
+      - uses: actions/upload-artifact@v2
+        if: ${{ always() }}  # even if we fail
+        with:
+          name: meson test logs
+          path: |
+            builddir/meson-logs/testlog*.txt
+            builddir/meson-logs/meson-log.txt


### PR DESCRIPTION
CircleCI is limiting how many runs we can do, which results in pipelines
randomly failing when we've used up the credits for this month.

Let's add a github workflow instead. Unfortunately github workflows are
a bit of a toy api, no support for YAML anchors or extending other jobs,
so there's a lot of duplication needed to get a job to do something.

The actions added in this patch help a bit to make the jobs easier to
understand (copied from libwacom).

This only runs on Ubuntu right now.