### PR TITLE
sinowealth: move device-specific data out of the driver

### DIFF
--- a/data/devices/glorious-model-d.device
+++ b/data/devices/glorious-model-d.device
@@ -3,3 +3,9 @@ Name=Glorious Model D
 DeviceMatch=usb:258a:0033
 Driver=sinowealth
 
+[Driver/sinowealth/devices/GloriousModelD]
+ButtonCount=6
+DeviceName=Glorious Model D
+FwVersion=V102
+LedType=RBG
+SensorType=PMW3360

--- a/data/devices/glorious-model-o.device
+++ b/data/devices/glorious-model-o.device
@@ -3,3 +3,9 @@ Name=Glorious Model O/O-
 DeviceMatch=usb:258a:0036
 Driver=sinowealth
 
+[Driver/sinowealth/devices/GloriousModelO]
+ButtonCount=6
+DeviceName=Glorious Model O/O- (updated firmware)
+FwVersion=V103
+LedType=RBG
+SensorType=PMW3360

--- a/data/devices/sinowealth-0027.device
+++ b/data/devices/sinowealth-0027.device
@@ -1,10 +1,38 @@
 [Device]
-# Several mice match this ID:
-# - Dream Machines DM5 Blink
-# - G-Wolves Hati HT-M Wired Ace
-# - G-Wolves Hati HT-M Wired Classic
-# - Genesys Xenon 770
-# - Glorious Model O (old firmware)
 DeviceMatch=usb:258a:0027
 Driver=sinowealth
 Name=SinoWealth Generic Mouse (0027)
+
+[Driver/sinowealth/devices/DreamMachinesDM5Blink]
+ButtonCount=8
+DeviceName=DreamMachines DM5 Blink
+FwVersion=3106
+LedType=RGB
+SensorType=PMW3389
+
+[Driver/sinowealth/devices/GWolvesHatiHTM]
+ButtonCount=6
+# Can be both `Ace` and `Classic` version.
+DeviceName=G-Wolves Hati HT-M Wired
+FwVersion=V161
+LedType=None
+# Can also be PMW3389
+SensorType=PMW3360
+
+[Driver/sinowealth/devices/GenesysXenon770]
+# There are 5 main buttons.
+# Side buttons are detachable.
+# There can be either 3 or 9 buttons on the side.
+# Going for the maximum count: 5 + 9 = 14.
+ButtonCount=14
+DeviceName=Genesys Xenon 770
+FwVersion=3110
+LedType=RGB
+SensorType=PMW3327
+
+[Driver/sinowealth/devices/GloriousModelOOld]
+ButtonCount=6
+DeviceName=Glorious Model O (old firmware)
+FwVersion=V102
+LedType=RBG
+SensorType=PMW3360

--- a/data/devices/sinowealth-1007.device
+++ b/data/devices/sinowealth-1007.device
@@ -1,0 +1,20 @@
+[Device]
+DeviceMatch=usb:258a:1007
+Driver=sinowealth
+Name=SinoWealth Generic Mouse (1007)
+
+# This does NOT work. See libratbag/libratbag#1296.
+# For future: ID of A3050 sensor is 0x2, and maximum DPI is 4000.
+#[Driver/sinowealth/devices/AntEsportsGM500]
+#ButtonCount=7
+#DeviceName=Ant Esports GM500
+#FwVersion=0910
+#LedType=RBG
+#SensorType=A3050
+
+[Driver/sinowealth/devices/MarvoScorpionG961]
+ButtonCount=6
+DeviceName=Marvo Scorpion G961
+FwVersion=9677
+LedType=RGB
+SensorType=PMW3327

