### PR TITLE
roccat: remove an unnecessary #include

### DIFF
--- a/src/driver-roccat-kone-emp.c
+++ b/src/driver-roccat-kone-emp.c
@@ -35,7 +35,6 @@
 
 #include "config.h"
 #include <assert.h>
-#include <bits/stdint-uintn.h>
 #include <errno.h>
 #include <libevdev/libevdev.h>
 #include <linux/input.h>


### PR DESCRIPTION
No obvious reason why we need to include that header and it appears to
be glibc-specific. Let's use stdint.h instead (which is already
included).

cc @LittleWhite-tb, @lonjil

Reported in https://github.com/libratbag/libratbag/issues/1253#issuecomment-1038311104