### PR TITLE
ratbagd: change type of a variable to fix stack smashing

### DIFF
--- a/ratbagd/ratbagd-profile.c
+++ b/ratbagd/ratbagd-profile.c
@@ -330,7 +330,7 @@ ratbagd_profile_set_disabled(sd_bus *bus,
 {
 	struct ratbagd_profile *profile = userdata;
 	int r;
-	bool disabled;
+	int disabled;
 
 	CHECK_CALL(sd_bus_message_read(m, "b", &disabled));
 


### PR DESCRIPTION
sd-bus requires an int variable to be passed to SD_BUS_TYPE_BOOLEAN calls, see man sd_bus_message_read (3).

We have had an issue of the same sort recently in
77fcaf6d281788edc3d52e52a19964bfc20786bc which was in some freshly new code, but this time it's something we have been shipping for a while.

Fixes #1452.