### PR TITLE
implement key bindings feature

### DIFF
--- a/ratbagd/ratbagd-button.c
+++ b/ratbagd/ratbagd-button.c
@@ -160,7 +160,7 @@ static int ratbagd_button_get_key(sd_bus *bus,
 	struct ratbagd_button *button = userdata;
 	unsigned int key;
 
-	unsigned int *modifiers = 0;
+	unsigned int *modifiers = NULL;
 	size_t *sz = 0;
         key = ratbag_button_get_key(button->lib_button, modifiers, sz);
 
@@ -188,7 +188,7 @@ static int ratbagd_button_set_key(sd_bus *bus,
 
 	CHECK_CALL(sd_bus_message_read(m, "v", "u", &key));
 
-	unsigned int *modifiers = 0;
+	unsigned int *modifiers = NULL;
 	size_t sz = 0;
 	r = ratbag_button_set_key(button->lib_button, key, modifiers, sz);
 

--- a/ratbagd/ratbagd-button.c
+++ b/ratbagd/ratbagd-button.c
@@ -158,11 +158,10 @@ static int ratbagd_button_get_key(sd_bus *bus,
 				      sd_bus_error *error)
 {
 	struct ratbagd_button *button = userdata;
-	unsigned int key;
 
 	unsigned int *modifiers = NULL;
 	size_t *sz = 0;
-        key = ratbag_button_get_key(button->lib_button, modifiers, sz);
+	const unsigned int key = ratbag_button_get_key(button->lib_button, modifiers, sz);
 
 	verify_unsigned_int(key);
 

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -1294,7 +1294,8 @@ ratbag_button_get_key(struct ratbag_button *button,
 		return 0;
 
 	/* FIXME: modifiers */
-	*sz = 0;
+	if (sz != NULL)
+		*sz = 0;
 	return button->action.action.key.key;
 }
 

--- a/tools/ratbagc.py.in
+++ b/tools/ratbagc.py.in
@@ -634,7 +634,7 @@ class RatbagdButton(metaclass=MetaRatbag):
 
     @key.setter
     def key(self, key):
-        libratbag.ratbag_button_set_key(self._button, key, None, 0)
+        libratbag.ratbag_button_set_key(self._button, int(key), None, 0)
 
     @property
     def action_type(self):

--- a/tools/ratbagc.py.in
+++ b/tools/ratbagc.py.in
@@ -648,8 +648,18 @@ class RatbagdButton(metaclass=MetaRatbag):
     @property
     def action_types(self):
         """An array of possible values for ActionType."""
-        return [t for t in (RatbagdButton.ActionType.BUTTON, RatbagdButton.ActionType.SPECIAL, RatbagdButton.ActionType.KEY, RatbagdButton.ActionType.MACRO)
-                if libratbag.ratbag_button_has_action_type(self._button, t)]
+        POSSIBLE_ACTION_TYPES = (
+            RatbagdButton.ActionType.BUTTON,
+            RatbagdButton.ActionType.SPECIAL,
+            RatbagdButton.ActionType.KEY,
+            RatbagdButton.ActionType.MACRO,
+        )
+
+        return [
+            t
+            for t in POSSIBLE_ACTION_TYPES
+            if libratbag.ratbag_button_has_action_type(self._button, t)
+        ]
 
     def disable(self):
         """Disables this button."""

--- a/tools/ratbagc.py.in
+++ b/tools/ratbagc.py.in
@@ -500,6 +500,7 @@ class RatbagdButton(metaclass=MetaRatbag):
         NONE = libratbag.RATBAG_BUTTON_ACTION_TYPE_NONE
         BUTTON = libratbag.RATBAG_BUTTON_ACTION_TYPE_BUTTON
         SPECIAL = libratbag.RATBAG_BUTTON_ACTION_TYPE_SPECIAL
+        KEY = libratbag.RATBAG_BUTTON_ACTION_TYPE_KEY
         MACRO = libratbag.RATBAG_BUTTON_ACTION_TYPE_MACRO
 
     class ActionSpecial(IntEnum):
@@ -626,6 +627,14 @@ class RatbagdButton(metaclass=MetaRatbag):
         @param special The special entry, as one of RatbagdButton.ActionSpecial
         """
         libratbag.ratbag_button_set_special(self._button, special)
+
+    @property
+    def key(self):
+        return libratbag.ratbag_button_get_key(self._button, None, None)
+
+    @key.setter
+    def key(self, key):
+        libratbag.ratbag_button_set_key(self._button, key, None, 0)
 
     @property
     def action_type(self):

--- a/tools/ratbagc.py.in
+++ b/tools/ratbagc.py.in
@@ -634,7 +634,7 @@ class RatbagdButton(metaclass=MetaRatbag):
 
     @key.setter
     def key(self, key):
-        libratbag.ratbag_button_set_key(self._button, int(key), None, 0)
+        libratbag.ratbag_button_set_key(self._button, key, None, 0)
 
     @property
     def action_type(self):
@@ -648,7 +648,7 @@ class RatbagdButton(metaclass=MetaRatbag):
     @property
     def action_types(self):
         """An array of possible values for ActionType."""
-        return [t for t in (RatbagdButton.ActionType.BUTTON, RatbagdButton.ActionType.SPECIAL, RatbagdButton.ActionType.MACRO)
+        return [t for t in (RatbagdButton.ActionType.BUTTON, RatbagdButton.ActionType.SPECIAL, RatbagdButton.ActionType.KEY, RatbagdButton.ActionType.MACRO)
                 if libratbag.ratbag_button_has_action_type(self._button, t)]
 
     def disable(self):

--- a/tools/ratbagctl.in.in
+++ b/tools/ratbagctl.in.in
@@ -163,6 +163,8 @@ def print_button(d, p, b, level):
         print("{}'button {}'".format(header, b.mapping))
     elif b.action_type == RatbagdButton.ActionType.SPECIAL:
         print("{}'{}'".format(header, button_specials_strmap[b.special]))
+    elif b.action_type == RatbagdButton.ActionType.KEY:
+        print("{}key '{}'".format(header, str(b.key)))
     elif b.action_type == RatbagdButton.ActionType.MACRO:
         print("{}macro '{}'".format(header, str(b.macro)))
     elif b.action_type == RatbagdButton.ActionType.NONE:
@@ -322,6 +324,17 @@ def func_button_action_set_special(r, args):
         pass
     else:
         b.special = button_specials_strmap[special]
+    commit(d, args)
+
+
+def func_button_action_set_key(r, args):
+    b, p, d = find_button(r, args)
+    try:
+        key = args.target_key
+    except AttributeError:
+        pass
+    else:
+        b.key = key
     commit(d, args)
 
 
@@ -963,6 +976,20 @@ active profile if none is given.""",
                                         },
                                     ],
                                     func: func_button_action_set_special,
+                                },
+                                {
+                                    of_type: command,
+                                    name: 'key',
+                                    help_str: 'Set the button action to key',
+                                    pos_args: [
+                                        {
+                                            of_type: argument,
+                                            name: 'target_key',
+                                            metavar: 'S',
+                                            help_str: 'The new key value to assign',
+                                        },
+                                    ],
+                                    func: func_button_action_set_key,
                                 },
                                 {
                                     of_type: command,

--- a/tools/ratbagctl.in.in
+++ b/tools/ratbagctl.in.in
@@ -378,7 +378,7 @@ def func_button_action_set_macro(r, args):
             t = int(s[1:])
             macro.append(RatbagdButton.Macro.WAIT, t)
         else:
-            code = convert_str_to_evcode(key)
+            code = convert_str_to_evcode(s)
             if is_press:
                 macro.append(RatbagdButton.Macro.KEY_PRESS, code)
             if is_release:

--- a/tools/ratbagctl.in.in
+++ b/tools/ratbagctl.in.in
@@ -47,7 +47,11 @@ def convert_str_to_evcode(s: str) -> int:
         msg = "Don't know how to convert {}".format(s)
         raise argparse.ArgumentTypeError(msg)
 
-    return evdev.ecodes.ecodes[s]
+    try:
+        return evdev.ecodes.ecodes[s]
+    except KeyError:
+        msg = "No such button or key `{}`".format(s)
+        raise argparse.ArgumentTypeError(msg)
 
 
 def list_devices(r, args):

--- a/tools/ratbagctl.in.in
+++ b/tools/ratbagctl.in.in
@@ -42,6 +42,14 @@ button_specials_strmap = {
 }
 
 
+def convert_str_to_evcode(s: str) -> int:
+    if not s.startswith("KEY_") and not s.startswith("BTN_"):
+        msg = "Don't know how to convert {}".format(s)
+        raise argparse.ArgumentTypeError(msg)
+
+    return evdev.ecodes.ecodes[s]
+
+
 def list_devices(r, args):
     if not r.devices:
         print("No devices available.")
@@ -164,7 +172,8 @@ def print_button(d, p, b, level):
     elif b.action_type == RatbagdButton.ActionType.SPECIAL:
         print("{}'{}'".format(header, button_specials_strmap[b.special]))
     elif b.action_type == RatbagdButton.ActionType.KEY:
-        print("{}key '{}'".format(header, str(b.key)))
+        key_name = evdev.ecodes.KEY[b.key][RatbagdMacro._PREFIX_LEN:]
+        print("{}key '{}'".format(header, key_name))
     elif b.action_type == RatbagdButton.ActionType.MACRO:
         print("{}macro '{}'".format(header, str(b.macro)))
     elif b.action_type == RatbagdButton.ActionType.NONE:
@@ -329,12 +338,15 @@ def func_button_action_set_special(r, args):
 
 def func_button_action_set_key(r, args):
     b, p, d = find_button(r, args)
+    if not b.ActionType.KEY in b.action_types:
+        raise RatbagErrorCapability("assigning a key is not supported on this device")
+
     try:
         key = args.target_key
     except AttributeError:
         pass
     else:
-        b.key = key
+        b.key = convert_str_to_evcode(key)
     commit(d, args)
 
 
@@ -366,11 +378,7 @@ def func_button_action_set_macro(r, args):
             t = int(s[1:])
             macro.append(RatbagdButton.Macro.WAIT, t)
         else:
-            if not s.startswith("KEY_") and not s.startswith("BTN_"):
-                msg = "Don't know how to convert {}".format(s)
-                raise argparse.ArgumentTypeError(msg)
-
-            code = evdev.ecodes.ecodes[s]
+            code = convert_str_to_evcode(key)
             if is_press:
                 macro.append(RatbagdButton.Macro.KEY_PRESS, code)
             if is_release:

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -617,6 +617,7 @@ class RatbagdButton(_RatbagdDBus):
         NONE = 0
         BUTTON = 1
         SPECIAL = 2
+        KEY = 3
         MACRO = 4
 
     class ActionSpecial(IntEnum):
@@ -754,6 +755,19 @@ class RatbagdButton(_RatbagdDBus):
         special = GLib.Variant("u", special)
         self._set_dbus_property("Mapping", "(uv)",
                                 (RatbagdButton.ActionType.SPECIAL, special))
+
+    @GObject.Property
+    def key(self):
+        type, key = self._mapping()
+        if type != RatbagdButton.ActionType.KEY:
+            return None
+        return key
+
+    @key.setter
+    def key(self, key):
+        key = GLib.Variant("u", key)
+        self._set_dbus_property("Mapping", "(uv)",
+                                (RatbagdButton.ActionType.KEY, key))
 
     @GObject.Property
     def action_type(self):


### PR DESCRIPTION
ASUS devices doesn't support macros, but they support simple keyboard actions. It's already implemented in ASUS driver but libratbag keyboard actions internal implementation is missing. I have implemented keyboard actions in internal API, DBus methods and ratbag-command. I already patched Piper and tested button binding with it, so I'm ready to open PR for the Piper too. 