### PR TITLE
RFC: use function defined by DEFINE_TRIVIAL_CLEANUP_FUNC manually as well

### DIFF
--- a/src/libratbag-data.c
+++ b/src/libratbag-data.c
@@ -124,22 +124,17 @@ init_data_hidpp10(struct ratbag *ratbag,
 	num = g_key_file_get_integer(keyfile, group, "DeviceIndex", &error);
 	if (num != 0 || !error)
 		data->hidpp10.index = num;
-	if (error)
-		g_error_free(error);
+	g_error_freep(&error);
 
-	error = NULL;
 	num = g_key_file_get_integer(keyfile, group, "Profiles", &error);
 	if (num > 0 || !error)
 		data->hidpp10.profile_count = num;
-	if (error)
-		g_error_free(error);
+	g_error_freep(&error);
 
-	error = NULL;
 	num = g_key_file_get_integer(keyfile, group, "Leds", &error);
 	if (num > 0 || !error)
 		data->hidpp10.led_count = num;
-	if (error)
-		g_error_free(error);
+	g_error_freep(&error);
 
 	profile_type = g_key_file_get_string(keyfile, group, "ProfileType", NULL);
 	if (profile_type)
@@ -173,29 +168,22 @@ init_data_hidpp20(struct ratbag *ratbag,
 	num = g_key_file_get_integer(keyfile, group, "Buttons", &error);
 	if (num > 0 || !error)
 		data->hidpp20.button_count = num;
-	if (error)
-		g_error_free(error);
+	g_error_freep(&error);
 
-	error = NULL;
 	num = g_key_file_get_integer(keyfile, group, "DeviceIndex", &error);
 	if (num != 0 || !error)
 		data->hidpp20.index = num;
-	if (error)
-		g_error_free(error);
+	g_error_freep(&error);
 
-	error = NULL;
 	num = g_key_file_get_integer(keyfile, group, "Leds", &error);
 	if (!error)
 		data->hidpp20.led_count = num;
-	if (error)
-		g_error_free(error);
+	g_error_freep(&error);
 
-	error = NULL;
 	num = g_key_file_get_integer(keyfile, group, "ReportRate", &error);
 	if (num > 0 || !error)
 		data->hidpp20.report_rate = num;
-	if (error)
-		g_error_free(error);
+	g_error_freep(&error);
 
 	str = g_key_file_get_string(keyfile, group, "Quirk", NULL);
 	data->hidpp20.quirk = HIDPP20_QUIRK_NONE;
@@ -228,22 +216,17 @@ init_data_steelseries(struct ratbag *ratbag,
 	num = g_key_file_get_integer(keyfile, group, "Buttons", &error);
 	if (num != 0 || !error)
 		data->steelseries.button_count = num;
-	if (error)
-		g_error_free(error);
+	g_error_freep(&error);
 
-	error = NULL;
 	num = g_key_file_get_integer(keyfile, group, "Leds", &error);
 	if (num > 0 || !error)
 		data->steelseries.led_count = num;
-	if (error)
-		g_error_free(error);
+	g_error_freep(&error);
 
-	error = NULL;
 	num = g_key_file_get_integer(keyfile, group, "DeviceVersion", &error);
 	if (num > 0 || !error)
 		data->steelseries.device_version = num;
-	if (error)
-		g_error_free(error);
+	g_error_freep(&error);
 
 	dpi_range = g_key_file_get_string(keyfile, group, "DpiRange", NULL);
 	if (dpi_range) {
@@ -254,12 +237,10 @@ init_data_steelseries(struct ratbag *ratbag,
 			data->steelseries.dpi_list = dpi_list_from_string(dpi_range);
 	}
 
-	error = NULL;
 	num = g_key_file_get_integer(keyfile, group, "MacroLength", &error);
 	if (num > 0 || !error)
 		data->steelseries.macro_length = num;
-	if (error)
-		g_error_free(error);
+	g_error_freep(&error);
 
 	quirk = g_key_file_get_string(keyfile, group, "Quirk", NULL);
 	if (quirk) {

--- a/src/shared-macro.h
+++ b/src/shared-macro.h
@@ -128,8 +128,10 @@ static inline void reset_errno(int *saved_errno)
 #define DEFINE_TRIVIAL_CLEANUP_FUNC(_type, _func)		\
 	static inline void _func##p(_type *_p)			\
 	{							\
-		if (*_p)					\
+		if (*_p) {					\
 			_func(*_p);				\
+			*_p = NULL;				\
+		}						\
 	}							\
 	struct __useless_struct_to_allow_trailing_semicolon__
 


### PR DESCRIPTION
While adding some new options to device files, I forgot to reset the `error` pointer after freeing it. Once there were `free` calls, I got double free, which took me a while to find.

This way we would never have to think about resetting the pointer, preventing potential double-free errors in the future. This also eliminates some code duplication. 