### PR TITLE
Add Support for G502 X over USB

### DIFF
--- a/data/devices/logitech-g502-x.device
+++ b/data/devices/logitech-g502-x.device
@@ -1,0 +1,4 @@
+[Device]
+Name=Logitech G502 X
+DeviceMatch=usb:046d:c099
+Driver=hidpp20


### PR DESCRIPTION
Just received my G502 X and saw it is not yet supported. This trivial change made ratbagd recognize it. Thus pull request addresses the "basic" version of the G502 X connected via USB.