### PR TITLE
Don't enable key-type button actions in drivers that don't suport them

### DIFF
--- a/src/driver-etekcity.c
+++ b/src/driver-etekcity.c
@@ -373,7 +373,6 @@ etekcity_read_button(struct ratbag_button *button)
 
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_NONE);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_BUTTON);
-	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_KEY);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_SPECIAL);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_MACRO);
 

--- a/src/driver-logitech-g300.c
+++ b/src/driver-logitech-g300.c
@@ -355,7 +355,6 @@ logitech_g300_read_button(struct ratbag_button *button)
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_NONE);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_BUTTON);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_SPECIAL);
-	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_KEY);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_MACRO);
 
 	button->type = logitech_g300_raw_to_button_type(button->index);

--- a/src/driver-logitech-g600.c
+++ b/src/driver-logitech-g600.c
@@ -358,7 +358,6 @@ logitech_g600_read_button(struct ratbag_button *button)
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_NONE);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_BUTTON);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_SPECIAL);
-	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_KEY);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_MACRO);
 
 	button->type = logitech_g600_raw_to_button_type(button->index);

--- a/src/driver-roccat-kone-emp.c
+++ b/src/driver-roccat-kone-emp.c
@@ -843,7 +843,6 @@ roccat_read_button(struct ratbag_button *button)
 //          __FILE__, __LINE__);
 
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_BUTTON);
-	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_KEY);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_SPECIAL);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_MACRO);
 

--- a/src/driver-roccat-kone-pure.c
+++ b/src/driver-roccat-kone-pure.c
@@ -444,7 +444,6 @@ roccat_read_button(struct ratbag_button *button)
 //			__FILE__, __LINE__);
 
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_BUTTON);
-	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_KEY);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_SPECIAL);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_MACRO);
 

--- a/src/driver-roccat.c
+++ b/src/driver-roccat.c
@@ -449,7 +449,6 @@ roccat_read_button(struct ratbag_button *button)
 //			__FILE__, __LINE__);
 
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_BUTTON);
-	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_KEY);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_SPECIAL);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_MACRO);
 

--- a/src/driver-steelseries.c
+++ b/src/driver-steelseries.c
@@ -392,7 +392,6 @@ steelseries_probe(struct ratbag_device *device)
 		ratbag_profile_for_each_button(profile, button) {
 			ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_BUTTON);
 			ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_SPECIAL);
-			ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_KEY);
 			if (quirk != STEELSERIES_QUIRK_SENSEIRAW) {
 				ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_MACRO);
 			}
@@ -660,7 +659,6 @@ steelseries_write_buttons(struct ratbag_profile *profile)
 			}
 			break;
 
-		case RATBAG_BUTTON_ACTION_TYPE_KEY:
 		case RATBAG_BUTTON_ACTION_TYPE_NONE:
 		default:
 			msg.msg.parameters[idx] = STEELSERIES_BUTTON_OFF;


### PR DESCRIPTION
Otherwise it would be impossible to set one key button actions through Piper, which tries to use key actions instead of macros if the driver says it supports them.
They should actually be easily implementable in most of these drivers, as most of them support macros with only a single key. However, I'd rather not blindly write code I can't test.