--- a/meson.build
+++ b/meson.build
@@ -179,6 +179,7 @@ src_libratbag = [
 	'src/driver-steelseries.c',
 	'src/driver-steelseries.h',
 	'src/driver-sinowealth.c',
+	'src/driver-sinowealth.h',
 	'src/driver-sinowealth-nubwo.c',
 	'src/driver-test.c',
 	'src/libratbag.c',

--- a/src/driver-sinowealth.c
+++ b/src/driver-sinowealth.c
@@ -1529,11 +1529,11 @@ sinowealth_init_profile(struct ratbag_device *device)
 	 */
 	struct sinowealth_config_report *config = &drv_data->configs[0];
 
-	char fw_version[SINOWEALTH_FW_VERSION_LEN] = { 0 };
+	char fw_version[SINOWEALTH_FW_VERSION_LEN + 1] = { 0 };
 	rc = sinowealth_get_fw_version(device, fw_version);
 	if (rc)
 		return rc;
-	log_info(device->ratbag, "firmware version: %.4s\n", fw_version);
+	log_info(device->ratbag, "firmware version: %s\n", fw_version);
 
 	rc = sinowealth_read_raw_config(device);
 	if (rc)

--- a/src/driver-sinowealth.c
+++ b/src/driver-sinowealth.c
@@ -87,6 +87,8 @@ _Static_assert(sizeof(enum sinowealth_command_id) == sizeof(uint8_t), "Invalid s
 /* Maximum amount of real events in a macro. */
 #define SINOWEALTH_MACRO_LENGTH_MAX 168
 
+#define SINOWEALTH_FW_VERSION_LEN 4
+
 /* Bit mask for @ref sinowealth_config_report.config.
  *
  * This naming may be incorrect as it's not actually known what the other bits do.
@@ -1527,7 +1529,7 @@ sinowealth_init_profile(struct ratbag_device *device)
 	 */
 	struct sinowealth_config_report *config = &drv_data->configs[0];
 
-	char fw_version[4];
+	char fw_version[SINOWEALTH_FW_VERSION_LEN] = { 0 };
 	rc = sinowealth_get_fw_version(device, fw_version);
 	if (rc)
 		return rc;

--- a/src/driver-sinowealth.h
+++ b/src/driver-sinowealth.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2022 Yaroslav Chvanov
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#include "libratbag-util.h"
+
+enum sinowealth_led_format {
+	SINOWEALTH_LED_TYPE_NONE,
+	SINOWEALTH_LED_TYPE_RBG,
+	SINOWEALTH_LED_TYPE_RGB,
+};
+
+struct sinowealth_device_data {
+	char *fw_version;
+	char *device_name;
+	enum sinowealth_led_format led_type;
+	unsigned int button_count;
+
+	struct list link;
+};

--- a/src/libratbag-data.h
+++ b/src/libratbag-data.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include "libratbag-private.h"
+
 struct ratbag_device_data;
 
 struct ratbag_device_data *

--- a/src/libratbag-data.h
+++ b/src/libratbag-data.h
@@ -92,6 +92,16 @@ ratbag_device_data_hidpp20_get_report_rate(const struct ratbag_device_data *data
 enum hidpp20_quirk
 ratbag_device_data_hidpp20_get_quirk(const struct ratbag_device_data *data);
 
+/* SinoWealth */
+
+/*
+ * NOTE: Don't forget to check for NULL in fields of each device data entry.
+ *
+ * @return List of data for supported devices.
+ */
+const struct list *
+ratbag_device_data_sinowealth_get_supported_devices(const struct ratbag_device_data *data);
+
 /* SteelSeries */
 
 /**


### PR DESCRIPTION
This moves device data out of the driver into device files. However, a
_single_ device file contains data for _several mice_ at the same time.
The reason for this is that different mice by SinoWealth may use the
same VID:PID pair. This is unfortunate, as we only allow a single
device file a given VID:PID pair.

@whot, what do you think of such a way? I've looked into making it possible to split it further so that each device has it's own device file by allowing several devices with the same VID:PID pair, but it turned out to be quite complex. Doing it like so on contrary was pretty easy.

Unrelated: also move `sinowealth_led_format` enum into a header file and rename
its constants to fit in outside of the driver.