### PR TITLE
Remove old driver methods

### DIFF
--- a/src/driver-etekcity.c
+++ b/src/driver-etekcity.c
@@ -496,9 +496,9 @@ etekcity_read_profile(struct ratbag_profile *profile)
 }
 
 static int
-etekcity_write_macro(struct ratbag_button *button,
-		     const struct ratbag_button_action *action)
+etekcity_write_macro(struct ratbag_button *button)
 {
+	const struct ratbag_button_action *action = &button->action;
 	struct ratbag_device *device;
 	struct etekcity_macro *macro;
 	struct etekcity_data *drv_data;
@@ -572,15 +572,7 @@ etekcity_write_button(struct ratbag_button *button)
 
 	*data = rc;
 
-	rc = etekcity_write_profile(button->profile);
-	if (rc) {
-		log_error(device->ratbag,
-			  "unable to write the profile to the device: '%s' (%d)\n",
-			  strerror(-rc), rc);
-		return rc;
-	}
-
-	rc = etekcity_write_macro(button, action);
+	rc = etekcity_write_macro(button);
 	if (rc) {
 		log_error(device->ratbag,
 			  "unable to write the macro to the device: '%s' (%d)\n",
@@ -719,10 +711,6 @@ etekcity_commit(struct ratbag_device *device)
 		if (!profile->dirty)
 			continue;
 
-		rc = etekcity_write_profile(profile);
-		if (rc)
-			return rc;
-
 		ratbag_profile_for_each_resolution(profile, resolution) {
 			if (!resolution->dirty)
 				continue;
@@ -740,6 +728,10 @@ etekcity_commit(struct ratbag_device *device)
 			if (rc)
 				return rc;
 		}
+
+		rc = etekcity_write_profile(profile);
+		if (rc)
+			return rc;
 	}
 
 	return 0;

--- a/src/driver-roccat-kone-pure.c
+++ b/src/driver-roccat-kone-pure.c
@@ -603,9 +603,9 @@ roccat_write_macro(struct ratbag_button *button,
 }
 
 static int
-roccat_write_button(struct ratbag_button *button,
-		      const struct ratbag_button_action *action)
+roccat_write_button(struct ratbag_button *button)
 {
+	const struct ratbag_button_action *action = &button->action;
 	struct ratbag_profile *profile = button->profile;
 	struct ratbag_device *device = profile->device;
 	struct roccat_data *drv_data = ratbag_get_drv_data(device);
@@ -639,8 +639,7 @@ roccat_write_button(struct ratbag_button *button,
 }
 
 static int
-roccat_write_resolution_dpi(struct ratbag_resolution *resolution,
-			      int dpi_x, int dpi_y)
+roccat_write_resolution(struct ratbag_resolution *resolution)
 {
 	struct ratbag_profile *profile = resolution->profile;
 	struct ratbag_device *device = profile->device;
@@ -649,7 +648,10 @@ roccat_write_resolution_dpi(struct ratbag_resolution *resolution,
 	uint8_t *buf;
 	int rc;
 
-	if (dpi_x < 100 || dpi_x > 5000 || dpi_x % 50)
+	const unsigned int dpi_x = resolution->dpi_x;
+	const unsigned int dpi_y = resolution->dpi_y;
+
+	if (dpi_x < 200 || dpi_x > 8200 || dpi_x % 50)
 		return -EINVAL;
 	if (dpi_y < 100 || dpi_y > 5000 || dpi_y % 50)
 		return -EINVAL;
@@ -833,13 +835,50 @@ roccat_remove(struct ratbag_device *device)
 	free(ratbag_get_drv_data(device));
 }
 
+static int
+roccat_commit(struct ratbag_device *device)
+{
+
+	int rc = 0;
+	struct ratbag_button *button = NULL;
+	struct ratbag_profile *profile = NULL;
+	struct ratbag_resolution *resolution = NULL;
+
+	ratbag_device_for_each_profile(device, profile) {
+		if (!profile->dirty)
+			continue;
+
+		rc = roccat_write_profile(profile);
+		if (rc)
+			return rc;
+
+		ratbag_profile_for_each_resolution(profile, resolution) {
+			if (!resolution->dirty)
+				continue;
+
+			rc = roccat_write_resolution(resolution);
+			if (rc)
+				return rc;
+		}
+
+		ratbag_profile_for_each_button(profile, button) {
+			if (!button->dirty)
+				continue;
+
+			rc = roccat_write_button(button);
+			if (rc)
+				return rc;
+		}
+	}
+
+	return 0;
+}
+
 struct ratbag_driver roccat_kone_pure_driver = {
 	.name = "Roccat Kone Pure",
 	.id = "roccat-kone-pure",
 	.probe = roccat_probe,
 	.remove = roccat_remove,
-	.write_profile = roccat_write_profile,
+	.commit = roccat_commit,
 	.set_active_profile = roccat_set_current_profile,
-	.write_button = roccat_write_button,
-	.write_resolution_dpi = roccat_write_resolution_dpi,
 };

--- a/src/driver-test.c
+++ b/src/driver-test.c
@@ -30,14 +30,6 @@
 #include "libratbag-test.h"
 
 static int
-test_write_profile(struct ratbag_profile *profile)
-{
-	/* check if the device is still valid */
-	assert(ratbag_get_drv_data(profile->device) != NULL);
-	return 0;
-}
-
-static int
 test_set_active_profile(struct ratbag_device *device, unsigned int index)
 {
 	struct ratbag_test_device *d = ratbag_get_drv_data(device);
@@ -134,26 +126,6 @@ test_read_led(struct ratbag_led *led)
 	 * devices easier by always getting the first profile's LED type.
 	 */
 	led->type = d->profiles[0].leds[led->index].type;
-}
-
-static int
-test_write_button(struct ratbag_button *button,
-		  const struct ratbag_button_action *action)
-{
-	/* check if the device is still valid */
-	assert(ratbag_get_drv_data(button->profile->device) != NULL);
-	return 0;
-}
-
-static int
-test_write_led(struct ratbag_led *led,
-	       enum ratbag_led_mode mode,
-	       struct ratbag_color color, unsigned int ms,
-	       unsigned int brightness)
-{
-	/* check if the device is still valid */
-	assert(ratbag_get_drv_data(led->profile->device) != NULL);
-	return 0;
 }
 
 static int
@@ -285,15 +257,21 @@ test_remove(struct ratbag_device *device)
 	free(d);
 }
 
+static int
+test_commit(struct ratbag_device *device)
+{
+	/* check if the device is still valid */
+	assert(ratbag_get_drv_data(device) != NULL);
+
+	return 0;
+}
+
 struct ratbag_driver test_driver = {
 	.name = "Test driver",
 	.id = "test_driver",
 	.probe = test_fake_probe,
 	.test_probe = test_probe,
 	.remove = test_remove,
-	.write_profile = test_write_profile,
+	.commit = test_commit,
 	.set_active_profile = test_set_active_profile,
-	.write_button = test_write_button,
-	.write_resolution_dpi = NULL,
-	.write_led = test_write_led,
 };

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -197,13 +197,6 @@ struct ratbag_driver {
 	 */
 	int (*commit)(struct ratbag_device *device);
 
-	/*
-	 * FIXME: This function is deprecated and should be removed. Once
-	 * we've updated all the device drivers to stop using it we'll remove
-	 * it. Look at commit() instead.
-	 */
-	int (*write_profile)(struct ratbag_profile *profile);
-
 	/**
 	 * Called to mark a previously writen profile as active.
 	 *
@@ -211,31 +204,6 @@ struct ratbag_driver {
 	 * .write_profile() call is issued before calling this.
 	 */
 	int (*set_active_profile)(struct ratbag_device *device, unsigned int index);
-
-	/*
-	 * FIXME: This function is deprecated and should be removed. Once
-	 * we've updated all the device drivers to stop using it we'll remove
-	 * it. Look at commit() instead.
-	 */
-	int (*write_button)(struct ratbag_button *button,
-			    const struct ratbag_button_action *action);
-
-	/*
-	 * FIXME: This function is deprecated and should be removed. Once
-	 * we've updated all the device drivers to stop using it we'll remove
-	 * it. Look at commit() instead.
-	 */
-	int (*write_resolution_dpi)(struct ratbag_resolution *resolution,
-				    int dpi_x, int dpi_y);
-
-	/*
-	 * FIXME: This function is deprecated and should be removed. Once
-	 * we've updated all the device drivers to stop using it we'll remove
-	 * it. Look at commit() instead.
-	 */
-	int (*write_led)(struct ratbag_led *led, enum ratbag_led_mode mode,
-			 struct ratbag_color color, unsigned int ms,
-			 unsigned int brightness);
 
 	/* private */
 	int (*test_probe)(struct ratbag_device *device, const void *data);


### PR DESCRIPTION
This basically puts now removed `ratbag_old_write_profile` in every driver that has not yet migrated to the profile-oriented API. The only other change is that now `etekcity` driver only writes profile once. While is might in theory be breaking, I think it's safe to assume it wont as I don't think official software destroys EEPROM of the mouse by repetitive overwriting like it did before this change.