### PR TITLE
libratbag: use const pointers where possible and makes sense

### DIFF
--- a/src/libratbag-data.c
+++ b/src/libratbag-data.c
@@ -465,11 +465,7 @@ ratbag_device_data_destroy(struct ratbag_device_data *data)
 {
 	switch (data->drivertype) {
 	case HIDPP10:
-		if (data->hidpp10.dpi_list) {
-			free(data->hidpp10.dpi_list->entries);
-			free(data->hidpp10.dpi_list);
-		}
-
+		dpi_list_free(data->hidpp10.dpi_list);
 		free(data->hidpp10.dpi_range);
 		free(data->hidpp10.profile_type);
 		break;
@@ -486,11 +482,7 @@ ratbag_device_data_destroy(struct ratbag_device_data *data)
 		break;
 	}
 	case STEELSERIES:
-		if (data->steelseries.dpi_list) {
-			free(data->steelseries.dpi_list->entries);
-			free(data->steelseries.dpi_list);
-		}
-
+		dpi_list_free(data->steelseries.dpi_list);
 		free(data->steelseries.dpi_range);
 		break;
 	default:

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -459,7 +459,7 @@ ratbag_button_action_match(const struct ratbag_button_action *action,
 }
 
 int
-ratbag_action_macro_num_keys(struct ratbag_button_action *action);
+ratbag_action_macro_num_keys(const struct ratbag_button_action *action);
 
 int
 ratbag_button_macro_new_from_keycode(struct ratbag_button *button,
@@ -467,7 +467,7 @@ ratbag_button_macro_new_from_keycode(struct ratbag_button *button,
 				     unsigned int modifiers);
 
 int
-ratbag_action_keycode_from_macro(struct ratbag_button_action *action,
+ratbag_action_keycode_from_macro(const struct ratbag_button_action *action,
 				     unsigned int *key_out,
 				     unsigned int *modifiers_out);
 
@@ -518,7 +518,7 @@ ratbag_resolution_set_dpi_list_from_range(struct ratbag_resolution *res,
 
 static inline void
 ratbag_resolution_set_dpi_list(struct ratbag_resolution *res,
-			       unsigned int *dpis,
+			       const unsigned int *dpis,
 			       size_t ndpis)
 {
 	assert(ndpis <= ARRAY_LENGTH(res->dpis));
@@ -534,7 +534,7 @@ ratbag_resolution_set_dpi_list(struct ratbag_resolution *res,
 
 static inline void
 ratbag_profile_set_report_rate_list(struct ratbag_profile *profile,
-				    unsigned int *rates,
+				    const unsigned int *rates,
 				    size_t nrates)
 {
 	assert(nrates <= ARRAY_LENGTH(profile->rates));

--- a/src/libratbag-util.h
+++ b/src/libratbag-util.h
@@ -334,7 +334,7 @@ err:
 }
 
 static inline uint16_t
-get_unaligned_be_u16(uint8_t *buf)
+get_unaligned_be_u16(const uint8_t *buf)
 {
 	return (buf[0] << 8) | buf[1];
 }
@@ -347,7 +347,7 @@ set_unaligned_be_u16(uint8_t *buf, uint16_t value)
 }
 
 static inline uint16_t
-get_unaligned_le_u16(uint8_t *buf)
+get_unaligned_le_u16(const uint8_t *buf)
 {
 	return (buf[1] << 8) | buf[0];
 }
@@ -360,7 +360,7 @@ set_unaligned_le_u16(uint8_t *buf, uint16_t value)
 }
 
 static inline uint32_t
-get_unaligned_be_u32(uint8_t *buf)
+get_unaligned_be_u32(const uint8_t *buf)
 {
 	return (buf[0] << 24) | (buf[1] << 16) | (buf[2] << 8) | buf[3];
 }

--- a/src/libratbag-util.h
+++ b/src/libratbag-util.h
@@ -264,6 +264,8 @@ struct dpi_list {
 static inline void
 dpi_list_free(struct dpi_list *list)
 {
+	if (list == NULL)
+		return;
 	free(list->entries);
 	free(list);
 }

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -369,28 +369,11 @@ error:
 	return false;
 }
 
-static inline bool
-ratbag_driver_fallback_logitech(struct ratbag_device *device,
-				const struct input_id *dev_id)
-{
-	int rc;
-
-	if (dev_id->vendor != USB_VENDOR_ID_LOGITECH)
-		return false;
-
-	rc = ratbag_try_driver(device, dev_id, "hidpp20", NULL);
-	if (!rc)
-		rc = ratbag_try_driver(device, dev_id, "hidpp10", NULL);
-
-	return rc;
-}
-
 bool
 ratbag_assign_driver(struct ratbag_device *device,
 		     const struct input_id *dev_id,
 		     const struct ratbag_test_device *test_device)
 {
-	bool rc;
 	const char *driver_name;
 
 	if (!test_device) {
@@ -400,14 +383,8 @@ ratbag_assign_driver(struct ratbag_device *device,
 		driver_name = "test_driver";
 	}
 
-	if (driver_name) {
-		log_debug(device->ratbag, "device assigned driver %s\n", driver_name);
-		rc = ratbag_try_driver(device, dev_id, driver_name, test_device);
-	} else {
-		rc = ratbag_driver_fallback_logitech(device, dev_id);
-	}
-
-	return rc;
+	log_debug(device->ratbag, "device assigned driver %s\n", driver_name);
+	return ratbag_try_driver(device, dev_id, driver_name, test_device);
 }
 
 static char *

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -804,7 +804,7 @@ ratbag_profile_set_enabled(struct ratbag_profile *profile, bool enabled)
 }
 
 LIBRATBAG_EXPORT bool
-ratbag_profile_is_active(struct ratbag_profile *profile)
+ratbag_profile_is_active(const struct ratbag_profile *profile)
 {
 	return !!profile->is_active;
 }
@@ -822,19 +822,19 @@ ratbag_profile_is_enabled(const struct ratbag_profile *profile)
 }
 
 LIBRATBAG_EXPORT unsigned int
-ratbag_device_get_num_profiles(struct ratbag_device *device)
+ratbag_device_get_num_profiles(const struct ratbag_device *device)
 {
 	return device->num_profiles;
 }
 
 LIBRATBAG_EXPORT unsigned int
-ratbag_device_get_num_buttons(struct ratbag_device *device)
+ratbag_device_get_num_buttons(const struct ratbag_device *device)
 {
 	return device->num_buttons;
 }
 
 LIBRATBAG_EXPORT unsigned int
-ratbag_device_get_num_leds(struct ratbag_device *device)
+ratbag_device_get_num_leds(const struct ratbag_device *device)
 {
 	return device->num_leds;
 }
@@ -913,7 +913,7 @@ ratbag_profile_set_active(struct ratbag_profile *profile)
 }
 
 LIBRATBAG_EXPORT unsigned int
-ratbag_profile_get_num_resolutions(struct ratbag_profile *profile)
+ratbag_profile_get_num_resolutions(const struct ratbag_profile *profile)
 {
 	return profile->num_resolutions;
 }
@@ -967,7 +967,7 @@ ratbag_resolution_unref(struct ratbag_resolution *resolution)
 }
 
 LIBRATBAG_EXPORT bool
-ratbag_resolution_has_capability(struct ratbag_resolution *resolution,
+ratbag_resolution_has_capability(const struct ratbag_resolution *resolution,
 				 enum ratbag_resolution_capability cap)
 {
 	assert(cap <= RATBAG_RESOLUTION_CAP_DISABLE);
@@ -976,7 +976,7 @@ ratbag_resolution_has_capability(struct ratbag_resolution *resolution,
 }
 
 static inline bool
-resolution_has_dpi(struct ratbag_resolution *resolution,
+resolution_has_dpi(const struct ratbag_resolution *resolution,
 		   unsigned int dpi)
 {
 	for (size_t i = 0; i < resolution->ndpis; i++) {
@@ -1072,13 +1072,13 @@ ratbag_profile_set_debounce(struct ratbag_profile *profile,
 }
 
 LIBRATBAG_EXPORT int
-ratbag_resolution_get_dpi(struct ratbag_resolution *resolution)
+ratbag_resolution_get_dpi(const struct ratbag_resolution *resolution)
 {
 	return resolution->dpi_x;
 }
 
 LIBRATBAG_EXPORT size_t
-ratbag_resolution_get_dpi_list(struct ratbag_resolution *resolution,
+ratbag_resolution_get_dpi_list(const struct ratbag_resolution *resolution,
 			       unsigned int *resolutions,
 			       size_t nres)
 {
@@ -1096,37 +1096,37 @@ ratbag_resolution_get_dpi_list(struct ratbag_resolution *resolution,
 }
 
 LIBRATBAG_EXPORT int
-ratbag_resolution_get_dpi_x(struct ratbag_resolution *resolution)
+ratbag_resolution_get_dpi_x(const struct ratbag_resolution *resolution)
 {
 	return resolution->dpi_x;
 }
 
 LIBRATBAG_EXPORT int
-ratbag_resolution_get_dpi_y(struct ratbag_resolution *resolution)
+ratbag_resolution_get_dpi_y(const struct ratbag_resolution *resolution)
 {
 	return resolution->dpi_y;
 }
 
 LIBRATBAG_EXPORT int
-ratbag_profile_get_report_rate(struct ratbag_profile *profile)
+ratbag_profile_get_report_rate(const struct ratbag_profile *profile)
 {
 	return profile->hz;
 }
 
 LIBRATBAG_EXPORT int
-ratbag_profile_get_angle_snapping(struct ratbag_profile *profile)
+ratbag_profile_get_angle_snapping(const struct ratbag_profile *profile)
 {
 	return profile->angle_snapping;
 }
 
 LIBRATBAG_EXPORT int
-ratbag_profile_get_debounce(struct ratbag_profile *profile)
+ratbag_profile_get_debounce(const struct ratbag_profile *profile)
 {
 	return profile->debounce;
 }
 
 LIBRATBAG_EXPORT size_t
-ratbag_profile_get_debounce_list(struct ratbag_profile *profile,
+ratbag_profile_get_debounce_list(const struct ratbag_profile *profile,
 				 unsigned int *debounces,
 				 size_t ndebounces)
 {
@@ -1144,7 +1144,7 @@ ratbag_profile_get_debounce_list(struct ratbag_profile *profile,
 }
 
 LIBRATBAG_EXPORT size_t
-ratbag_profile_get_report_rate_list(struct ratbag_profile *profile,
+ratbag_profile_get_report_rate_list(const struct ratbag_profile *profile,
 				    unsigned int *rates,
 				    size_t nrates)
 {
@@ -1279,13 +1279,13 @@ ratbag_profile_get_button(struct ratbag_profile *profile,
 }
 
 LIBRATBAG_EXPORT enum ratbag_button_action_type
-ratbag_button_get_action_type(struct ratbag_button *button)
+ratbag_button_get_action_type(const struct ratbag_button *button)
 {
 	return button->action.type;
 }
 
 LIBRATBAG_EXPORT bool
-ratbag_button_has_action_type(struct ratbag_button *button,
+ratbag_button_has_action_type(const struct ratbag_button *button,
 			      enum ratbag_button_action_type action_type)
 {
 	switch (action_type) {
@@ -1303,7 +1303,7 @@ ratbag_button_has_action_type(struct ratbag_button *button,
 }
 
 LIBRATBAG_EXPORT unsigned int
-ratbag_button_get_button(struct ratbag_button *button)
+ratbag_button_get_button(const struct ratbag_button *button)
 {
 	if (button->action.type != RATBAG_BUTTON_ACTION_TYPE_BUTTON)
 		return 0;
@@ -1342,7 +1342,7 @@ ratbag_button_set_button(struct ratbag_button *button, unsigned int btn)
 }
 
 LIBRATBAG_EXPORT enum ratbag_button_action_special
-ratbag_button_get_special(struct ratbag_button *button)
+ratbag_button_get_special(const struct ratbag_button *button)
 {
 	if (button->action.type != RATBAG_BUTTON_ACTION_TYPE_SPECIAL)
 		return RATBAG_BUTTON_ACTION_SPECIAL_INVALID;
@@ -1373,7 +1373,7 @@ ratbag_button_set_special(struct ratbag_button *button,
 }
 
 LIBRATBAG_EXPORT unsigned int
-ratbag_button_get_key(struct ratbag_button *button,
+ratbag_button_get_key(const struct ratbag_button *button,
 		      unsigned int *modifiers,
 		      size_t *sz)
 {
@@ -1505,13 +1505,13 @@ ratbag_led_unref(struct ratbag_led *led)
 }
 
 LIBRATBAG_EXPORT enum ratbag_led_mode
-ratbag_led_get_mode(struct ratbag_led *led)
+ratbag_led_get_mode(const struct ratbag_led *led)
 {
 	return led->mode;
 }
 
 LIBRATBAG_EXPORT bool
-ratbag_led_has_mode(struct ratbag_led *led,
+ratbag_led_has_mode(const struct ratbag_led *led,
 		    enum ratbag_led_mode mode)
 {
 	assert(mode <= RATBAG_LED_BREATHING);
@@ -1523,19 +1523,19 @@ ratbag_led_has_mode(struct ratbag_led *led,
 }
 
 LIBRATBAG_EXPORT struct ratbag_color
-ratbag_led_get_color(struct ratbag_led *led)
+ratbag_led_get_color(const struct ratbag_led *led)
 {
 	return led->color;
 }
 
 LIBRATBAG_EXPORT int
-ratbag_led_get_effect_duration(struct ratbag_led *led)
+ratbag_led_get_effect_duration(const struct ratbag_led *led)
 {
 	return led->ms;
 }
 
 LIBRATBAG_EXPORT unsigned int
-ratbag_led_get_brightness(struct ratbag_led *led)
+ratbag_led_get_brightness(const struct ratbag_led *led)
 {
 	return led->brightness;
 }
@@ -1559,7 +1559,7 @@ ratbag_led_set_color(struct ratbag_led *led, struct ratbag_color color)
 }
 
 LIBRATBAG_EXPORT enum ratbag_led_colordepth
-ratbag_led_get_colordepth(struct ratbag_led *led)
+ratbag_led_get_colordepth(const struct ratbag_led *led)
 {
 	return led->colordepth;
 }
@@ -1606,7 +1606,7 @@ ratbag_profile_get_led(struct ratbag_profile *profile,
 }
 
 LIBRATBAG_EXPORT const char *
-ratbag_profile_get_name(struct ratbag_profile *profile)
+ratbag_profile_get_name(const struct ratbag_profile *profile)
 {
 	return profile->name;
 }
@@ -1786,7 +1786,8 @@ ratbag_button_macro_set_event(struct ratbag_button_macro *m,
 }
 
 LIBRATBAG_EXPORT enum ratbag_macro_event_type
-ratbag_button_macro_get_event_type(struct ratbag_button_macro *macro, unsigned int index)
+ratbag_button_macro_get_event_type(const struct ratbag_button_macro *macro,
+				   unsigned int index)
 {
 	if (index >= MAX_MACRO_EVENTS)
 		return RATBAG_MACRO_EVENT_INVALID;
@@ -1795,9 +1796,10 @@ ratbag_button_macro_get_event_type(struct ratbag_button_macro *macro, unsigned i
 }
 
 LIBRATBAG_EXPORT int
-ratbag_button_macro_get_event_key(struct ratbag_button_macro *m, unsigned int index)
+ratbag_button_macro_get_event_key(const struct ratbag_button_macro *m,
+				  unsigned int index)
 {
-	struct ratbag_macro *macro = &m->macro;
+	const struct ratbag_macro *macro = &m->macro;
 
 	if (index >= MAX_MACRO_EVENTS)
 		return 0;
@@ -1810,10 +1812,10 @@ ratbag_button_macro_get_event_key(struct ratbag_button_macro *m, unsigned int in
 }
 
 LIBRATBAG_EXPORT int
-ratbag_button_macro_get_event_timeout(struct ratbag_button_macro *m,
+ratbag_button_macro_get_event_timeout(const struct ratbag_button_macro *m,
 				      unsigned int index)
 {
-	struct ratbag_macro *macro = &m->macro;
+	const struct ratbag_macro *macro = &m->macro;
 
 	if (index >= MAX_MACRO_EVENTS)
 		return 0;
@@ -1825,13 +1827,13 @@ ratbag_button_macro_get_event_timeout(struct ratbag_button_macro *m,
 }
 
 LIBRATBAG_EXPORT unsigned int
-ratbag_button_macro_get_num_events(struct ratbag_button_macro *macro)
+ratbag_button_macro_get_num_events(const struct ratbag_button_macro *macro)
 {
 	return MAX_MACRO_EVENTS;
 }
 
 LIBRATBAG_EXPORT const char *
-ratbag_button_macro_get_name(struct ratbag_button_macro *macro)
+ratbag_button_macro_get_name(const struct ratbag_button_macro *macro)
 {
 	return macro->macro.name;
 }
@@ -1940,9 +1942,9 @@ ratbag_button_macro_new_from_keycode(struct ratbag_button *button,
 }
 
 int
-ratbag_action_macro_num_keys(struct ratbag_button_action *action)
+ratbag_action_macro_num_keys(const struct ratbag_button_action *action)
 {
-	struct ratbag_macro *macro = action->macro;
+	const struct ratbag_macro *macro = action->macro;
 	int i, count;
 
 	count = 0;
@@ -1972,7 +1974,7 @@ ratbag_action_macro_num_keys(struct ratbag_button_action *action)
 }
 
 int
-ratbag_action_keycode_from_macro(struct ratbag_button_action *action,
+ratbag_action_keycode_from_macro(const struct ratbag_button_action *action,
 				 unsigned int *key_out,
 				 unsigned int *modifiers_out)
 {

--- a/src/libratbag.h
+++ b/src/libratbag.h
@@ -528,7 +528,7 @@ ratbag_device_commit(struct ratbag_device *device);
  * @return The number of profiles available on this device.
  */
 unsigned int
-ratbag_device_get_num_profiles(struct ratbag_device *device);
+ratbag_device_get_num_profiles(const struct ratbag_device *device);
 
 /**
  * @ingroup device
@@ -539,7 +539,7 @@ ratbag_device_get_num_profiles(struct ratbag_device *device);
  * @return The number of buttons available on this device.
  */
 unsigned int
-ratbag_device_get_num_buttons(struct ratbag_device *device);
+ratbag_device_get_num_buttons(const struct ratbag_device *device);
 
 /**
  * @ingroup device
@@ -550,7 +550,7 @@ ratbag_device_get_num_buttons(struct ratbag_device *device);
  * @return The number of LEDs available on this device.
  */
 unsigned int
-ratbag_device_get_num_leds(struct ratbag_device *device);
+ratbag_device_get_num_leds(const struct ratbag_device *device);
 
 /**
  * @ingroup profile
@@ -597,7 +597,7 @@ ratbag_profile_has_capability(const struct ratbag_profile *profile,
  * @return the profile name
  */
 const char *
-ratbag_profile_get_name(struct ratbag_profile *profile);
+ratbag_profile_get_name(const struct ratbag_profile *profile);
 
 /**
  * @ingroup profile
@@ -700,7 +700,7 @@ ratbag_device_get_profile(struct ratbag_device *device, unsigned int index);
  * @return non-zero if the profile is currently active, zero otherwise
  */
 bool
-ratbag_profile_is_active(struct ratbag_profile *profile);
+ratbag_profile_is_active(const struct ratbag_profile *profile);
 
 /**
  * @ingroup profile
@@ -757,7 +757,7 @@ ratbag_profile_set_report_rate(struct ratbag_profile *profile,
  * @return The report rate for this profile in Hz
  */
 int
-ratbag_profile_get_report_rate(struct ratbag_profile *profile);
+ratbag_profile_get_report_rate(const struct ratbag_profile *profile);
 
 /**
  * @ingroup profile
@@ -779,7 +779,7 @@ ratbag_profile_get_report_rate(struct ratbag_profile *profile);
  * is larger than nrates, the list was truncated.
  */
 size_t
-ratbag_profile_get_report_rate_list(struct ratbag_profile *profile,
+ratbag_profile_get_report_rate_list(const struct ratbag_profile *profile,
 				    unsigned int *rates,
 				    size_t nrates);
 
@@ -812,7 +812,7 @@ ratbag_profile_set_angle_snapping(struct ratbag_profile *profile,
  * @return Angle snapping value
  */
 int
-ratbag_profile_get_angle_snapping(struct ratbag_profile *profile);
+ratbag_profile_get_angle_snapping(const struct ratbag_profile *profile);
 
 /**
  * @ingroup profile
@@ -841,7 +841,7 @@ ratbag_profile_set_debounce(struct ratbag_profile *profile,
  * @return Debounce time for this profile in ms
  */
 int
-ratbag_profile_get_debounce(struct ratbag_profile *profile);
+ratbag_profile_get_debounce(const struct ratbag_profile *profile);
 
 /**
  * @ingroup profile
@@ -863,7 +863,7 @@ ratbag_profile_get_debounce(struct ratbag_profile *profile);
  * is larger than ndebounces, the list was truncated.
  */
 size_t
-ratbag_profile_get_debounce_list(struct ratbag_profile *profile,
+ratbag_profile_get_debounce_list(const struct ratbag_profile *profile,
 				 unsigned int *debounces,
 				 size_t ndebounces);
 
@@ -883,7 +883,7 @@ ratbag_profile_get_debounce_list(struct ratbag_profile *profile,
  * @return The number of resolutions available.
  */
 unsigned int
-ratbag_profile_get_num_resolutions(struct ratbag_profile *profile);
+ratbag_profile_get_num_resolutions(const struct ratbag_profile *profile);
 
 /**
  * @ingroup profile
@@ -969,7 +969,7 @@ ratbag_resolution_get_user_data(const struct ratbag_resolution *resolution);
  * @return non-zero if the capability is available, zero otherwise.
  */
 bool
-ratbag_resolution_has_capability(struct ratbag_resolution *resolution,
+ratbag_resolution_has_capability(const struct ratbag_resolution *resolution,
 				 enum ratbag_resolution_capability cap);
 
 /**
@@ -1035,7 +1035,7 @@ ratbag_resolution_set_dpi_xy(struct ratbag_resolution *resolution,
  * @return The resolution in dpi
  */
 int
-ratbag_resolution_get_dpi(struct ratbag_resolution *resolution);
+ratbag_resolution_get_dpi(const struct ratbag_resolution *resolution);
 
 /**
  * @ingroup resolution
@@ -1057,7 +1057,7 @@ ratbag_resolution_get_dpi(struct ratbag_resolution *resolution);
  * is larger than nres, the list was truncated.
  */
 size_t
-ratbag_resolution_get_dpi_list(struct ratbag_resolution *resolution,
+ratbag_resolution_get_dpi_list(const struct ratbag_resolution *resolution,
 			       unsigned int *resolutions,
 			       size_t nres);
 
@@ -1076,7 +1076,7 @@ ratbag_resolution_get_dpi_list(struct ratbag_resolution *resolution,
  * @return The resolution in dpi
  */
 int
-ratbag_resolution_get_dpi_x(struct ratbag_resolution *resolution);
+ratbag_resolution_get_dpi_x(const struct ratbag_resolution *resolution);
 
 /**
  * @ingroup resolution
@@ -1093,7 +1093,7 @@ ratbag_resolution_get_dpi_x(struct ratbag_resolution *resolution);
  * @return The resolution in dpi
  */
 int
-ratbag_resolution_get_dpi_y(struct ratbag_resolution *resolution);
+ratbag_resolution_get_dpi_y(const struct ratbag_resolution *resolution);
 
 /**
  * @ingroup resolution
@@ -1243,7 +1243,7 @@ ratbag_button_get_user_data(const struct ratbag_button *button);
  * @return The type of the action currently configured for this button
  */
 enum ratbag_button_action_type
-ratbag_button_get_action_type(struct ratbag_button *button);
+ratbag_button_get_action_type(const struct ratbag_button *button);
 
 /**
  * @ingroup button
@@ -1263,7 +1263,7 @@ ratbag_button_get_action_type(struct ratbag_button *button);
  * @return non-zero if the action type is supported, zero otherwise.
  */
 bool
-ratbag_button_has_action_type(struct ratbag_button *button,
+ratbag_button_has_action_type(const struct ratbag_button *button,
 			      enum ratbag_button_action_type action_type);
 
 /**
@@ -1286,7 +1286,7 @@ ratbag_button_has_action_type(struct ratbag_button *button,
  * @see ratbag_button_set_button
  */
 unsigned int
-ratbag_button_get_button(struct ratbag_button *button);
+ratbag_button_get_button(const struct ratbag_button *button);
 
 /**
  * @ingroup button
@@ -1318,7 +1318,7 @@ ratbag_button_set_button(struct ratbag_button *button,
  * @see ratbag_button_set_button
  */
 enum ratbag_button_action_special
-ratbag_button_get_special(struct ratbag_button *button);
+ratbag_button_get_special(const struct ratbag_button *button);
 
 /**
  * @ingroup led
@@ -1352,7 +1352,7 @@ ratbag_profile_get_led(struct ratbag_profile *profile, unsigned int index);
  * @see ratbag_led_set_mode
  */
 bool
-ratbag_led_has_mode(struct ratbag_led *led,
+ratbag_led_has_mode(const struct ratbag_led *led,
 		    enum ratbag_led_mode mode);
 
 /**
@@ -1366,7 +1366,7 @@ ratbag_led_has_mode(struct ratbag_led *led,
  * @see ratbag_led_set_mode
  */
 enum ratbag_led_mode
-ratbag_led_get_mode(struct ratbag_led *led);
+ratbag_led_get_mode(const struct ratbag_led *led);
 /**
  * @ingroup led
  *
@@ -1383,7 +1383,7 @@ ratbag_led_get_mode(struct ratbag_led *led);
  * @see ratbag_led_set_color
  */
 struct ratbag_color
-ratbag_led_get_color(struct ratbag_led *led);
+ratbag_led_get_color(const struct ratbag_led *led);
 
 /**
  * @ingroup led
@@ -1396,7 +1396,7 @@ ratbag_led_get_color(struct ratbag_led *led);
  * @see ratbag_led_set_color
  */
 enum ratbag_led_colordepth
-ratbag_led_get_colordepth(struct ratbag_led *led);
+ratbag_led_get_colordepth(const struct ratbag_led *led);
 
 /**
  * @ingroup led
@@ -1409,7 +1409,7 @@ ratbag_led_get_colordepth(struct ratbag_led *led);
  * @see ratbag_led_set_effect_duration
  */
 int
-ratbag_led_get_effect_duration(struct ratbag_led *led);
+ratbag_led_get_effect_duration(const struct ratbag_led *led);
 /**
  * @ingroup led
  *
@@ -1421,7 +1421,7 @@ ratbag_led_get_effect_duration(struct ratbag_led *led);
  * @see ratbag_led_get_brightness
  */
 unsigned int
-ratbag_led_get_brightness(struct ratbag_led *led);
+ratbag_led_get_brightness(const struct ratbag_led *led);
 
 /**
  * @ingroup led
@@ -1525,7 +1525,7 @@ ratbag_button_set_special(struct ratbag_button *button,
  * @return The button number
  */
 unsigned int
-ratbag_button_get_key(struct ratbag_button *button,
+ratbag_button_get_key(const struct ratbag_button *button,
 		      unsigned int *modifiers,
 		      size_t *sz);
 
@@ -1569,7 +1569,7 @@ ratbag_button_disable(struct ratbag_button *button);
  * @return The name of the macro
  */
 const char *
-ratbag_button_macro_get_name(struct ratbag_button_macro *macro);
+ratbag_button_macro_get_name(const struct ratbag_button_macro *macro);
 
 /**
  * @ingroup button
@@ -1579,7 +1579,7 @@ ratbag_button_macro_get_name(struct ratbag_button_macro *macro);
  * @return The maximum number of events that can be assigned to this macro
  */
 unsigned int
-ratbag_button_macro_get_num_events(struct ratbag_button_macro *macro);
+ratbag_button_macro_get_num_events(const struct ratbag_button_macro *macro);
 
 /**
  * @ingroup button
@@ -1596,7 +1596,7 @@ ratbag_button_macro_get_num_events(struct ratbag_button_macro *macro);
  * @return The type of the event at the given index
  */
 enum ratbag_macro_event_type
-ratbag_button_macro_get_event_type(struct ratbag_button_macro *macro,
+ratbag_button_macro_get_event_type(const struct ratbag_button_macro *macro,
 				   unsigned int index);
 
 /**
@@ -1616,7 +1616,7 @@ ratbag_button_macro_get_event_type(struct ratbag_button_macro *macro,
  * @return The key of the event at the given index
  */
 int
-ratbag_button_macro_get_event_key(struct ratbag_button_macro*macro,
+ratbag_button_macro_get_event_key(const struct ratbag_button_macro*macro,
 				  unsigned int index);
 
 /**
@@ -1635,7 +1635,7 @@ ratbag_button_macro_get_event_key(struct ratbag_button_macro*macro,
  * @return The timeout of the event at the given index
  */
 int
-ratbag_button_macro_get_event_timeout(struct ratbag_button_macro *macro,
+ratbag_button_macro_get_event_timeout(const struct ratbag_button_macro *macro,
 				      unsigned int index);
 
 /**


### PR DESCRIPTION
This fixes the following warning:
```
[10/73] Compiling C object libratbag.a.p/src_driver-hidpp10.c.o
../src/driver-hidpp10.c: In function ‘hidpp10drv_write_button’:
../src/driver-hidpp10.c:280:55: warning: passing argument 1 of ‘ratbag_action_keycode_from_macro’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  280 |                 rc = ratbag_action_keycode_from_macro(action, &key, &modifiers);
      |                                                       ^~~~~~
In file included from ../src/driver-hidpp10.c:48:
../src/libratbag-private.h:470:63: note: expected ‘struct ratbag_button_action *’ but argument is of type ‘const struct ratbag_button_action *’
  470 | ratbag_action_keycode_from_macro(struct ratbag_button_action *action,
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
```

and a few unrelated things I noticed while going though files