### PR TITLE
build: remove redundant build targets for tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -666,10 +666,6 @@ run_target(
 )
 
 python_black_check = find_program(join_paths(project_source_root, 'test/python-black-check.sh'))
-run_target(
-  'python-black-check',
-  command : python_black_check,
-)
 test(
   'python-black-check',
   python_black_check,
@@ -683,10 +679,6 @@ run_target(
 )
 
 python_ruff_check = find_program(join_paths(project_source_root, 'test/python-ruff-check.sh'))
-run_target(
-  'python-ruff-check',
-  command : python_ruff_check,
-)
 test(
   'python-ruff-check',
   python_ruff_check,


### PR DESCRIPTION
Initially I made them so that you can run them separately to see their output, however, this can be done with meson out of the box. E.g., replace:
`ninja -C builddir python-black-check`
with
`meson test -v -C build python-black-check`.