### PR TITLE
ASUS: reworked ButtonMapping config property and added Spatha X mouse

### DIFF
--- a/data/devices/asus-rog-chakram-x.device
+++ b/data/devices/asus-rog-chakram-x.device
@@ -1,0 +1,13 @@
+[Device]
+Name=ASUS ROG Chakram X
+DeviceMatch=usb:0b05:1a1a
+Driver=asus
+
+[Driver/asus]
+Profiles=3
+Buttons=5
+Leds=3
+Dpis=4
+Wireless=1
+DpiRange=100:36000@100
+Quirks=DOUBLE_DPI;STRIX_PROFILE

--- a/data/devices/asus-rog-gladius2-origin-pink.device
+++ b/data/devices/asus-rog-gladius2-origin-pink.device
@@ -9,5 +9,4 @@ Buttons=8
 Leds=3
 Dpis=2
 DpiRange=100:12000@100
-ButtonMapping=0;1;2;7;8;5;3;4
 Quirks=DOUBLE_DPI

--- a/data/devices/asus-rog-gladius2-origin.device
+++ b/data/devices/asus-rog-gladius2-origin.device
@@ -10,5 +10,4 @@ Buttons=8
 Leds=3
 Dpis=2
 DpiRange=100:12000@100
-ButtonMapping=0;1;2;7;8;5;3;4
 Quirks=DOUBLE_DPI

--- a/data/devices/asus-rog-gladius2.device
+++ b/data/devices/asus-rog-gladius2.device
@@ -5,8 +5,8 @@ Driver=asus
 
 [Driver/asus]
 Profiles=3
-Buttons=8
+Buttons=9
 Leds=3
 Dpis=2
 DpiRange=100:12000@100
-ButtonMapping=0;1;2;7;8;5;3;4
+ButtonMapping=f0;f1;f2;e4;e5;e6;e7;e8;e9

--- a/data/devices/asus-rog-pugio.device
+++ b/data/devices/asus-rog-pugio.device
@@ -9,6 +9,4 @@ Buttons=10
 Leds=3
 Dpis=2
 DpiRange=100:7200@100
-
-# Mappings the same as the Gladius II but with an extra 2 buttons
-ButtonMapping=0;1;2;7;8;5;3;4;9;10
+ButtonMapping=f0;f1;f2;e4;e5;e6;e8;e9;e1;e2

--- a/data/devices/asus-rog-spatha-x.device
+++ b/data/devices/asus-rog-spatha-x.device
@@ -1,0 +1,14 @@
+[Device]
+Name=ASUS ROG Spatha X
+DeviceMatch=usb:0b05:1979
+Driver=asus
+
+[Driver/asus]
+Profiles=5
+Buttons=14
+Leds=3
+Dpis=4
+Wireless=1
+DpiRange=100:19000@50
+Quirks=DOUBLE_DPI
+ButtonMapping=f0;f1;f2;e4;e5;e6;e8;e9;ea;eb;ec;ed;ee;ef

--- a/data/devices/asus-rog-spatha-x.device
+++ b/data/devices/asus-rog-spatha-x.device
@@ -1,7 +1,8 @@
 [Device]
 Name=ASUS ROG Spatha X
-DeviceMatch=usb:0b05:1979
+DeviceMatch=usb:0b05:1979;usb:0b05:1977
 Driver=asus
+LedTypes=logo;wheel;side
 
 [Driver/asus]
 Profiles=5
@@ -10,5 +11,4 @@ Leds=3
 Dpis=4
 Wireless=1
 DpiRange=100:19000@50
-Quirks=DOUBLE_DPI
 ButtonMapping=f0;f1;f2;e4;e5;e6;e8;e9;ea;eb;ec;ed;ee;ef

--- a/data/devices/device.example
+++ b/data/devices/device.example
@@ -73,8 +73,8 @@ Dpis=2
 # DPI range in format min:max@step
 DpiRange=100:16000@100
 
-# Button index mapping
-# ButtonMapping=0;1;2;6;7;5;3;4
+# Button mapping
+# ButtonMapping=f0;f1;f2;e4;e5;e6;e8;e9
 
 # Device quirks
 # Quirk=DOUBLE_DPI;STRIX_PROFILE

--- a/src/asus.c
+++ b/src/asus.c
@@ -46,26 +46,6 @@
 #define ASUS_FIELD_RESPONSE	1
 #define ASUS_FIELD_SNAPPING	2
 
