### PR TITLE
A bunch of SinoWealth driver improvements

### DIFF
--- a/src/driver-sinowealth.c
+++ b/src/driver-sinowealth.c
@@ -84,6 +84,18 @@ _Static_assert(sizeof(enum sinowealth_command_id) == sizeof(uint8_t), "Invalid s
 
 /* Technically SinoWealth mice support second profile, but there isn't
  * a single configuration software that exposes it.
+ * It's suggested that some may even support 3 profiles, but at least
+ * V103 only supports 2.
+ *
+ * We could enable this, but by default other profiles have no button
+ * mappings, so the user will have their mouse soft-locked if they don't
+ * have another mouse to set some mappings with.
+ *
+ * To fix this we could populate empty profiles with some default
+ * mappings.
+ *
+ * There may also be some other problem we are not aware of, after all,
+ * why would SinoWealth even hide this feature.
  */
 #define SINOWEALTH_NUM_PROFILES 1
 _Static_assert(SINOWEALTH_NUM_PROFILES <= 2, "Too many profiles enabled");
@@ -476,12 +488,7 @@ static const struct sinowealth_button_mapping sinowealth_button_map[] = {
 	/* None of the other bits do anything. */
 
 	{ { SINOWEALTH_BUTTON_TYPE_SPECIAL, { { 0x1 } } }, BUTTON_ACTION_NONE },
-	/* Disabled as we don't support second profile officially.
-	 * Not only that, by default default second profile has no button
-	 * mapping and by using this the user is just going to be left with
-	 * a practically non-working mouse. To fix this we would have to
-	 * populate the empty profile with some default mappings.
-	 */
+	/* See the note near @ref SINOWEALTH_NUM_PROFILES. */
 	/* Hidden. */
 	/* { { SINOWEALTH_BUTTON_TYPE_SPECIAL, { { 0x6 } } }, BUTTON_ACTION_SPECIAL(RATBAG_BUTTON_ACTION_SPECIAL_PROFILE_UP) }, */
 

--- a/src/driver-sinowealth.c
+++ b/src/driver-sinowealth.c
@@ -46,7 +46,7 @@ enum sinowealth_command_id {
 	SINOWEALTH_CMD_LONG_ANGLESNAPPING_AND_LOD = 0x1b,
 	/* Same as GET_CONFIG but for the second profile. */
 	SINOWEALTH_CMD_GET_CONFIG2 = 0x21,
-	/* Same as GET_CONFIG but for the second profile. */
+	/* Same as GET_BUTTONS but for the second profile. */
 	SINOWEALTH_CMD_GET_BUTTONS2 = 0x22,
 	SINOWEALTH_CMD_MACRO = 0x30,
 	/* Puts the device into DFU mode.

--- a/src/driver-sinowealth.c
+++ b/src/driver-sinowealth.c
@@ -488,9 +488,11 @@ static const struct sinowealth_button_mapping sinowealth_button_map[] = {
 	/* None of the other bits do anything. */
 
 	{ { SINOWEALTH_BUTTON_TYPE_SPECIAL, { { 0x1 } } }, BUTTON_ACTION_NONE },
+#if SINOWEALTH_NUM_PROFILES > 1
 	/* See the note near @ref SINOWEALTH_NUM_PROFILES. */
 	/* Hidden. */
-	/* { { SINOWEALTH_BUTTON_TYPE_SPECIAL, { { 0x6 } } }, BUTTON_ACTION_SPECIAL(RATBAG_BUTTON_ACTION_SPECIAL_PROFILE_UP) }, */
+	{ { SINOWEALTH_BUTTON_TYPE_SPECIAL, { { 0x6 } } }, BUTTON_ACTION_SPECIAL(RATBAG_BUTTON_ACTION_SPECIAL_PROFILE_UP) },
+#endif
 
 	/* This must defined after `SPECIAL` type so that correct raw data
 	 * for action type `NONE` is used. */

--- a/src/driver-sinowealth.c
+++ b/src/driver-sinowealth.c
@@ -627,7 +627,7 @@ sinowealth_dpi_to_raw(struct ratbag_device *device, unsigned int dpi)
 
 	assert(dpi >= SINOWEALTH_DPI_MIN && dpi <= sinowealth_get_max_dpi_for_sensor(sensor));
 
-	uint8_t raw = dpi / 100;
+	uint8_t raw = (uint8_t)(dpi / 100);
 
 	if (sensor == SINOWEALTH_SENSOR_PMW3327 || sensor == SINOWEALTH_SENSOR_PMW3360)
 		raw -= 1;
@@ -677,14 +677,14 @@ sinowealth_color_to_raw(struct ratbag_device *device, struct ratbag_color color)
 	/* Fall back to RBG if the LED type is incorrect. */
 	default:
 	case SINOWEALTH_LED_TYPE_RBG:
-		raw_color.data[0] = color.red;
-		raw_color.data[1] = color.blue;
-		raw_color.data[2] = color.green;
+		raw_color.data[0] = (uint8_t)color.red;
+		raw_color.data[1] = (uint8_t)color.blue;
+		raw_color.data[2] = (uint8_t)color.green;
 		break;
 	case SINOWEALTH_LED_TYPE_RGB:
-		raw_color.data[0] = color.red;
-		raw_color.data[1] = color.green;
-		raw_color.data[2] = color.blue;
+		raw_color.data[0] = (uint8_t)color.red;
+		raw_color.data[1] = (uint8_t)color.green;
+		raw_color.data[2] = (uint8_t)color.blue;
 		break;
 	}
 
@@ -751,7 +751,7 @@ static struct sinowealth_rgb_mode
 sinowealth_led_to_rgb_mode(const struct ratbag_led *led)
 {
 	struct sinowealth_rgb_mode mode;
-	mode.brightness = sinowealth_brightness_to_rgb_mode(led->brightness);
+	mode.brightness = sinowealth_brightness_to_rgb_mode((uint8_t)led->brightness);
 	mode.speed = sinowealth_duration_to_rgb_mode(led->ms);
 	return mode;
 }
@@ -867,7 +867,7 @@ sinowealth_set_active_profile(struct ratbag_device *device, unsigned int index)
 
 	struct sinowealth_data *drv_data = device->drv_data;
 
-	uint8_t buf[SINOWEALTH_CMD_SIZE] = { SINOWEALTH_REPORT_ID_CMD, SINOWEALTH_CMD_PROFILE, index + 1 };
+	uint8_t buf[SINOWEALTH_CMD_SIZE] = { SINOWEALTH_REPORT_ID_CMD, SINOWEALTH_CMD_PROFILE, (uint8_t)index + 1u };
 
 	rc = sinowealth_query_write(device, buf, sizeof(buf));
 	if (rc != 0) {
@@ -1015,7 +1015,7 @@ sinowealth_read_raw_config(struct ratbag_device *device)
 		log_error(device->ratbag, "Could not read device configuration: %d\n", rc);
 		return -1;
 	}
-	drv_data->config_size = rc;
+	drv_data->config_size = (unsigned int)rc;
 
 	log_debug(device->ratbag, "Configuration size is %d bytes\n", drv_data->config_size);
 
@@ -1262,7 +1262,7 @@ sinowealth_update_buttons_from_profile(struct ratbag_profile *profile)
 			 */
 
 			button_data->type = SINOWEALTH_BUTTON_TYPE_MACRO;
-			button_data->macro.index = button->index + (profile->index * drv_data->button_count);
+			button_data->macro.index = (uint8_t)(button->index + (profile->index * drv_data->button_count));
 			button_data->macro.mode = SINOWEALTH_BUTTON_MACRO_MODE_REPEAT;
 			button_data->macro.option = 1;
 
@@ -1288,7 +1288,7 @@ sinowealth_update_macro_from_action(struct ratbag_profile *profile, struct ratba
 	if (action->type != RATBAG_BUTTON_ACTION_TYPE_MACRO)
 		return;
 
-	macro->index = button->index + (profile->index * drv_data->button_count);
+	macro->index = (uint8_t)(button->index + (profile->index * drv_data->button_count));
 
 	/* Reset the `events` field. Even if we don't do this, the mouse will ignore unneeded data. */
 	memset(&macro->events, 0, sizeof(macro->events));
@@ -1355,7 +1355,7 @@ sinowealth_update_macro_from_action(struct ratbag_profile *profile, struct ratba
 				event->event.timeout = 0xff;
 
 			/* Set delay of the previous event. */
-			macro->events[raw_event_count - 1].delay = event->event.timeout;
+			macro->events[raw_event_count - 1].delay = (uint8_t)event->event.timeout;
 			break;
 		/* Should not be reachable but let's ignore it just in case. */
 		default:
@@ -1563,7 +1563,7 @@ sinowealth_write_config(struct ratbag_device *device)
 
 	config1->report_id = config_report_id;
 	config1->command_id = SINOWEALTH_CMD_GET_CONFIG;
-	config1->config_write = drv_data->config_size - 8;
+	config1->config_write = (uint8_t)drv_data->config_size - 8;
 
 	rc = sinowealth_query_write(device, (uint8_t*)config1, sizeof(*config1));
 	if (rc != 0) {

--- a/src/driver-sinowealth.c
+++ b/src/driver-sinowealth.c
@@ -486,7 +486,7 @@ static const struct sinowealth_button_mapping sinowealth_button_map[] = {
 
 	/* This must defined after `SPECIAL` type so that correct raw data
 	 * for action type `NONE` is used. */
-	{ { SINOWEALTH_BUTTON_TYPE_NONE, {} }, BUTTON_ACTION_NONE },
+	{ { SINOWEALTH_BUTTON_TYPE_NONE, { { 0 } } }, BUTTON_ACTION_NONE },
 };
 
 /* Check if two given button data structs are equal.
@@ -1586,7 +1586,7 @@ sinowealth_write_macros(struct ratbag_device *device)
 	const char config_report_id = drv_data->is_long ? SINOWEALTH_REPORT_ID_CONFIG_LONG : SINOWEALTH_REPORT_ID_CONFIG;
 
 	/* NOTE: We will reuse the same buffer for all commands and reset it's `events` field for every button. */
-	struct sinowealth_macro_report macro = {};
+	struct sinowealth_macro_report macro = { 0 };
 	macro.report_id = config_report_id;
 	macro.command_id = SINOWEALTH_CMD_MACRO;
 	macro.unknown1 = 0x2;

--- a/src/driver-sinowealth.c
+++ b/src/driver-sinowealth.c
@@ -490,22 +490,20 @@ static const struct sinowealth_button_mapping sinowealth_button_map[] = {
 };
 
 /* Check if two given button data structs are equal.
- *
- * @return 1 if structs are equal or 0 otherwise.
  */
-static int
+static bool
 sinowealth_button_data_is_equal(const struct sinowealth_button_data *lhs, const struct sinowealth_button_data *rhs)
 {
 	if (lhs->type != rhs->type)
-		return 0;
+		return false;
 
 	for (unsigned int i = 0; i < sizeof(lhs->data); ++i) {
 		if (lhs->data[i] != rhs->data[i]) {
-			return 0;
+			return false;
 		}
 	}
 
-	return 1;
+	return true;
 }
 
 /* Convert a button action to raw data using the `sinowealth_button_map`.
@@ -542,7 +540,7 @@ sinowealth_raw_to_button_action(const struct sinowealth_button_data *data)
 	const struct sinowealth_button_mapping *mapping = NULL;
 
 	ARRAY_FOR_EACH(sinowealth_button_map, mapping) {
-		if (sinowealth_button_data_is_equal(data, &mapping->data) == 0)
+		if (!sinowealth_button_data_is_equal(data, &mapping->data))
 			continue;
 
 		return &mapping->action;

--- a/src/driver-sinowealth.c
+++ b/src/driver-sinowealth.c
@@ -1283,8 +1283,7 @@ sinowealth_update_macro_from_action(struct ratbag_profile *profile, struct ratba
 	struct ratbag_device *device = profile->device;
 	struct sinowealth_data *drv_data = device->drv_data;
 
-	if (action->type != RATBAG_BUTTON_ACTION_TYPE_MACRO)
-		return;
+	assert(action->type == RATBAG_BUTTON_ACTION_TYPE_MACRO);
 
 	macro->index = (uint8_t)(button->index + (profile->index * drv_data->button_count));
 

--- a/src/driver-sinowealth.c
+++ b/src/driver-sinowealth.c
@@ -1020,15 +1020,9 @@ sinowealth_query_read_config(struct ratbag_device *device, uint8_t config_cmd, u
 
 	{
 		uint8_t cmd[SINOWEALTH_CMD_SIZE] = { SINOWEALTH_REPORT_ID_CMD, config_cmd };
-		rc = ratbag_hidraw_set_feature_report(device, SINOWEALTH_REPORT_ID_CMD, cmd, sizeof(cmd));
-		if (rc < 0) {
-			log_error(device->ratbag, "Error while sending read config command: %s (%d)\n", strerror(-rc), rc);
+		rc = sinowealth_query_write(device, cmd, sizeof(cmd));
+		if (rc < 0)
 			return rc;
-		}
-		if (rc != sizeof(cmd)) {
-			log_error(device->ratbag, "Unexpeced amount of transmitted data: %d (instead of %zu)\n", rc, sizeof(cmd));
-			return -EIO;
-		}
 	}
 
 	{

--- a/src/driver-sinowealth.c
+++ b/src/driver-sinowealth.c
@@ -692,7 +692,7 @@ sinowealth_color_to_raw(struct ratbag_device *device, struct ratbag_color color)
 }
 
 /* Get brightness to use with ratbag's API from RGB mode `mode`. */
-static int
+static unsigned int
 sinowealth_rgb_mode_to_brightness(struct sinowealth_rgb_mode mode)
 {
 	/* Convert 0-4 to 0-255. */
@@ -708,7 +708,7 @@ sinowealth_brightness_to_rgb_mode(uint8_t brightness)
 }
 
 /* @return Effect duration or `0` on error. */
-static int
+static unsigned int
 sinowealth_rgb_mode_to_duration(struct sinowealth_rgb_mode mode)
 {
 	switch (mode.speed) {
@@ -1293,7 +1293,7 @@ sinowealth_update_macro_from_action(struct ratbag_profile *profile, struct ratba
 	/* Reset the `events` field. Even if we don't do this, the mouse will ignore unneeded data. */
 	memset(&macro->events, 0, sizeof(macro->events));
 
-	unsigned int raw_event_count = 0;
+	uint8_t raw_event_count = 0;
 	for (unsigned int i = 0; i < MAX_MACRO_EVENTS; ++i) {
 		struct ratbag_macro_event *event = &action->macro->events[i];
 
@@ -1318,7 +1318,7 @@ sinowealth_update_macro_from_action(struct ratbag_profile *profile, struct ratba
 		switch (event->type) {
 		case RATBAG_MACRO_EVENT_KEY_PRESSED:
 		case RATBAG_MACRO_EVENT_KEY_RELEASED: {
-			int raw_key = ratbag_hidraw_get_keyboard_usage_from_keycode(device, event->event.key);
+			uint8_t raw_key = ratbag_hidraw_get_keyboard_usage_from_keycode(device, event->event.key);
 			if (raw_key == 0) {
 				log_error(device->ratbag, "Could not set unsupported key %#x in macro for button %u", event->event.key, button->index);
 				/* Ignore the error to not mess up event order. */
@@ -1530,7 +1530,7 @@ sinowealth_write_buttons(struct ratbag_device *device)
 
 	struct sinowealth_data *drv_data = device->drv_data;
 
-	const char config_report_id = drv_data->is_long ? SINOWEALTH_REPORT_ID_CONFIG_LONG : SINOWEALTH_REPORT_ID_CONFIG;
+	const uint8_t config_report_id = drv_data->is_long ? SINOWEALTH_REPORT_ID_CONFIG_LONG : SINOWEALTH_REPORT_ID_CONFIG;
 
 	struct sinowealth_button_report *buttons1 = &drv_data->buttons[0];
 
@@ -1583,7 +1583,7 @@ sinowealth_write_macros(struct ratbag_device *device)
 
 	struct sinowealth_data *drv_data = device->drv_data;
 
-	const char config_report_id = drv_data->is_long ? SINOWEALTH_REPORT_ID_CONFIG_LONG : SINOWEALTH_REPORT_ID_CONFIG;
+	const uint8_t config_report_id = drv_data->is_long ? SINOWEALTH_REPORT_ID_CONFIG_LONG : SINOWEALTH_REPORT_ID_CONFIG;
 
 	/* NOTE: We will reuse the same buffer for all commands and reset it's `events` field for every button. */
 	struct sinowealth_macro_report macro = { 0 };

--- a/src/driver-sinowealth.c
+++ b/src/driver-sinowealth.c
@@ -1294,8 +1294,18 @@ sinowealth_update_macro_from_action(struct ratbag_profile *profile, struct ratba
 	memset(&macro->events, 0, sizeof(macro->events));
 
 	unsigned int raw_event_count = 0;
-	for (unsigned int i = 0; i < MAX_MACRO_EVENTS && raw_event_count < SINOWEALTH_MACRO_LENGTH_MAX; ++i) {
+	for (unsigned int i = 0; i < MAX_MACRO_EVENTS; ++i) {
 		struct ratbag_macro_event *event = &action->macro->events[i];
+
+		if (raw_event_count >= SINOWEALTH_MACRO_LENGTH_MAX) {
+			log_error(device->ratbag, "There are more events in the macro than the mouse supports\n");
+
+			/* Update the type of this event so that libratbag ignores
+			 * unused events.
+			 */
+			event->type = RATBAG_MACRO_EVENT_NONE;
+			break;
+		};
 
 		if (action->macro->events[i].type == RATBAG_MACRO_EVENT_INVALID)
 			break;

--- a/src/driver-sinowealth.c
+++ b/src/driver-sinowealth.c
@@ -1379,7 +1379,7 @@ sinowealth_update_macro_from_action(struct ratbag_profile *profile, struct ratba
 		case RATBAG_MACRO_EVENT_KEY_RELEASED: {
 			uint8_t raw_key = ratbag_hidraw_get_keyboard_usage_from_keycode(device, event->event.key);
 			if (raw_key == 0) {
-				log_error(device->ratbag, "Could not set unsupported key %#x in macro for button %u", event->event.key, button->index);
+				log_error(device->ratbag, "Could not set unsupported key %#x in macro for button %u\n", event->event.key, button->index);
 				/* Ignore the error to not mess up event order. */
 			}
 


### PR DESCRIPTION
Another portion of improvements:
- Some code quality improvements.
- Support for LMB, RMB and MMB actions in macros.
- Complete support for the second profile if a preproccessor macro is set (subject for removal because of lack of usefulness, kept for archival reasons and to prevent questions like "why is there a set_active_profile() even though there is only one profile?").
