### PR TITLE
sinowealth: fix all devices being detected as `generic device`

### DIFF
--- a/src/driver-sinowealth.c
+++ b/src/driver-sinowealth.c
@@ -1497,7 +1497,7 @@ sinowealth_find_device_data(struct input_id ids, const char *fw_version)
 		if (device_data->vid != ids.vendor || device_data->pid != ids.product)
 			continue;
 
-		if (strneq(fw_version, device_data->fw_version, sizeof(device_data->fw_version)))
+		if (!strneq(fw_version, device_data->fw_version, sizeof(device_data->fw_version)))
 			continue;
 
 		return device_data;


### PR DESCRIPTION
Hot-fix.
I did not notice that the logic was inverted when I replaced `strncmp` with `strneq`, and I didn't test it, oops.
I guess that's exactly the reason why `strneq` is more safe. :D