-/* order is mandatory because index is mapped from ButtonMapping configuration property */
-static struct asus_button ASUS_BUTTON_MAPPING[] = {
-	{ 0xf0, RATBAG_BUTTON_ACTION_TYPE_BUTTON, 1, 0 },  /* left */
-	{ 0xf1, RATBAG_BUTTON_ACTION_TYPE_BUTTON, 2, 0 },  /* right (button 3 in xev) */
-	{ 0xf2, RATBAG_BUTTON_ACTION_TYPE_BUTTON, 3, 0 },  /* middle (button 2 in xev) */
-	{ 0xe4, RATBAG_BUTTON_ACTION_TYPE_BUTTON, 4, 0 },  /* backward (on left side) */
-	{ 0xe5, RATBAG_BUTTON_ACTION_TYPE_BUTTON, 5, 0 },  /* forward (on left side) */
-	{ 0xe6, RATBAG_BUTTON_ACTION_TYPE_SPECIAL, 0, RATBAG_BUTTON_ACTION_SPECIAL_RESOLUTION_CYCLE_UP },
-	{ 0xe8, RATBAG_BUTTON_ACTION_TYPE_SPECIAL, 0, RATBAG_BUTTON_ACTION_SPECIAL_WHEEL_UP },
-	{ 0xe9, RATBAG_BUTTON_ACTION_TYPE_SPECIAL, 0, RATBAG_BUTTON_ACTION_SPECIAL_WHEEL_DOWN },
-	{ 0xe1, RATBAG_BUTTON_ACTION_TYPE_BUTTON, 4, 0 },  /* backward on right side */
-	{ 0xe2, RATBAG_BUTTON_ACTION_TYPE_BUTTON, 5, 0 },  /* forward on right side */
-	{ 0xff, RATBAG_BUTTON_ACTION_TYPE_NONE, 0, 0 },  /* placeholder */
-	{ 0xff, RATBAG_BUTTON_ACTION_TYPE_NONE, 0, 0 },  /* placeholder */
-	{ 0xff, RATBAG_BUTTON_ACTION_TYPE_NONE, 0, 0 },  /* placeholder */
-	{ 0xff, RATBAG_BUTTON_ACTION_TYPE_NONE, 0, 0 },  /* placeholder */
-	{ 0xff, RATBAG_BUTTON_ACTION_TYPE_NONE, 0, 0 },  /* placeholder */
-	{ 0xff, RATBAG_BUTTON_ACTION_TYPE_NONE, 0, 0 },  /* placeholder */
-};
-
 /* key mapping, the index is actual ASUS code */
 static unsigned char ASUS_KEY_MAPPING[] = {
 /* 00 */	0,		0,		0,		0,
@@ -268,7 +248,7 @@ asus_set_profile(struct ratbag_device *device, unsigned int index)
 	return 0;
 }
 
