### PR TITLE
libratbag-data: fix a memory leak

### DIFF
--- a/src/libratbag-data.c
+++ b/src/libratbag-data.c
@@ -325,7 +325,17 @@ ratbag_device_data_destroy(struct ratbag_device_data *data)
 {
 	switch (data->drivertype) {
 	case HIDPP10:
+		free(data->hidpp10.dpi_list->entries);
+
+		free(data->hidpp10.dpi_list);
+		free(data->hidpp10.dpi_range);
 		free(data->hidpp10.profile_type);
+		break;
+	case STEELSERIES:
+		free(data->steelseries.dpi_list->entries);
+
+		free(data->steelseries.dpi_list);
+		free(data->steelseries.dpi_range);
 		break;
 	default:
 		break;


### PR DESCRIPTION
In driver data of hidpp10 and steelseries drivers `dpi_list` and
`dpi_range` were allocated with calloc, but never got freed.

Found with Valgrind, I noticed this a long time ago, but never stumbled upon the deconstuctor of driver data where the `free` call could be added.