### PR TITLE
steelseries: fix length of LED cycle output report being incorrect

### DIFF
--- a/src/driver-steelseries.c
+++ b/src/driver-steelseries.c
@@ -893,7 +893,7 @@ steelseries_write_led_cycle(struct ratbag_led *led,
 						sizeof(msg.msg.parameters), cycle_spec->hid_report_type,
 						HID_REQ_SET_REPORT);
 	else
-		ret = ratbag_hidraw_output_report(device, msg.data, sizeof(STEELSERIES_REPORT_SIZE));
+		ret = ratbag_hidraw_output_report(device, msg.data, sizeof(msg.data));
 
 	if (ret < 0)
 		return ret;


### PR DESCRIPTION
It probably meant to use the macro directly, not `sizeof` of it (which
made it be 4 instead of 64).

Found by clang-tidy. I'm not sure how it worked before considering this, so somebody with a V2 mouse should test this first.