### PR TITLE
data: add device Logitech G Pro (X) keyboard

### DIFF
--- a/data/devices/logitech-g-pro-keyboard.device
+++ b/data/devices/logitech-g-pro-keyboard.device
@@ -1,0 +1,6 @@
+[Device]
+DeviceMatch=usb:046d:c339
+DeviceType=keyboard
+Driver=hidpp20
+LedTypes=logo;switches
+Name=Logitech G PRO Keyboard


### PR DESCRIPTION
Device file for `Logitech G Pro` and `Logitech G Pro X` keyboards

Known issues:
- not possible to change LED color of Caps lock indicator, Scroll lock indicator and Game Mode button.