### PR TITLE
Add device-file for Logitech MX Anywhere 3B

### DIFF
--- a/data/devices/logitech-MX-Anywhere3B.device
+++ b/data/devices/logitech-MX-Anywhere3B.device
@@ -1,0 +1,4 @@
+# Logitech MX Anywhere 3B
+[Device]
+Name=Logitech MX Anywhere 3B
+DeviceMatch=bluetooth:046d:b02d;usb:046d:c548

--- a/data/devices/logitech-MX-Anywhere3B.device
+++ b/data/devices/logitech-MX-Anywhere3B.device
@@ -1,4 +1,4 @@
 # Logitech MX Anywhere 3B
 [Device]
 Name=Logitech MX Anywhere 3B
-DeviceMatch=bluetooth:046d:b02d;usb:046d:c548
+DeviceMatch=bluetooth:046d:b02d


### PR DESCRIPTION
This variant stands for Logitech MX Anywhere 3 for Business.

Signed-off-by: Sami Olmari <sami@olmari.fi>