### PR TITLE
driver-hidpp10: fix integer overflow when profile count is unset

### DIFF
--- a/src/driver-hidpp10.c
+++ b/src/driver-hidpp10.c
@@ -656,7 +656,15 @@ hidpp10drv_probe(struct ratbag_device *device)
 		else if (strcasecmp("G9", typestr) == 0)
 			type = HIDPP10_PROFILE_G9;
 
-		profile_count = ratbag_device_data_hidpp10_get_profile_count(device->data);
+		rc = ratbag_device_data_hidpp10_get_profile_count(device->data);
+		if (rc == -1) {
+			log_error(device->ratbag,
+				  "Device %s has no profile count set, even though profiles are enabled. "
+				  "Please adjust the .device file.\n",
+				  device->name);
+		} else {
+			profile_count = (unsigned int)rc;
+		};
 	}
 
 	device_idx = ratbag_device_data_hidpp10_get_index(device->data);

--- a/src/hidpp10.c
+++ b/src/hidpp10.c
@@ -180,7 +180,8 @@ hidpp10_request_command(struct hidpp10_device *dev, union hidpp10_message *msg)
 		command_size = LONG_MESSAGE_LENGTH;
 		break;
 	default:
-		abort();
+		hidpp_log_error(&dev->base, "Incorrect message report id: %02x\n", msg->msg.report_id);
+		return -EINVAL;
 	}
 
 	/* create the expected header */
@@ -1943,7 +1944,8 @@ hidpp10_set_led_status(struct hidpp10_device *dev,
 			case HIDPP10_LED_STATUS_SLOW_OFF:
 				break;
 			default:
-				abort();
+				hidpp_log_error(&dev->base, "Incorrect LED status: %02x\n", led[i]);
+				return -EINVAL;
 		}
 	}
 


### PR DESCRIPTION
This showed up while working on #1244.