### PR TITLE
Minor ASUS driver refactoring

### DIFF
--- a/src/asus.c
+++ b/src/asus.c
@@ -47,7 +47,7 @@
 #define ASUS_FIELD_SNAPPING	2
 
 /* key mapping, the index is actual ASUS code */
-static unsigned char ASUS_KEY_MAPPING[] = {
+static const unsigned char ASUS_KEY_MAPPING[] = {
 /* 00 */	0,		0,		0,		0,
 /* 04 */	KEY_A,		KEY_B,		KEY_C,		KEY_D,
 /* 08 */	KEY_E,		KEY_F,		KEY_G,		KEY_H,
@@ -75,7 +75,7 @@ static unsigned char ASUS_KEY_MAPPING[] = {
 /* 5E */	KEY_KP8,	KEY_KP9,	0,
 };
 
-static unsigned int ASUS_LED_TYPE[] = {
+static const unsigned int ASUS_LED_TYPE[] = {
 	RATBAG_LED_TYPE_LOGO,  /* Mouse logo */
 	RATBAG_LED_TYPE_WHEEL,  /* Mouse wheel */
 	RATBAG_LED_TYPE_SIDE,  /* Bottom of the mouse */
@@ -84,10 +84,10 @@ static unsigned int ASUS_LED_TYPE[] = {
 static unsigned int ASUS_POLLING_RATES[] = { 125, 250, 500, 1000 };
 
 /* search for ASUS button by ratbag types */
-struct asus_button *
+const struct asus_button *
 asus_find_button_by_action(struct ratbag_button_action action)
 {
-	struct asus_button *asus_button;
+	const struct asus_button *asus_button;
 	for (unsigned int i = 0; i < ARRAY_LENGTH(ASUS_BUTTON_MAPPING); i++) {
 		asus_button = &ASUS_BUTTON_MAPPING[i];
 		if ((action.type == RATBAG_BUTTON_ACTION_TYPE_BUTTON && asus_button->button == action.action.button) ||
@@ -98,7 +98,7 @@ asus_find_button_by_action(struct ratbag_button_action action)
 }
 
 /* search for ASUS button by ASUS button code */
-struct asus_button *
+const struct asus_button *
 asus_find_button_by_code(uint8_t asus_code)
 {
 	for (unsigned int i = 0; i < ARRAY_LENGTH(ASUS_BUTTON_MAPPING); i++) {

--- a/src/asus.c
+++ b/src/asus.c
@@ -88,8 +88,7 @@ const struct asus_button *
 asus_find_button_by_action(struct ratbag_button_action action)
 {
 	const struct asus_button *asus_button;
-	for (unsigned int i = 0; i < ARRAY_LENGTH(ASUS_BUTTON_MAPPING); i++) {
-		asus_button = &ASUS_BUTTON_MAPPING[i];
+	ARRAY_FOR_EACH(ASUS_BUTTON_MAPPING, asus_button) {
 		if ((action.type == RATBAG_BUTTON_ACTION_TYPE_BUTTON && asus_button->button == action.action.button) ||
 				(action.type == RATBAG_BUTTON_ACTION_TYPE_SPECIAL && asus_button->special == action.action.special))
 			return asus_button;

--- a/src/asus.h
+++ b/src/asus.h
@@ -135,7 +135,7 @@ struct asus_button {
 };
 
 /* ASUS code, button type, button number, special button action */
-static struct asus_button ASUS_BUTTON_MAPPING[] = {
+static const struct asus_button ASUS_BUTTON_MAPPING[] = {
 	{ 0xf0, RATBAG_BUTTON_ACTION_TYPE_BUTTON, 1, 0 },  /* left */
 	{ 0xf1, RATBAG_BUTTON_ACTION_TYPE_BUTTON, 2, 0 },  /* right (button 3 in xev) */
 	{ 0xf2, RATBAG_BUTTON_ACTION_TYPE_BUTTON, 3, 0 },  /* middle (button 2 in xev) */
@@ -155,10 +155,10 @@ static struct asus_button ASUS_BUTTON_MAPPING[] = {
 	{ 0xef, RATBAG_BUTTON_ACTION_TYPE_NONE, 0, 0 },  /* side button F */
 };
 
-struct asus_button *
+const struct asus_button *
 asus_find_button_by_action(struct ratbag_button_action action);
 
-struct asus_button *
+const struct asus_button *
 asus_find_button_by_code(uint8_t asus_code);
 
 int

--- a/src/driver-asus.c
+++ b/src/driver-asus.c
@@ -78,9 +78,9 @@ static int
 asus_driver_load_profile(struct ratbag_device *device, struct ratbag_profile *profile)
 {
 	int rc;
-	struct _asus_binding *asus_binding;
-	struct _asus_led *asus_led;
-	struct asus_button *asus_button;
+	const struct _asus_binding *asus_binding;
+	const struct _asus_led *asus_led;
+	const struct asus_button *asus_button;
 	struct ratbag_button *button;
 	struct ratbag_led *led;
 	struct ratbag_resolution *resolution;
@@ -208,9 +208,9 @@ asus_driver_save_profile(struct ratbag_device *device, struct ratbag_profile *pr
 			continue;
 		}
 
+		const struct asus_button *asus_button;
 		uint8_t asus_code_src;
 		uint8_t asus_code_dst;
-		struct asus_button *asus_button;
 
 		rc = drv_data->button_mapping[asus_index];
 		if (rc == -1) {
@@ -447,7 +447,7 @@ asus_driver_probe(struct ratbag_device *device)
 	/* setup a lookup table for all defined buttons */
 	unsigned int button_index = 0;
 	for (unsigned int i = 0; i < ARRAY_LENGTH(ASUS_BUTTON_MAPPING); i++) {
-		struct asus_button *asus_button = &ASUS_BUTTON_MAPPING[i];
+		const struct asus_button *asus_button = &ASUS_BUTTON_MAPPING[i];
 
 		/* search for this button in the ButtonMapping by it's ASUS code */
 		for (unsigned int j = 0; j < ASUS_MAX_NUM_BUTTON; j++) {

--- a/src/driver-asus.c
+++ b/src/driver-asus.c
@@ -416,6 +416,7 @@ asus_driver_probe(struct ratbag_device *device)
 {
 	int rc;
 	unsigned int profile_count, dpi_count, button_count, led_count;
+	const struct asus_button *asus_button;
 	struct asus_data *drv_data;
 	struct ratbag_profile *profile;
 	struct ratbag_button *button;
@@ -446,16 +447,14 @@ asus_driver_probe(struct ratbag_device *device)
 
 	/* setup a lookup table for all defined buttons */
 	unsigned int button_index = 0;
-	for (unsigned int i = 0; i < ARRAY_LENGTH(ASUS_BUTTON_MAPPING); i++) {
-		const struct asus_button *asus_button = &ASUS_BUTTON_MAPPING[i];
-
+	ARRAY_FOR_EACH(ASUS_BUTTON_MAPPING, asus_button) {
 		/* search for this button in the ButtonMapping by it's ASUS code */
-		for (unsigned int j = 0; j < ASUS_MAX_NUM_BUTTON; j++) {
-			if (drv_data->button_mapping[j] == (int)asus_button->asus_code) {
+		for (unsigned int i = 0; i < ASUS_MAX_NUM_BUTTON; i++) {
+			if (drv_data->button_mapping[i] == (int)asus_button->asus_code) {
 				/* add button to indices array */
-				drv_data->button_indices[button_index] = (int)j;
+				drv_data->button_indices[button_index] = (int)i;
 				log_debug(device->ratbag, "Button %d is mapped to 0x%02x\n",
-					  button_index, (uint8_t) drv_data->button_mapping[j]);
+					  button_index, (uint8_t)drv_data->button_mapping[i]);
 				button_index++;
 				break;
 			}

--- a/src/libratbag-data.c
+++ b/src/libratbag-data.c
@@ -378,12 +378,12 @@ init_data_asus(struct ratbag *ratbag,
 	}
 	g_clear_error(&error);
 
-        int leds = g_key_file_get_integer(keyfile, group, "Leds", &error);
+	int leds = g_key_file_get_integer(keyfile, group, "Leds", &error);
 	if (!error && leds >= 0 && leds <= ASUS_MAX_NUM_LED)
 		data->asus.led_count = leds;
 	g_clear_error(&error);
 
-        int dpis = g_key_file_get_integer(keyfile, group, "Dpis", &error);
+	int dpis = g_key_file_get_integer(keyfile, group, "Dpis", &error);
 	if (!error && dpis >= 2 && dpis <= ASUS_MAX_NUM_DPI)
 		data->asus.dpi_count = dpis;
 	g_clear_error(&error);
@@ -393,12 +393,12 @@ init_data_asus(struct ratbag *ratbag,
 		data->asus.dpi_range = dpi_range_from_string(dpi_range);
 	g_clear_error(&error);
 
-        int wireless = g_key_file_get_integer(keyfile, group, "Wireless", &error);
+	int wireless = g_key_file_get_integer(keyfile, group, "Wireless", &error);
 	if (!error && (wireless == 0 || wireless == 1))
 		data->asus.is_wireless = wireless;
 	g_clear_error(&error);
 
-        gsize quirks_count = 0;
+	gsize quirks_count = 0;
 	_cleanup_(g_strfreevp) char **quirks = g_key_file_get_string_list(keyfile, group, "Quirks", &quirks_count, &error);
 	if (!error && quirks) {
 		for (unsigned int i = 0; i < quirks_count; i++) {


### PR DESCRIPTION
To fix a compiler warning:
```
[60/72] Compiling C object libratbag.a.p/src_libratbag-data.c.o
In file included from ../src/libratbag-data.c:33:
../src/asus.h:138:27: warning: ‘ASUS_BUTTON_MAPPING’ defined but not used [-Wunused-variable]
  138 | static struct asus_button ASUS_BUTTON_MAPPING[] = {
      |                           ^~~~~~~~~~~~~~~~~~~
```