### PR TITLE
SinoWealth driver improvemnts

### DIFF
--- a/src/driver-sinowealth.c
+++ b/src/driver-sinowealth.c
@@ -572,7 +572,7 @@ sinowealth_raw_to_report_rate(uint8_t raw)
 
 /* @return Maximum DPI for sensor `sensor` or 0 on error. */
 static unsigned int
-get_max_dpi_for_sensor(enum sinowealth_sensor sensor)
+sinowealth_get_max_dpi_for_sensor(enum sinowealth_sensor sensor)
 {
 	switch (sensor) {
 	case PWM3327: return 10200;
@@ -610,7 +610,7 @@ sinowealth_dpi_to_raw(struct ratbag_device *device, unsigned int dpi)
 	struct sinowealth_data *drv_data = device->drv_data;
 	enum sinowealth_sensor sensor = drv_data->sensor;
 
-	assert(dpi >= SINOWEALTH_DPI_MIN && dpi <= get_max_dpi_for_sensor(sensor));
+	assert(dpi >= SINOWEALTH_DPI_MIN && dpi <= sinowealth_get_max_dpi_for_sensor(sensor));
 
 	unsigned int raw = dpi / 100;
 
@@ -1453,7 +1453,7 @@ sinowealth_init_profile(struct ratbag_device *device)
 	/* Number of DPIs = all DPIs from min to max (inclusive) and "0 DPI" as a special value
 	 * to signal a disabled DPI step.
 	 */
-	unsigned int num_dpis = (get_max_dpi_for_sensor(drv_data->sensor) - SINOWEALTH_DPI_MIN) / SINOWEALTH_DPI_STEP + 2;
+	unsigned int num_dpis = (sinowealth_get_max_dpi_for_sensor(drv_data->sensor) - SINOWEALTH_DPI_MIN) / SINOWEALTH_DPI_STEP + 2;
 
 	ratbag_device_init_profiles(device, SINOWEALTH_NUM_PROFILES, SINOWEALTH_NUM_DPIS, drv_data->button_count, drv_data->led_count);
 

--- a/src/driver-sinowealth.c
+++ b/src/driver-sinowealth.c
@@ -1464,6 +1464,18 @@ static const struct sinowealth_device_data sinowealth_supported_devices[] = {
 		.button_count = 6,
 	},
 
+	/* 2581:1007 devices. */
+	{
+		.fw_version = "9677",
+		.device_name = "Marvo Scorpion G961",
+		.led_type = LED_RGB,
+		/* Official software allows up to 12000 DPI instead of 10200. */
+		.sensor_type = SINOWEALTH_SENSOR_PMW3327,
+		.vid = 0x258a,
+		.pid = 0x1007,
+		.button_count = 6,
+	},
+
 	/* Dummy device. Make sure it's the last entry. */
 	{
 		.fw_version = "0000",

--- a/src/driver-sinowealth.c
+++ b/src/driver-sinowealth.c
@@ -495,7 +495,7 @@ sinowealth_button_data_is_equal(const struct sinowealth_button_data *lhs, const 
 
 /* Convert a button action to raw data using the `sinowealth_button_map`.
  * NOTE: It does not contain all of the button types, as some of them are
- * better made programatically. See @ref sinowealth_update_buttons_from_profile.
+ * better made programmatically. See @ref sinowealth_update_buttons_from_profile.
  *
  * @param data Struct to write to.
  *
@@ -518,7 +518,7 @@ sinowealth_button_action_to_raw(const struct ratbag_button_action *action, struc
 
 /* Convert raw button data to a button action using the `sinowealth_button_map`.
  * NOTE: It does not contain all of the button types, as some of them are
- * better made programatically. See @ref sinowealth_update_profile_from_buttons.
+ * better made programmatically. See @ref sinowealth_update_profile_from_buttons.
  *
  * @return Button action or NULL if such action is not in the map. */
 static const struct ratbag_button_action *

--- a/src/driver-sinowealth.c
+++ b/src/driver-sinowealth.c
@@ -58,7 +58,7 @@ _Static_assert(sizeof(enum sinowealth_command_id) == sizeof(uint8_t), "Invalid s
 /* Report length commands that get configuration data should use. */
 #define SINOWEALTH_CONFIG_REPORT_SIZE 520
 #define SINOWEALTH_CONFIG_SIZE_MAX 167
-#define SINOWEALTH_CONFIG_SIZE_MIN 131
+#define SINOWEALTH_CONFIG_SIZE_MIN 123
 
 #define SINOWEALTH_MACRO_SIZE 515
 
@@ -222,6 +222,12 @@ struct sinowealth_config_report {
 	uint8_t unknown3[12];
 	struct sinowealth_rgb_mode rave_mode;
 	struct sinowealth_color rave_colors[2];
+
+	/* From here onward goes the data not available in short mice.
+	 * .. judging by the size of this struct. The data in them may
+	 * actually be different, we didn't test this yet.
+	 */
+
 	struct sinowealth_rgb_mode random_mode;
 	struct sinowealth_rgb_mode wave_mode;
 	struct sinowealth_rgb_mode breathing1_mode;
@@ -235,7 +241,7 @@ struct sinowealth_config_report {
 
 	/* From here onward goes the data only available in long mice. */
 
-	uint8_t unknown5[SINOWEALTH_CONFIG_SIZE_MAX - SINOWEALTH_CONFIG_SIZE_MIN];
+	uint8_t unknown5[36];
 
 	uint8_t padding[SINOWEALTH_CONFIG_REPORT_SIZE - SINOWEALTH_CONFIG_SIZE_MAX];
 } __attribute__((packed));

--- a/src/driver-sinowealth.c
+++ b/src/driver-sinowealth.c
@@ -1090,6 +1090,7 @@ sinowealth_update_profile_from_config(struct ratbag_profile *profile)
 			led->color = sinowealth_raw_to_color(device, config->breathing1_color);
 			sinowealth_set_led_from_rgb_mode(led, config->breathing1_mode);
 			break;
+		case RGB_NOT_SUPPORTED:
 		default:
 			log_error(device->ratbag, "Got unknown RGB effect: %d\n", config->rgb_effect);
 			break;

--- a/src/driver-sinowealth.c
+++ b/src/driver-sinowealth.c
@@ -1795,6 +1795,14 @@ sinowealth_update_config_from_profile(struct ratbag_profile *profile)
 	ratbag_profile_for_each_resolution(profile, resolution) {
 		if (!resolution->dpi_x || !resolution->dpi_y)
 			continue;
+
+		/* Limit the resolution if it somehow got higher than allowed. */
+		{
+			const unsigned int max_dpi = sinowealth_get_max_dpi_for_sensor(config->sensor_type);
+			resolution->dpi_x = min(resolution->dpi_x, max_dpi);
+			resolution->dpi_y = min(resolution->dpi_y, max_dpi);
+		}
+
 		if (config->config_flags & SINOWEALTH_XY_INDEPENDENT) {
 			config->dpis.independent[resolution->index].x = sinowealth_dpi_to_raw(device, resolution->dpi_x);
 			config->dpis.independent[resolution->index].y = sinowealth_dpi_to_raw(device, resolution->dpi_y);

--- a/src/driver-sinowealth.c
+++ b/src/driver-sinowealth.c
@@ -105,11 +105,14 @@ struct sinowealth_color {
 } __attribute__((packed));
 _Static_assert(sizeof(struct sinowealth_color) == 3, "Invalid size");
 
+/* Sensor IDs used in SinoWealth firmware and software. */
 enum sinowealth_sensor {
-	PWM3327,
-	PWM3360,
-	PWM3389,
-};
+	SINOWEALTH_SENSOR_NONE,
+	PWM3360 = 0x06,
+	PWM3327 = 0x0e,
+	PWM3389 = 0x0f,
+} __attribute__((packed));
+_Static_assert(sizeof(enum sinowealth_sensor) == sizeof(uint8_t), "Invalid sensor enum size");
 
 enum sinowealth_rgb_effect {
 	RGB_OFF = 0,

--- a/src/driver-sinowealth.c
+++ b/src/driver-sinowealth.c
@@ -604,7 +604,7 @@ sinowealth_raw_to_dpi(struct ratbag_device *device, unsigned int raw)
  *
  * @ref sinowealth_dpis.
  */
-static unsigned int
+static uint8_t
 sinowealth_dpi_to_raw(struct ratbag_device *device, unsigned int dpi)
 {
 	struct sinowealth_data *drv_data = device->drv_data;
@@ -612,7 +612,7 @@ sinowealth_dpi_to_raw(struct ratbag_device *device, unsigned int dpi)
 
 	assert(dpi >= SINOWEALTH_DPI_MIN && dpi <= sinowealth_get_max_dpi_for_sensor(sensor));
 
-	unsigned int raw = dpi / 100;
+	uint8_t raw = dpi / 100;
 
 	if (sensor == PWM3327 || sensor == PWM3360)
 		raw -= 1;

--- a/src/driver-sinowealth.c
+++ b/src/driver-sinowealth.c
@@ -66,6 +66,10 @@ _Static_assert(sizeof(enum sinowealth_command_id) == sizeof(uint8_t), "Invalid s
 /* The PC software only goes down to 400, but the PMW3360 doesn't care */
 #define SINOWEALTH_DPI_MIN 100
 #define SINOWEALTH_DPI_STEP 100
+/* Arbitrary, but I think every sensor supports this DPI, and this is
+ * about as high as most people would ever like to go anyway.
+ */
+#define SINOWEALTH_DPI_FALLBACK 2000
 
 /* Different software expose different amount of DPI slots:
  * Glorious - 6;
@@ -589,7 +593,7 @@ sinowealth_get_max_dpi_for_sensor(enum sinowealth_sensor sensor)
 	case SINOWEALTH_SENSOR_PMW3327: return 10200;
 	case SINOWEALTH_SENSOR_PMW3360: return 12000;
 	case SINOWEALTH_SENSOR_PMW3389: return 16000;
-	default: return 0;
+	default: return SINOWEALTH_DPI_FALLBACK;
 	}
 }
 

--- a/src/driver-sinowealth.c
+++ b/src/driver-sinowealth.c
@@ -37,6 +37,7 @@ enum sinowealth_command_id {
 	SINOWEALTH_CMD_PROFILE = 0x2,
 	SINOWEALTH_CMD_GET_CONFIG = 0x11,
 	SINOWEALTH_CMD_GET_BUTTONS = 0x12,
+	/* Doesn't work on devices with shorter configuration data (123 instead of 137). */
 	SINOWEALTH_CMD_DEBOUNCE = 0x1a,
 	/* Only works on devices that use CONFIG_LONG report ID. */
 	SINOWEALTH_CMD_LONG_ANGLESNAPPING_AND_LOD = 0x1b,

--- a/src/driver-sinowealth.c
+++ b/src/driver-sinowealth.c
@@ -195,7 +195,9 @@ struct sinowealth_config_report {
 	 * CONFIG_SIZE-8 - write.
 	 */
 	uint8_t config_write;
-	uint8_t unknown2[6];
+	uint8_t unknown2[2];
+	enum sinowealth_sensor sensor_type;
+	uint8_t unknown6[3];
 	/* @ref sinowealth_report_rate_map. */
 	uint8_t report_rate:4;
 	/* 0b1000 - make DPI axes independent. */


### PR DESCRIPTION
- Make it easier to add new devices by putting devices data into a struct, instead of working with the values manually. This way a person that doesn't understand coding can easily add new data (though they would have to be familiar with building process).
- Automatically detect sensor type, and if the sensor type was recognized, set corresponding maximum DPI.
- Add support for Marvo Scorpion G961, which has shorter configuration data. Though to use it, a device file for ratbagd would have to be created manually, as another mice with the same VID:PID has been reported not to work (Ant Esports GM500). Incidentally it also has shorter configuration data.
- Minor quality of life improvements.