### PR TITLE
ratbag-command handle button key actions

### DIFF
--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -1294,7 +1294,8 @@ ratbag_button_get_key(struct ratbag_button *button,
 		return 0;
 
 	/* FIXME: modifiers */
-	*sz = 0;
+	if (sz != NULL)
+		*sz = 0;
 	return button->action.action.key.key;
 }
 

--- a/tools/ratbagc.py.in
+++ b/tools/ratbagc.py.in
@@ -500,6 +500,7 @@ class RatbagdButton(metaclass=MetaRatbag):
         NONE = libratbag.RATBAG_BUTTON_ACTION_TYPE_NONE
         BUTTON = libratbag.RATBAG_BUTTON_ACTION_TYPE_BUTTON
         SPECIAL = libratbag.RATBAG_BUTTON_ACTION_TYPE_SPECIAL
+        KEY = libratbag.RATBAG_BUTTON_ACTION_TYPE_KEY
         MACRO = libratbag.RATBAG_BUTTON_ACTION_TYPE_MACRO
 
     class ActionSpecial(IntEnum):
@@ -626,6 +627,14 @@ class RatbagdButton(metaclass=MetaRatbag):
         @param special The special entry, as one of RatbagdButton.ActionSpecial
         """
         libratbag.ratbag_button_set_special(self._button, special)
+
+    @property
+    def key(self):
+        return libratbag.ratbag_button_get_key(self._button, None, None)
+
+    @key.setter
+    def key(self, key):
+        libratbag.ratbag_button_set_key(self._button, key, None, 0)
 
     @property
     def action_type(self):

--- a/tools/ratbagctl.in.in
+++ b/tools/ratbagctl.in.in
@@ -163,6 +163,8 @@ def print_button(d, p, b, level):
         print("{}'button {}'".format(header, b.mapping))
     elif b.action_type == RatbagdButton.ActionType.SPECIAL:
         print("{}'{}'".format(header, button_specials_strmap[b.special]))
+    elif b.action_type == RatbagdButton.ActionType.KEY:
+        print("{}key '{}'".format(header, str(b.key)))
     elif b.action_type == RatbagdButton.ActionType.MACRO:
         print("{}macro '{}'".format(header, str(b.macro)))
     elif b.action_type == RatbagdButton.ActionType.NONE:
@@ -322,6 +324,17 @@ def func_button_action_set_special(r, args):
         pass
     else:
         b.special = button_specials_strmap[special]
+    commit(d, args)
+
+
+def func_button_action_set_key(r, args):
+    b, p, d = find_button(r, args)
+    try:
+        key = args.target_key
+    except AttributeError:
+        pass
+    else:
+        b.key = key
     commit(d, args)
 
 
@@ -963,6 +976,20 @@ active profile if none is given.""",
                                         },
                                     ],
                                     func: func_button_action_set_special,
+                                },
+                                {
+                                    of_type: command,
+                                    name: 'key',
+                                    help_str: 'Set the button action to key',
+                                    pos_args: [
+                                        {
+                                            of_type: argument,
+                                            name: 'target_key',
+                                            metavar: 'S',
+                                            help_str: 'The new key value to assign',
+                                        },
+                                    ],
+                                    func: func_button_action_set_key,
                                 },
                                 {
                                     of_type: command,

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -617,6 +617,7 @@ class RatbagdButton(_RatbagdDBus):
         NONE = 0
         BUTTON = 1
         SPECIAL = 2
+        KEY = 3
         MACRO = 4
 
     class ActionSpecial(IntEnum):
@@ -754,6 +755,19 @@ class RatbagdButton(_RatbagdDBus):
         special = GLib.Variant("u", special)
         self._set_dbus_property("Mapping", "(uv)",
                                 (RatbagdButton.ActionType.SPECIAL, special))
+
+    @GObject.Property
+    def key(self):
+        type, key = self._mapping()
+        if type != RatbagdButton.ActionType.KEY:
+            return None
+        return key
+
+    @key.setter
+    def key(self, key):
+        key = GLib.Variant("u", key)
+        self._set_dbus_property("Mapping", "(uv)",
+                                (RatbagdButton.ActionType.KEY, key))
 
     @GObject.Property
     def action_type(self):


### PR DESCRIPTION
I'm not familiar with swig and I don't know how to make proper bindings to "ratbag_button_get_key" and "ratbag_button_set_key".
So I made a separate simplified bindings "ratbag_button_get_key_nomod" and "ratbag_button_set_key_nomod" for getting/setting keys without modifiers. Anyway the modifiers are not supported by ratbag itself and also not supported by ASUS mice. So I think it's still better to have than not able to bind any key at all.

I have added "brightness" to leds info with "RatbagdLed.Mode.ON" mode, because you can control brightness in this mode on ASUS mice. I also tried to make "print_led" more readable.

Fixes https://github.com/libratbag/libratbag/issues/1251