### PR TITLE
libratbag-data: fix possible NULL dereferences

### DIFF
--- a/src/libratbag-data.c
+++ b/src/libratbag-data.c
@@ -325,16 +325,20 @@ ratbag_device_data_destroy(struct ratbag_device_data *data)
 {
 	switch (data->drivertype) {
 	case HIDPP10:
-		free(data->hidpp10.dpi_list->entries);
+		if (data->hidpp10.dpi_list) {
+			free(data->hidpp10.dpi_list->entries);
+			free(data->hidpp10.dpi_list);
+		}
 
-		free(data->hidpp10.dpi_list);
 		free(data->hidpp10.dpi_range);
 		free(data->hidpp10.profile_type);
 		break;
 	case STEELSERIES:
-		free(data->steelseries.dpi_list->entries);
+		if (data->steelseries.dpi_list) {
+			free(data->steelseries.dpi_list->entries);
+			free(data->steelseries.dpi_list);
+		}
 
-		free(data->steelseries.dpi_list);
 		free(data->steelseries.dpi_range);
 		break;
 	default:


### PR DESCRIPTION
This can happen when a device has not properly initialized and this
fields have not been set.