-/* read button bindings using ButtonMapping configuration property */
+/* read button bindings */
 int
 asus_get_binding_data(struct ratbag_device *device, union asus_binding_data *data)
 {
@@ -288,7 +268,7 @@ asus_get_binding_data(struct ratbag_device *device, union asus_binding_data *dat
 
 /* set button binding using ASUS code of the button */
 int
-asus_set_button_action(struct ratbag_device *device, unsigned int asus_index, uint8_t asus_code, uint8_t asus_type)
+asus_set_button_action(struct ratbag_device *device, uint8_t button_asus_code, uint8_t asus_code, uint8_t asus_type)
 {
 	int rc;
 	union asus_response response;
@@ -297,7 +277,7 @@ asus_set_button_action(struct ratbag_device *device, unsigned int asus_index, ui
 	};
 
 	/* source (physical mouse button) */
-	request.data.params[2] = ASUS_BUTTON_MAPPING[asus_index].asus_code;
+	request.data.params[2] = button_asus_code;
 	request.data.params[3] = ASUS_BUTTON_ACTION_TYPE_BUTTON;
 
 	/* destination (mouse button or keyboard key action) */

--- a/src/asus.c
+++ b/src/asus.c
@@ -268,7 +268,8 @@ asus_get_binding_data(struct ratbag_device *device, union asus_binding_data *dat
 
 /* set button binding using ASUS code of the button */
 int
-asus_set_button_action(struct ratbag_device *device, uint8_t button_asus_code, uint8_t asus_code, uint8_t asus_type)
+asus_set_button_action(struct ratbag_device *device, uint8_t asus_code_src,
+		       uint8_t asus_code_dst, uint8_t asus_type)
 {
 	int rc;
 	union asus_response response;
@@ -277,11 +278,11 @@ asus_set_button_action(struct ratbag_device *device, uint8_t button_asus_code, u
 	};
 
 	/* source (physical mouse button) */
-	request.data.params[2] = button_asus_code;
+	request.data.params[2] = asus_code_src;
 	request.data.params[3] = ASUS_BUTTON_ACTION_TYPE_BUTTON;
 
 	/* destination (mouse button or keyboard key action) */
-	request.data.params[4] = asus_code;
+	request.data.params[4] = asus_code_dst;
 	request.data.params[5] = asus_type;
 
 	rc = asus_query(device, &request, &response);

--- a/src/asus.h
+++ b/src/asus.h
@@ -17,7 +17,7 @@
 #define ASUS_STATUS_ERROR 0xffaa  /* invalid state/request, disconnected or sleeping */
 
 /* maximum number of buttons across all ASUS devices */
-#define ASUS_MAX_NUM_BUTTON 16
+#define ASUS_MAX_NUM_BUTTON 17
 
 /* maximum number of DPI presets across all ASUS devices */
 /* for 4 DPI devices: 0 - red, 1 - purple, 2 - blue (default), 3 - green */
@@ -147,11 +147,12 @@ static struct asus_button ASUS_BUTTON_MAPPING[] = {
 	{ 0xe1, RATBAG_BUTTON_ACTION_TYPE_BUTTON, 4, 0 },  /* backward, right side */
 	{ 0xe2, RATBAG_BUTTON_ACTION_TYPE_BUTTON, 5, 0 },  /* forward, right side */
 	{ 0xe7, RATBAG_BUTTON_ACTION_TYPE_SPECIAL, 0, RATBAG_BUTTON_ACTION_SPECIAL_RESOLUTION_ALTERNATE },  /* DPI target */
-	{ 0xff, RATBAG_BUTTON_ACTION_TYPE_NONE, 0, 0 },  /* placeholder */
-	{ 0xff, RATBAG_BUTTON_ACTION_TYPE_NONE, 0, 0 },  /* placeholder */
-	{ 0xff, RATBAG_BUTTON_ACTION_TYPE_NONE, 0, 0 },  /* placeholder */
-	{ 0xff, RATBAG_BUTTON_ACTION_TYPE_NONE, 0, 0 },  /* placeholder */
-	{ 0xff, RATBAG_BUTTON_ACTION_TYPE_NONE, 0, 0 },  /* placeholder */
+	{ 0xea, RATBAG_BUTTON_ACTION_TYPE_NONE, 0, 0 },  /* side button A */
+	{ 0xeb, RATBAG_BUTTON_ACTION_TYPE_NONE, 0, 0 },  /* side button B */
+	{ 0xec, RATBAG_BUTTON_ACTION_TYPE_NONE, 0, 0 },  /* side button C */
+	{ 0xed, RATBAG_BUTTON_ACTION_TYPE_NONE, 0, 0 },  /* side button D */
+	{ 0xee, RATBAG_BUTTON_ACTION_TYPE_NONE, 0, 0 },  /* side button E */
+	{ 0xef, RATBAG_BUTTON_ACTION_TYPE_NONE, 0, 0 },  /* side button F */
 };
 
 struct asus_button *

--- a/src/asus.h
+++ b/src/asus.h
@@ -8,6 +8,7 @@
 
 #define ASUS_QUIRK_DOUBLE_DPI 1 << 0
 #define ASUS_QUIRK_STRIX_PROFILE 1 << 1
+#define ASUS_QUIRK_BATTERY_V2 1 << 2
 
 #define ASUS_PACKET_SIZE 64
 #define ASUS_BUTTON_ACTION_TYPE_KEY 0  /* keyboard key */
@@ -133,6 +134,26 @@ struct asus_button {
 	enum ratbag_button_action_special special;  /* special action, optional */
 };
 
+/* ASUS code, button type, button number, special button action */
+static struct asus_button ASUS_BUTTON_MAPPING[] = {
+	{ 0xf0, RATBAG_BUTTON_ACTION_TYPE_BUTTON, 1, 0 },  /* left */
+	{ 0xf1, RATBAG_BUTTON_ACTION_TYPE_BUTTON, 2, 0 },  /* right (button 3 in xev) */
+	{ 0xf2, RATBAG_BUTTON_ACTION_TYPE_BUTTON, 3, 0 },  /* middle (button 2 in xev) */
+	{ 0xe8, RATBAG_BUTTON_ACTION_TYPE_SPECIAL, 0, RATBAG_BUTTON_ACTION_SPECIAL_WHEEL_UP },
+	{ 0xe9, RATBAG_BUTTON_ACTION_TYPE_SPECIAL, 0, RATBAG_BUTTON_ACTION_SPECIAL_WHEEL_DOWN },
+	{ 0xe6, RATBAG_BUTTON_ACTION_TYPE_SPECIAL, 0, RATBAG_BUTTON_ACTION_SPECIAL_RESOLUTION_CYCLE_UP },
+	{ 0xe4, RATBAG_BUTTON_ACTION_TYPE_BUTTON, 4, 0 },  /* backward, left side */
+	{ 0xe5, RATBAG_BUTTON_ACTION_TYPE_BUTTON, 5, 0 },  /* forward, left side */
+	{ 0xe1, RATBAG_BUTTON_ACTION_TYPE_BUTTON, 4, 0 },  /* backward, right side */
+	{ 0xe2, RATBAG_BUTTON_ACTION_TYPE_BUTTON, 5, 0 },  /* forward, right side */
+	{ 0xe7, RATBAG_BUTTON_ACTION_TYPE_SPECIAL, 0, RATBAG_BUTTON_ACTION_SPECIAL_RESOLUTION_ALTERNATE },  /* DPI target */
+	{ 0xff, RATBAG_BUTTON_ACTION_TYPE_NONE, 0, 0 },  /* placeholder */
+	{ 0xff, RATBAG_BUTTON_ACTION_TYPE_NONE, 0, 0 },  /* placeholder */
+	{ 0xff, RATBAG_BUTTON_ACTION_TYPE_NONE, 0, 0 },  /* placeholder */
+	{ 0xff, RATBAG_BUTTON_ACTION_TYPE_NONE, 0, 0 },  /* placeholder */
+	{ 0xff, RATBAG_BUTTON_ACTION_TYPE_NONE, 0, 0 },  /* placeholder */
+};
+
 struct asus_button *
 asus_find_button_by_action(struct ratbag_button_action action);
 
@@ -183,7 +204,7 @@ int
 asus_get_binding_data(struct ratbag_device *device, union asus_binding_data *data);
 
 int
-asus_set_button_action(struct ratbag_device *device, unsigned int index,
+asus_set_button_action(struct ratbag_device *device, uint8_t button_asus_code,
 		uint8_t asus_code, uint8_t asus_type);
 
 /* resolution settings */

--- a/src/asus.h
+++ b/src/asus.h
@@ -205,8 +205,8 @@ int
 asus_get_binding_data(struct ratbag_device *device, union asus_binding_data *data);
 
 int
-asus_set_button_action(struct ratbag_device *device, uint8_t button_asus_code,
-		uint8_t asus_code, uint8_t asus_type);
+asus_set_button_action(struct ratbag_device *device, uint8_t asus_code_src,
+		       uint8_t asus_code_dst, uint8_t asus_type);
 
 /* resolution settings */
 

--- a/src/driver-asus.c
+++ b/src/driver-asus.c
@@ -55,6 +55,7 @@ static int8_t ASUS_CONFIG_BUTTON_MAPPING[] = {
 	-1,  /* placeholder */
 	-1,  /* placeholder */
 	-1,  /* placeholder */
+	-1,  /* placeholder */
 };
 
 static unsigned int ASUS_LED_MODE[] = {

--- a/src/driver-asus.c
+++ b/src/driver-asus.c
@@ -207,36 +207,35 @@ asus_driver_save_profile(struct ratbag_device *device, struct ratbag_profile *pr
 			continue;
 		}
 
-		int button_asus_code = drv_data->button_mapping[asus_index];
+		int asus_code_src = drv_data->button_mapping[asus_index];
+		int asus_code_dst;
+		struct asus_button *asus_button;
 		log_debug(device->ratbag, "Button %d (%02x) changed\n",
-			  button->index, (uint8_t) button_asus_code);
+			  button->index, (uint8_t) asus_code_src);
 
 		switch (button->action.type) {
 		case RATBAG_BUTTON_ACTION_TYPE_NONE:
 			rc = asus_set_button_action(
-				device, button_asus_code,
-				ASUS_BUTTON_CODE_DISABLED,
+				device, asus_code_src, ASUS_BUTTON_CODE_DISABLED,
 				ASUS_BUTTON_ACTION_TYPE_BUTTON);
 			break;
 
 		case RATBAG_BUTTON_ACTION_TYPE_KEY:
 			/* Linux code to ASUS code */
-			int asus_code = asus_find_key_code(button->action.action.key.key);
-			if (asus_code >= 0)
+			asus_code_dst = asus_find_key_code(button->action.action.key.key);
+			if (asus_code_dst >= 0)
 				rc = asus_set_button_action(
-					device, button_asus_code,
-					asus_code,
+					device, asus_code_src, asus_code_dst,
 					ASUS_BUTTON_ACTION_TYPE_KEY);
 			break;
 
 		case RATBAG_BUTTON_ACTION_TYPE_BUTTON:
 		case RATBAG_BUTTON_ACTION_TYPE_SPECIAL:
 			/* ratbag action to ASUS code */
-			struct asus_button *asus_button = asus_find_button_by_action(button->action);
+			asus_button = asus_find_button_by_action(button->action);
 			if (asus_button != NULL)  /* found button to bind to */
 				rc = asus_set_button_action(
-					device, button_asus_code,
-					asus_button->asus_code,
+					device, asus_code_src, asus_button->asus_code,
 					ASUS_BUTTON_ACTION_TYPE_BUTTON);
 			break;
 

--- a/src/driver-asus.c
+++ b/src/driver-asus.c
@@ -38,7 +38,7 @@
 #include "asus.h"
 
 /* ButtonMapping configuration property defaults */
-static int8_t ASUS_CONFIG_BUTTON_MAPPING[] = {
+static int ASUS_CONFIG_BUTTON_MAPPING[] = {
 	0xf0,  /* left */
 	0xf1,  /* right (button 3 in xev) */
 	0xf2,  /* middle (button 2 in xev) */
@@ -70,7 +70,7 @@ static unsigned int ASUS_LED_MODE[] = {
 
 struct asus_data {
 	uint8_t is_ready;
-	int8_t button_mapping[ASUS_MAX_NUM_BUTTON];
+	int button_mapping[ASUS_MAX_NUM_BUTTON];
 	int button_indices[ASUS_MAX_NUM_BUTTON];
 };
 
@@ -436,7 +436,7 @@ asus_driver_probe(struct ratbag_device *device)
 	dpi_count = ratbag_device_data_asus_get_dpi_count(device->data);
 	button_count = ratbag_device_data_asus_get_button_count(device->data);
 	led_count = ratbag_device_data_asus_get_led_count(device->data);
-	const int8_t *bm = ratbag_device_data_asus_get_button_mapping(device->data);
+	const int *bm = ratbag_device_data_asus_get_button_mapping(device->data);
 
 	/* merge ButtonMapping configuration property with defaults */
 	for (unsigned int i = 0; i < button_count; i++) {
@@ -451,7 +451,7 @@ asus_driver_probe(struct ratbag_device *device)
 
 		/* search for this button in the ButtonMapping by it's ASUS code */
 		for (unsigned int j = 0; j < button_count; j++) {
-			if (drv_data->button_mapping[j] == (int8_t) asus_button->asus_code) {
+			if (drv_data->button_mapping[j] == (int)asus_button->asus_code) {
 				/* add button to indices array */
 				drv_data->button_indices[button_index] = (int)j;
 				log_debug(device->ratbag, "Button %d is mapped to 0x%02x\n",

--- a/src/driver-asus.c
+++ b/src/driver-asus.c
@@ -208,11 +208,19 @@ asus_driver_save_profile(struct ratbag_device *device, struct ratbag_profile *pr
 			continue;
 		}
 
-		int asus_code_src = drv_data->button_mapping[asus_index];
-		int asus_code_dst;
+		uint8_t asus_code_src;
+		uint8_t asus_code_dst;
 		struct asus_button *asus_button;
+
+		rc = drv_data->button_mapping[asus_index];
+		if (rc == -1) {
+			log_debug(device->ratbag, "No mapping for button %d\n", button->index);
+			continue;
+		}
+
+		asus_code_src = (uint8_t)rc;
 		log_debug(device->ratbag, "Button %d (%02x) changed\n",
-			  button->index, (uint8_t) asus_code_src);
+			  button->index, asus_code_src);
 
 		switch (button->action.type) {
 		case RATBAG_BUTTON_ACTION_TYPE_NONE:
@@ -223,11 +231,13 @@ asus_driver_save_profile(struct ratbag_device *device, struct ratbag_profile *pr
 
 		case RATBAG_BUTTON_ACTION_TYPE_KEY:
 			/* Linux code to ASUS code */
-			asus_code_dst = asus_find_key_code(button->action.action.key.key);
-			if (asus_code_dst >= 0)
+			rc = asus_find_key_code(button->action.action.key.key);
+			if (rc != -1) {
+				asus_code_dst = (uint8_t)rc;
 				rc = asus_set_button_action(
 					device, asus_code_src, asus_code_dst,
 					ASUS_BUTTON_ACTION_TYPE_KEY);
+			}
 			break;
 
 		case RATBAG_BUTTON_ACTION_TYPE_BUTTON:

--- a/src/libratbag-data.c
+++ b/src/libratbag-data.c
@@ -373,7 +373,7 @@ init_data_asus(struct ratbag *ratbag,
 	_cleanup_(g_strfreevp) char **button_mapping = g_key_file_get_string_list(keyfile, group, "ButtonMapping", &button_mapping_count, &error);
 	if (!error && button_mapping) {
 		for (unsigned int i = 0; i < button_mapping_count; i++) {
-			data->asus.button_mapping[i] = (int8_t) strtoul(button_mapping[i], NULL, 10);
+			data->asus.button_mapping[i] = (int8_t) strtoul(button_mapping[i], NULL, 16);
 		}
 	}
 	g_clear_error(&error);

--- a/src/libratbag-data.c
+++ b/src/libratbag-data.c
@@ -99,7 +99,7 @@ struct data_steelseries {
 struct data_asus {
 	int profile_count;
 	int button_count;
-	int8_t button_mapping[ASUS_MAX_NUM_BUTTON];
+	int button_mapping[ASUS_MAX_NUM_BUTTON];
 	int led_count;
 	int dpi_count;
 	int is_wireless;
@@ -373,7 +373,7 @@ init_data_asus(struct ratbag *ratbag,
 	_cleanup_(g_strfreevp) char **button_mapping = g_key_file_get_string_list(keyfile, group, "ButtonMapping", &button_mapping_count, &error);
 	if (!error && button_mapping) {
 		for (unsigned int i = 0; i < button_mapping_count; i++) {
-			data->asus.button_mapping[i] = (int8_t) strtoul(button_mapping[i], NULL, 16);
+			data->asus.button_mapping[i] = strtoul(button_mapping[i], NULL, 16);
 		}
 	}
 	g_clear_error(&error);
@@ -897,7 +897,7 @@ ratbag_device_data_asus_get_button_count(const struct ratbag_device_data *data)
 	return data->asus.button_count;
 }
 
-const int8_t *
+const int *
 ratbag_device_data_asus_get_button_mapping(const struct ratbag_device_data *data)
 {
 	assert(data->drivertype == ASUS);

--- a/src/libratbag-data.h
+++ b/src/libratbag-data.h
@@ -156,7 +156,7 @@ ratbag_device_data_asus_get_button_count(const struct ratbag_device_data *data);
 /**
  * @return Array of button indices, which are used for reading and writing button actions
  */
-const int8_t *
+const int *
 ratbag_device_data_asus_get_button_mapping(const struct ratbag_device_data *data);
 
 /**


### PR DESCRIPTION
Some mice uses button order which differs from the default one. So storing button indices won't work for them. I can't rely on the hardcoded buttons table. I have changed ButtonMapping to store the actual button codes in the order that they appear in the packet. So I can get the current bindings and rebind any button.
I also added extra buttons for Spatha X mouse and it's device file. We did some research and tests with device owner in this issue - https://github.com/kyokenn/rogdrv/issues/50. 

