### PR TITLE
fix: ignore a Ruff f-string formatting warning (UP032)

### DIFF
--- a/tools/ratbagctl.body.py.in
+++ b/tools/ratbagctl.body.py.in
@@ -1856,7 +1856,7 @@ Exit codes:
   1     Unsupported feature, index out of available range or invalid device
   2     Commandline arguments are invalid
   3     A command failed on the device
-""".format(
+""".format(  # noqa: UP032
                 self.parser.prog
             )
         )


### PR DESCRIPTION
I think we're better off ignoring the warning here (instead of repeating the same argument like 10 times).

Fixes tests failing because UP032 was extended in Ruff (and this has happened before). Pinning Ruff is probably a good idea. (Fixes #1515.)