### PR TITLE
asus: allow empty cells in bindings table and fix pugio button bindings

### DIFF
--- a/data/devices/asus-rog-pugio.device
+++ b/data/devices/asus-rog-pugio.device
@@ -9,4 +9,4 @@ Buttons=10
 Leds=3
 Dpis=2
 DpiRange=100:7200@100
-ButtonMapping=f0;f1;f2;e4;e5;e6;;e8;e9;e1;e2
+ButtonMapping=f0;f1;f2;e4;e5;e6;0;e8;e9;e1;e2

--- a/data/devices/asus-rog-pugio.device
+++ b/data/devices/asus-rog-pugio.device
@@ -9,4 +9,4 @@ Buttons=10
 Leds=3
 Dpis=2
 DpiRange=100:7200@100
-ButtonMapping=f0;f1;f2;e4;e5;e6;e8;e9;e1;e2
+ButtonMapping=f0;f1;f2;e4;e5;e6;;e8;e9;e1;e2

--- a/src/driver-asus.c
+++ b/src/driver-asus.c
@@ -439,7 +439,7 @@ asus_driver_probe(struct ratbag_device *device)
 	const int *bm = ratbag_device_data_asus_get_button_mapping(device->data);
 
 	/* merge ButtonMapping configuration property with defaults */
-	for (unsigned int i = 0; i < button_count; i++) {
+	for (unsigned int i = 0; i < ASUS_MAX_NUM_BUTTON; i++) {
 		drv_data->button_mapping[i] = bm[i] != -1 ? bm[i] : ASUS_CONFIG_BUTTON_MAPPING[i];
 		drv_data->button_indices[i] = -1;
 	}
@@ -450,7 +450,7 @@ asus_driver_probe(struct ratbag_device *device)
 		struct asus_button *asus_button = &ASUS_BUTTON_MAPPING[i];
 
 		/* search for this button in the ButtonMapping by it's ASUS code */
-		for (unsigned int j = 0; j < button_count; j++) {
+		for (unsigned int j = 0; j < ASUS_MAX_NUM_BUTTON; j++) {
 			if (drv_data->button_mapping[j] == (int)asus_button->asus_code) {
 				/* add button to indices array */
 				drv_data->button_indices[button_index] = (int)j;


### PR DESCRIPTION
I forgot that some mice have zero byte elements in the bindings array. So those elements should be skipped while searching for the button code. It also fixes button bindings info for the Pugio mouse.