### PR TITLE
steelseries: Add "support" for Rival 650 Wireless

### DIFF
--- a/data/devices/steelseries-rival-650-wireless.device
+++ b/data/devices/steelseries-rival-650-wireless.device
@@ -1,0 +1,13 @@
+[Device]
+# Wired mode; 2.4 Ghz wireless mode.
+DeviceMatch=usb:1038:172b;usb:1038:1726
+DeviceType=mouse
+Driver=steelseries
+Name=SteelSeries Rival 650 Wireless
+
+[Driver/steelseries]
+Buttons=0
+DeviceVersion=4
+DpiRange=100:12000@100
+Leds=0
+MacroLength=0


### PR DESCRIPTION
I got the protocol binary implementation entirely from [flozz/rivalcfg](https://github.com/flozz/rivalcfg), and even [their implementation](https://github.com/flozz/rivalcfg/blob/master/rivalcfg/devices/rival650.py) is relatively lacking in expected features like loading settings from the device and LED control, but I went ahead and added what was necessary for me to at least get the polling rate and DPI changes working for me.

**Implemented**
- [x] DPI/Sensitivity for the singular set of 2 DPI settings that the steelseries devices allow for
- [x] Polling rate changes (4-step similar to the oldest of the `steelseries` devices)

**Possible, but left out**
- [ ] Button mapping / macros

**Missing abstractions in libratbag, but possible**
- [ ] Sleep time configuration
- [ ] Battery status

**Unknown protocol**
- [ ] LED handling
- [ ] `get_settings` on load (i.e. just getting the settings from the device). Someone more experienced w/ reverse-engineering protocols and with access to other environments *may* be able to get this working, as I imagine that the functionality is at least on the device in some manner.

These `PROTOCOL4` patterns should also work with minimal difference for the [`rival3` wireless](https://github.com/flozz/rivalcfg/blob/master/rivalcfg/devices/rival3_wireless.py) as well, but I did not include a `.device` for it as I lack the hardware to test. It seems their wireless peripherals tend to follow similar-ish protocols (though not entirely unified).

# Thoughs on the steelseries driver going forward

Overall, I think the global `device_version` paradigm is showing itself to be a poor pattern for representing SteelSeries' compatibility across devices, so I stopped going further with this implementation so that I can look for a better way than the existing one to abstract the device-specific functionality in this driver.

It seems that SteelSeries is prone to choosing a given subset of protocols for various functionality, such that there's often a lot of overlap between different "protocol versions", but never enough to have have them be globally separate. Therefore, it seems prudent to take a look at having a "DPI Protocol", "Button protocol", "LED protocol", etc. for each device for this driver. Doing so would make edits for new/broken devices much less likely to interfere with other working devices, and allow for easier adding of devices in the future.

That's why I stopped going after the rest of the functionality on this implementation for now, but if DPI and polling rate had been present already from the get-go, I wouldn't have ever even bothered, so I figure this can hopefully help someone have a "just working" setup, while we (potentially) chase down a better way to abstract over the protocol changes for these devices going forward.

If we don't want to pull this due to the introduction of *yet another* `PROTOCOL[0-9]+` set for this driver, that's fine by me, but as a user I would have liked for this to have been present rather than having to do it myself.