### PR TITLE
Fix ratbag_button_action_match not matching on type NONE

### DIFF
--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -471,6 +471,7 @@ ratbag_button_action_match(const struct ratbag_button_action *action,
 	case RATBAG_BUTTON_ACTION_TYPE_SPECIAL:
 		return match->action.special == action->action.special;
 	case RATBAG_BUTTON_ACTION_TYPE_MACRO:
+		/* TODO: check if events match. */
 		return 1;
 	default:
 		break;

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -462,6 +462,8 @@ ratbag_button_action_match(const struct ratbag_button_action *action,
 		return 0;
 
 	switch (action->type) {
+	case RATBAG_BUTTON_ACTION_TYPE_NONE:
+		return 1;
 	case RATBAG_BUTTON_ACTION_TYPE_BUTTON:
 		return match->action.button == action->action.button;
 	case RATBAG_BUTTON_ACTION_TYPE_KEY:


### PR DESCRIPTION
Noticed this while working adding button changing support to Sinowealth driver.

And also add a TODO to make this function support macro actions. I decided not to implement it right now because I don't think would actually be used anywhere.