### PR TITLE
Refactor: fix some clang-tidy warnings

### DIFF
--- a/src/driver-sinowealth.c
+++ b/src/driver-sinowealth.c
@@ -251,7 +251,7 @@ struct sinowealth_config_report {
 	enum sinowealth_sensor sensor_type;
 	/* @ref sinowealth_report_rate_map. */
 	uint8_t report_rate:4;
-	/* 0b1000 - make DPI axes independent. */
+	/* @ref sinowealth_config_data_mask */
 	uint8_t config_flags:4;
 	uint8_t dpi_count:4;
 	/* Starting from 1 counting only active slots. */

--- a/src/driver-sinowealth.c
+++ b/src/driver-sinowealth.c
@@ -85,6 +85,14 @@ _Static_assert(sizeof(enum sinowealth_command_id) == sizeof(uint8_t), "Invalid s
 #define SINOWEALTH_DEBOUNCE_MIN 4
 #define SINOWEALTH_DEBOUNCE_MAX 16
 
+/* This is a much as can be fit in 8 bytes.
+ *
+ * NOTE: Glorious Model O Software v1.0.9 allows you to set
+ * up to 4096 ms, but it's actually a bug and the sent
+ * number overflows.
+ */
+#define SINOWEALTH_MACRO_MAX_POSSIBLE_TIMEOUT 0xff
+
 /* Different software expose different amount of DPI slots:
  * Glorious - 6;
  * G-Wolves - 7.
@@ -1653,15 +1661,8 @@ sinowealth_update_macro_events_from_action(
 
 			struct sinowealth_macro_event *prev_mouse_macro_event = &mouse_macro->events[raw_event_count - 1];
 
-			/* Limit timeout to 255 ms.
-			 * Obviously we can't put more in 8 bytes.
-			 *
-			 * NOTE: Glorious Model O Software v1.0.9 allows you to set
-			 * up to 4096 ms, but it's actually a bug and the sent
-			 * number overflows.
-			 */
-			if (*timeout > 0xff)
-				*timeout = 0xff;
+			if (*timeout > SINOWEALTH_MACRO_MAX_POSSIBLE_TIMEOUT)
+				*timeout = SINOWEALTH_MACRO_MAX_POSSIBLE_TIMEOUT;
 
 			prev_mouse_macro_event->delay = (uint8_t)*timeout;
 			break;

--- a/src/driver-steelseries.c
+++ b/src/driver-steelseries.c
@@ -34,7 +34,6 @@
 #include "libratbag-private.h"
 #include "libratbag-hidraw.h"
 #include "libratbag-data.h"
-#include "hidpp-generic.h"
 
 #define STEELSERIES_NUM_PROFILES	1
 #define STEELSERIES_NUM_DPI		2

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -1875,7 +1875,7 @@ hidpp20_onboard_profiles_read_sector(struct hidpp20_device *device,
 {
 	uint16_t offset;
 	uint8_t feature_index;
-	int rc, count;
+	int rc = 0;
 	union hidpp20_message buf;
 	union hidpp20_message msg = {
 		.msg.report_id = REPORT_ID_LONG,
@@ -1893,8 +1893,6 @@ hidpp20_onboard_profiles_read_sector(struct hidpp20_device *device,
 	msg.msg.sub_id = feature_index;
 	set_unaligned_be_u16(&msg.msg.parameters[0], sector);
 
-	count = sector_size;
-
 	for (offset = 0; offset < sector_size; offset += 16) {
 		/*
 		 * the firmware replies with an ERR_INVALID_ARGUMENT error
@@ -1910,13 +1908,6 @@ hidpp20_onboard_profiles_read_sector(struct hidpp20_device *device,
 
 		/* msg.msg.parameters is guaranteed to have a size >= 16 */
 		memcpy(data + offset, buf.msg.parameters, 16);
-
-		/*
-		 * no need to check for count >= 0:
-		 * if count is negative, then offset will be greater than
-		 * sector_size, thus stopping the loop.
-		 */
-		count -= 16;
 	}
 
 	return 0;

--- a/src/libratbag-data.c
+++ b/src/libratbag-data.c
@@ -645,7 +645,8 @@ filter_device_files(const struct dirent *entry)
 {
 	const char *SUFFIX = ".device";
 	const char *name = entry->d_name;
-	int len, slen;
+	size_t len = 0;
+	size_t slen = 0;
 
 	if (!name || name[0] == '.')
 		return 0;

--- a/src/libratbag-hidraw.c
+++ b/src/libratbag-hidraw.c
@@ -1180,14 +1180,14 @@ static const unsigned int hid_consumer_mapping[] = {
 };
 
 unsigned int
-ratbag_hidraw_get_keycode_from_keyboard_usage(struct ratbag_device *device,
+ratbag_hidraw_get_keycode_from_keyboard_usage(const struct ratbag_device *device,
 					      uint8_t hid_code)
 {
 	return hid_keyboard_mapping[hid_code];
 }
 
 uint8_t
-ratbag_hidraw_get_keyboard_usage_from_keycode(struct ratbag_device *device, unsigned keycode)
+ratbag_hidraw_get_keyboard_usage_from_keycode(const struct ratbag_device *device, unsigned keycode)
 {
 	unsigned int j;
 
@@ -1200,14 +1200,14 @@ ratbag_hidraw_get_keyboard_usage_from_keycode(struct ratbag_device *device, unsi
 }
 
 unsigned int
-ratbag_hidraw_get_keycode_from_consumer_usage(struct ratbag_device *device,
+ratbag_hidraw_get_keycode_from_consumer_usage(const struct ratbag_device *device,
 					      uint16_t hid_code)
 {
 	return hid_consumer_mapping[hid_code];
 }
 
 uint16_t
-ratbag_hidraw_get_consumer_usage_from_keycode(struct ratbag_device *device, unsigned keycode)
+ratbag_hidraw_get_consumer_usage_from_keycode(const struct ratbag_device *device, unsigned keycode)
 {
 	unsigned int j;
 
@@ -1468,7 +1468,7 @@ ratbag_open_hidraw_index(struct ratbag_device *device, int endpoint_index, int h
 }
 
 static struct ratbag_hid_report *
-ratbag_hidraw_get_report(struct ratbag_device *device, unsigned int report_id)
+ratbag_hidraw_get_report(const struct ratbag_device *device, unsigned int report_id)
 {
 	unsigned i;
 
@@ -1489,13 +1489,13 @@ ratbag_hidraw_get_report(struct ratbag_device *device, unsigned int report_id)
 
 
 int
-ratbag_hidraw_has_report(struct ratbag_device *device, unsigned int report_id)
+ratbag_hidraw_has_report(const struct ratbag_device *device, unsigned int report_id)
 {
 	return ratbag_hidraw_get_report(device, report_id) != NULL;
 }
 
 unsigned int
-ratbag_hidraw_get_usage_page(struct ratbag_device *device, unsigned int report_id)
+ratbag_hidraw_get_usage_page(const struct ratbag_device *device, unsigned int report_id)
 {
 	struct ratbag_hid_report *report;
 
@@ -1508,7 +1508,7 @@ ratbag_hidraw_get_usage_page(struct ratbag_device *device, unsigned int report_i
 }
 
 unsigned int
-ratbag_hidraw_get_usage(struct ratbag_device *device, unsigned int report_id)
+ratbag_hidraw_get_usage(const struct ratbag_device *device, unsigned int report_id)
 {
 	struct ratbag_hid_report *report;
 
@@ -1521,7 +1521,7 @@ ratbag_hidraw_get_usage(struct ratbag_device *device, unsigned int report_id)
 }
 
 unsigned int
-ratbag_hidraw_has_vendor_page(struct ratbag_device *device)
+ratbag_hidraw_has_vendor_page(const struct ratbag_device *device)
 {
 	unsigned i;
 
@@ -1642,14 +1642,14 @@ ratbag_hidraw_output_report(struct ratbag_device *device, uint8_t *buf, size_t l
 }
 
 int
-ratbag_hidraw_read_input_report(struct ratbag_device *device, uint8_t *buf, size_t len,
+ratbag_hidraw_read_input_report(const struct ratbag_device *device, uint8_t *buf, size_t len,
 				 ratbagd_hidraw_filter_t filter)
 {
 	return ratbag_hidraw_read_input_report_index(device, buf, len, 0, filter);
 }
 
 int
-ratbag_hidraw_read_input_report_index(struct ratbag_device *device, uint8_t *buf, size_t len, int hidrawno,
+ratbag_hidraw_read_input_report_index(const struct ratbag_device *device, uint8_t *buf, size_t len, int hidrawno,
 				 ratbagd_hidraw_filter_t filter)
 {
 	int rc, nfds;

--- a/src/libratbag-hidraw.h
+++ b/src/libratbag-hidraw.h
@@ -173,7 +173,7 @@ int ratbag_hidraw_output_report(struct ratbag_device *device, uint8_t *buf, size
  *
  * @return count of data transferred, or a negative errno on error
  */
-int ratbag_hidraw_read_input_report(struct ratbag_device *device, uint8_t *buf, size_t len,
+int ratbag_hidraw_read_input_report(const struct ratbag_device *device, uint8_t *buf, size_t len,
 				 ratbagd_hidraw_filter_t filter);
 
 /**
@@ -188,7 +188,7 @@ int ratbag_hidraw_read_input_report(struct ratbag_device *device, uint8_t *buf, 
  *
  * @return count of data transferred, or a negative errno on error
  */
-int ratbag_hidraw_read_input_report_index(struct ratbag_device *device, uint8_t *buf, size_t len, int hidrawno,
+int ratbag_hidraw_read_input_report_index(const struct ratbag_device *device, uint8_t *buf, size_t len, int hidrawno,
 				 ratbagd_hidraw_filter_t filter);
 
 /**
@@ -200,7 +200,7 @@ int ratbag_hidraw_read_input_report_index(struct ratbag_device *device, uint8_t 
  * @return 1 if the device has the given report id, 0 otherwise
  */
 int
-ratbag_hidraw_has_report(struct ratbag_device *device, unsigned int report_id);
+ratbag_hidraw_has_report(const struct ratbag_device *device, unsigned int report_id);
 
 /**
  * Gives the usage page of a report with the specified report ID.
@@ -212,7 +212,7 @@ ratbag_hidraw_has_report(struct ratbag_device *device, unsigned int report_id);
  * 0 otherwise
  */
 unsigned int
-ratbag_hidraw_get_usage_page(struct ratbag_device *device, unsigned int report_id);
+ratbag_hidraw_get_usage_page(const struct ratbag_device *device, unsigned int report_id);
 
 /**
  * Gives the usage of a report with the specified report ID.
@@ -224,7 +224,7 @@ ratbag_hidraw_get_usage_page(struct ratbag_device *device, unsigned int report_i
  * 0 otherwise
  */
 unsigned int
-ratbag_hidraw_get_usage(struct ratbag_device *device, unsigned int report_id);
+ratbag_hidraw_get_usage(const struct ratbag_device *device, unsigned int report_id);
 
 /**
  * Tells if a given device has a vendor usage page
@@ -234,7 +234,7 @@ ratbag_hidraw_get_usage(struct ratbag_device *device, unsigned int report_id);
  * @return 1 if the device has a vendor usage page, 0 otherwise
  */
 unsigned int
-ratbag_hidraw_has_vendor_page(struct ratbag_device *device);
+ratbag_hidraw_has_vendor_page(const struct ratbag_device *device);
 
 /**
  * Gives the input key code associated to the keyboard HID usage.
@@ -242,7 +242,7 @@ ratbag_hidraw_has_vendor_page(struct ratbag_device *device);
  * @return the key code of the HID usage or 0.
  */
 unsigned int
-ratbag_hidraw_get_keycode_from_keyboard_usage(struct ratbag_device *device,
+ratbag_hidraw_get_keycode_from_keyboard_usage(const struct ratbag_device *device,
 					      uint8_t hid_code);
 
 /**
@@ -251,7 +251,7 @@ ratbag_hidraw_get_keycode_from_keyboard_usage(struct ratbag_device *device,
  * @return the HID keyboard usage or 0.
  */
 uint8_t
-ratbag_hidraw_get_keyboard_usage_from_keycode(struct ratbag_device *device,
+ratbag_hidraw_get_keyboard_usage_from_keycode(const struct ratbag_device *device,
 					      unsigned keycode);
 
 /**
@@ -260,7 +260,7 @@ ratbag_hidraw_get_keyboard_usage_from_keycode(struct ratbag_device *device,
  * @return the key code of the HID usage or 0.
  */
 unsigned int
-ratbag_hidraw_get_keycode_from_consumer_usage(struct ratbag_device *device,
+ratbag_hidraw_get_keycode_from_consumer_usage(const struct ratbag_device *device,
 					      uint16_t hid_code);
 
 /**
@@ -269,5 +269,5 @@ ratbag_hidraw_get_keycode_from_consumer_usage(struct ratbag_device *device,
  * @return the HID Consumer Control usage or 0.
  */
 uint16_t
-ratbag_hidraw_get_consumer_usage_from_keycode(struct ratbag_device *device,
+ratbag_hidraw_get_consumer_usage_from_keycode(const struct ratbag_device *device,
 					      unsigned keycode);

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -51,7 +51,7 @@ void
 log_buffer(struct ratbag *ratbag,
 	enum ratbag_log_priority priority,
 	const char *header,
-	uint8_t *buf, size_t len);
+	const uint8_t *buf, size_t len);
 
 #define log_raw(li_, ...) log_msg((li_), RATBAG_LOG_PRIORITY_RAW, __VA_ARGS__)
 #define log_debug(li_, ...) log_msg((li_), RATBAG_LOG_PRIORITY_DEBUG, __VA_ARGS__)

--- a/src/libratbag-util.c
+++ b/src/libratbag-util.c
@@ -191,7 +191,7 @@ err:
 	return ret;
 }
 
-int mkdir_p(char *dir, mode_t mode)
+int mkdir_p(const char *dir, mode_t mode)
 {
     struct stat sb;
 

--- a/src/libratbag-util.h
+++ b/src/libratbag-util.h
@@ -64,7 +64,7 @@ int list_empty(const struct list *list);
 	     pos = tmp,							\
 	     tmp = container_of(pos->member.next, tmp, member))
 
-int mkdir_p(char *dir, mode_t mode);
+int mkdir_p(const char *dir, mode_t mode);
 
 static inline char*
 strncpy_safe(char *dest, const char *src, size_t n)

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -123,7 +123,7 @@ void
 log_buffer(struct ratbag *ratbag,
 	enum ratbag_log_priority priority,
 	const char *header,
-	uint8_t *buf, size_t len)
+	const uint8_t *buf, size_t len)
 {
 	_cleanup_free_ char *output_buf = NULL;
 	char *sep = "";
@@ -1942,7 +1942,6 @@ int
 ratbag_action_macro_num_keys(const struct ratbag_button_action *action)
 {
 	const struct ratbag_macro *macro = action->macro;
-
 	int count = 0;
 	for (int i = 0; i < MAX_MACRO_EVENTS; i++) {
 		struct ratbag_macro_event event = macro->events[i];
@@ -1965,7 +1964,7 @@ ratbag_action_keycode_from_macro(const struct ratbag_button_action *action,
 				 unsigned int *key_out,
 				 unsigned int *modifiers_out)
 {
-	struct ratbag_macro *macro = action->macro;
+	const struct ratbag_macro *macro = action->macro;
 	unsigned int key = KEY_RESERVED;
 	unsigned int modifiers = 0;
 	unsigned int i;


### PR DESCRIPTION
..or that's what the branch name says. I've had this tucked up in some branch for a long while.