### PR TITLE
asus: check for hid report and fix chakram x

### DIFF
--- a/data/devices/asus-rog-chakram-x.device
+++ b/data/devices/asus-rog-chakram-x.device
@@ -1,6 +1,6 @@
 [Device]
 Name=ASUS ROG Chakram X
-DeviceMatch=usb:0b05:1a1a
+DeviceMatch=usb:0b05:1a18
 DeviceType=mouse
 Driver=asus
 
@@ -11,4 +11,4 @@ Leds=3
 Dpis=4
 Wireless=1
 DpiRange=100:36000@100
-Quirks=DOUBLE_DPI;STRIX_PROFILE
+Quirks=DOUBLE_DPI

--- a/src/asus.c
+++ b/src/asus.c
@@ -136,7 +136,7 @@ asus_query(struct ratbag_device *device,
 		return rc;
 
 	/* invalid state, disconnected or sleeping */
-	if (response->data.code == 0xaaff) {
+	if (response->data.code == ASUS_STATUS_ERROR) {
 		return ASUS_STATUS_ERROR;
 	}
 

--- a/src/asus.h
+++ b/src/asus.h
@@ -14,7 +14,7 @@
 #define ASUS_BUTTON_ACTION_TYPE_KEY 0  /* keyboard key */
 #define ASUS_BUTTON_ACTION_TYPE_BUTTON 1  /* mouse button */
 #define ASUS_BUTTON_CODE_DISABLED 0xff  /* disabled mouse button */
-#define ASUS_STATUS_ERROR 0xffaa  /* invalid state/request, disconnected or sleeping */
+#define ASUS_STATUS_ERROR 0xaaff  /* invalid state/request, disconnected or sleeping */
 
 /* maximum number of buttons across all ASUS devices */
 #define ASUS_MAX_NUM_BUTTON 17

--- a/src/driver-asus.c
+++ b/src/driver-asus.c
@@ -434,6 +434,7 @@ asus_driver_probe(struct ratbag_device *device)
 	unsigned int profile_count, dpi_count, button_count, led_count;
 	const struct asus_button *asus_button;
 	struct asus_data *drv_data;
+	struct asus_profile_data profile_data;
 	struct ratbag_profile *profile;
 	struct ratbag_button *button;
 	struct ratbag_resolution *resolution;
@@ -442,6 +443,12 @@ asus_driver_probe(struct ratbag_device *device)
 	rc = ratbag_open_hidraw(device);
 	if (rc)
 		return rc;
+
+	rc = asus_get_profile_data(device, &profile_data);
+	if (rc) {
+		ratbag_close_hidraw(device);
+		return -ENODEV;
+	}
 
 	/* create device state data */
 	drv_data = zalloc(sizeof(*drv_data));


### PR DESCRIPTION
Fixes https://github.com/libratbag/libratbag/issues/1413

Every ASUS mouse have multiple interfaces for mouse, keyboard, configuration and other stuff. There was some error messages because libratbag tried to initialize on the wrong interfaces of the mouse. It tries every interface and fails on the wrong one with error message. This PR fixes it and I have tested this part.