### PR TITLE
set first profile as active if no active profile found

### DIFF
--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -2103,7 +2103,7 @@ hidpp20_onboard_profiles_set_onboard_mode(struct hidpp20_device *device,
 int
 hidpp20_onboard_profiles_get_current_profile(struct hidpp20_device *device)
 {
-	uint8_t feature_index;
+	uint8_t feature_index, unknown_0, active_profile_index;
 	int rc;
 	union hidpp20_message msg = {
 		.msg.report_id = REPORT_ID_SHORT,
@@ -2122,7 +2122,15 @@ hidpp20_onboard_profiles_get_current_profile(struct hidpp20_device *device)
 	if (rc)
 		return rc;
 
-	return msg.msg.parameters[1];
+	unknown_0 = msg.msg.parameters[0];
+	active_profile_index = msg.msg.parameters[1];
+
+	hidpp_log_raw(
+	    &device->base,
+	    "current active profile is index: %d unknown_0: %d\n",
+	    active_profile_index, unknown_0);
+
+	return active_profile_index;
 }
 
 int


### PR DESCRIPTION
a pristine mouse will often come with competly clean memory and there will be no
active profile set, the result is that mouse cannot be configured by libratbag
at all.