### PR TITLE
Use fprintf instead of error

### DIFF
--- a/tools/hidpp10-dump-page.c
+++ b/tools/hidpp10-dump-page.c
@@ -23,7 +23,6 @@
 
 #include <config.h>
 #include <errno.h>
-#include <error.h>
 #include <fcntl.h>
 
 #include <hidpp10.h>
@@ -94,8 +93,10 @@ main(int argc, char **argv)
 
 	path = argv[argc - 1];
 	fd = open(path, O_RDWR);
-	if (fd < 0)
-		error(1, errno, "Failed to open path %s", path);
+	if (fd < 0) {
+		fprintf(stderr, "Failed to open path '%s': %s", path, strerror(errno));
+		exit(3);
+	}
 
 	hidpp_device_init(&base, fd);
 	rc = hidpp10_device_new(&base, HIDPP_WIRED_DEVICE_IDX, HIDPP10_PROFILE_UNKNOWN, 5, &dev);

--- a/tools/hidpp20-dump-page.c
+++ b/tools/hidpp20-dump-page.c
@@ -23,7 +23,6 @@
 
 #include <config.h>
 #include <errno.h>
-#include <error.h>
 #include <fcntl.h>
 
 #include <hidpp20.h>
@@ -111,13 +110,17 @@ main(int argc, char **argv)
 
 	path = argv[argc - 1];
 	fd = open(path, O_RDWR);
-	if (fd < 0)
-		error(1, errno, "Failed to open path %s", path);
+	if (fd < 0) {
+		fprintf(stderr, "Failed to open path '%s': %s", path, strerror(errno));
+		exit(3);
+	}
 
 	hidpp_device_init(&base, fd);
 	dev = hidpp20_device_new(&base, 0xff, NULL, 0);
-	if (!dev)
-		error(1, 0, "Failed to open %s as a HID++ 2.0 device", path);
+	if (!dev) {
+		fprintf(stderr, "Failed to open %s as a HID++ 2.0 device", path);
+		exit(3);
+	}
 
 	hidpp20_onboard_profiles_get_profiles_desc(dev, &info);
 

--- a/tools/hidpp20-reset.c
+++ b/tools/hidpp20-reset.c
@@ -23,7 +23,6 @@
 
 #include <config.h>
 #include <errno.h>
-#include <error.h>
 #include <fcntl.h>
 
 #include <hidpp20.h>
@@ -87,13 +86,17 @@ main(int argc, char **argv)
 
 	path = argv[argc - 1];
 	fd = open(path, O_RDWR);
-	if (fd < 0)
-		error(1, errno, "Failed to open path %s", path);
+	if (fd < 0) {
+		fprintf(stderr, "Failed to open path '%s': %s", path, strerror(errno));
+		exit(3);
+	}
 
 	hidpp_device_init(&base, fd);
 	dev = hidpp20_device_new(&base, 0xff, NULL, 0);
-	if (!dev)
-		error(1, 0, "Failed to open %s as a HID++ 2.0 device", path);
+	if (!dev) {
+		fprintf(stderr, "Failed to open %s as a HID++ 2.0 device", path);
+		exit(3);
+	}
 
 	hidpp20_onboard_profiles_get_profiles_desc(dev, &info);
 


### PR DESCRIPTION
hidpp files were using the error function from error.h header file.
Unfortunately not every libc comes with this particular header file, so
with this patch we won't be requiring to be rely on error function and
use fprintf function.

Thanks to developer Yaroslav Chvanov <staticssleever668> for the
original suggestion

Closes: https://github.com/libratbag/libratbag/issues/1253

Signed-off-by: listout <listout@protonmail.com>