### PR TITLE
tools: fix printing of macros with buttons in them

### DIFF
--- a/tools/ratbagc.py.in
+++ b/tools/ratbagc.py.in
@@ -34,6 +34,14 @@ def N_(x):
     return x
 
 
+def evcode_to_str(evcode: int) -> str:
+    # Values in ecodes.keys are stored as either a str or list[str].
+    value = ecodes.keys[evcode]
+    if isinstance(value, list):
+        return value[0]
+    return value
+
+
 # we use a metaclass to automatically load symbols from libratbag in the classes
 # define _PREFIX in subclasses to take advantage of this.
 class MetaRatbag(type):
@@ -775,24 +783,14 @@ class RatbagdMacro(metaclass=MetaRatbag):
     linux/input.h and not those used by X.Org or any other higher layer such as
     Gdk."""
 
-    # All keys from ecodes.KEY have a KEY_ prefix. We strip it.
-    _PREFIX_LEN = len("KEY_")
-
     # Both a key press and release.
     _MACRO_KEY = 1000
 
     _MACRO_DESCRIPTION = {
-        RatbagdButton.Macro.NONE: lambda key: ".",
-        RatbagdButton.Macro.KEY_PRESS: lambda key: "↓{}".format(
-            ecodes.KEY[key][RatbagdMacro._PREFIX_LEN :]
-        ),
-        RatbagdButton.Macro.KEY_RELEASE: lambda key: "↑{}".format(
-            ecodes.KEY[key][RatbagdMacro._PREFIX_LEN :]
-        ),
+        RatbagdButton.Macro.KEY_PRESS: lambda key: f"↓{evcode_to_str(key)}",
+        RatbagdButton.Macro.KEY_RELEASE: lambda key: f"↑{evcode_to_str(key)}",
         RatbagdButton.Macro.WAIT: lambda val: f"{val}ms",
-        _MACRO_KEY: lambda key: "↕{}".format(
-            ecodes.KEY[key][RatbagdMacro._PREFIX_LEN :]
-        ),
+        _MACRO_KEY: lambda key: f"↕{evcode_to_str(key)}",
     }
 
     def __init__(self):

--- a/tools/ratbagctl.body.py.in
+++ b/tools/ratbagctl.body.py.in
@@ -30,7 +30,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 # This must be on a single line, as we replace it using merge_ratbagd.py while building.
 # fmt: off
-from ratbagd import Ratbagd, RatbagdDevice, RatbagdProfile, RatbagdMacro, RatbagdResolution, RatbagdButton, RatbagdLed, RatbagdUnavailableError, RatbagError, RatbagErrorCode, RatbagCapabilityError, RatbagDeviceType  # NOQA
+from ratbagd import Ratbagd, RatbagdDevice, RatbagdProfile, RatbagdMacro, RatbagdResolution, RatbagdButton, RatbagdLed, RatbagdUnavailableError, RatbagError, RatbagErrorCode, RatbagCapabilityError, RatbagDeviceType, evcode_to_str  # NOQA
 # fmt: on
 
 
@@ -225,7 +225,7 @@ def print_button(
     elif button.action_type == RatbagdButton.ActionType.SPECIAL:
         print(f"{header}'{button_specials_strmap[button.special]}'")
     elif button.action_type == RatbagdButton.ActionType.KEY:
-        key_name = evdev.ecodes.KEY[button.key][RatbagdMacro._PREFIX_LEN :]
+        key_name = evcode_to_str(button.key)
         print(f"{header}key '{key_name}'")
     elif button.action_type == RatbagdButton.ActionType.MACRO:
         print(f"{header}macro '{str(button.macro)}'")

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -35,6 +35,14 @@ def N_(x):
     return x
 
 
+def evcode_to_str(evcode: int) -> str:
+    # Values in ecodes.keys are stored as either a str or list[str].
+    value = ecodes.keys[evcode]
+    if isinstance(value, list):
+        return value[0]
+    return value
+
+
 class RatbagErrorCode(IntEnum):
     SUCCESS = 0
 
@@ -989,23 +997,14 @@ class RatbagdMacro(GObject.Object):
     linux/input.h and not those used by X.Org or any other higher layer such as
     Gdk."""
 
-    # All keys from ecodes.KEY have a KEY_ prefix. We strip it.
-    _PREFIX_LEN = len("KEY_")
-
     # Both a key press and release.
     _MACRO_KEY = 1000
 
     _MACRO_DESCRIPTION = {
-        RatbagdButton.Macro.KEY_PRESS: lambda key: "↓{}".format(
-            ecodes.KEY[key][RatbagdMacro._PREFIX_LEN :]
-        ),
-        RatbagdButton.Macro.KEY_RELEASE: lambda key: "↑{}".format(
-            ecodes.KEY[key][RatbagdMacro._PREFIX_LEN :]
-        ),
+        RatbagdButton.Macro.KEY_PRESS: lambda key: f"↓{evcode_to_str(key)}",
+        RatbagdButton.Macro.KEY_RELEASE: lambda key: f"↑{evcode_to_str(key)}",
         RatbagdButton.Macro.WAIT: lambda val: f"{val}ms",
-        _MACRO_KEY: lambda key: "↕{}".format(
-            ecodes.KEY[key][RatbagdMacro._PREFIX_LEN :]
-        ),
+        _MACRO_KEY: lambda key: f"↕{evcode_to_str(key)}",
     }
 
     __gsignals__ = {


### PR DESCRIPTION
As the fields are not always keys, also don't strip the first four symbols of the string.
(as it's not always obvious what the stripped string can be, for example BTN_0 and KEY_0).
Fixes #1454.