### PR TITLE
Fixes for ratbagctl test

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -422,8 +422,8 @@ executable('ratbagd.devel',
 	   include_directories : include_directories('src'),
 	   install : false,
 	   c_args : ['-DRATBAG_DBUS_INTERFACE="ratbag_devel1"',
-		     '-DDBUS_POLICY_SRC="@0@/@1@"'.format(project_build_root, dbus_devel_policy),
-		     '-DDBUS_POLICY_DST="@0@/@1@"'.format(dbussystemdir, dbus_devel_policy),
+		     '-DDBUS_POLICY_SRC="@0@/@1@"'.format(project_build_root, 'org.freedesktop.ratbag_devel1.conf'),
+		     '-DDBUS_POLICY_DST="@0@/@1@"'.format(dbussystemdir, 'org.freedesktop.ratbag_devel1.conf'),
 		     '-DDISABLE_COREDUMP=1'],
 )
 

--- a/tools/ratbagctl.body.py.in
+++ b/tools/ratbagctl.body.py.in
@@ -1977,7 +1977,7 @@ def main(argv: List[str]) -> None:
     cmd = parser.parse(argv)
     if cmd.help:
         parser.print_help()
-        return
+        return 0
 
     _r = open_ratbagd(verbose=cmd.verbose)
     if _r is not None:
@@ -1986,13 +1986,19 @@ def main(argv: List[str]) -> None:
                 f = cmd.func
             except AttributeError:
                 parser.print_help()
-                return
+                return 2
             else:
                 try:
                     f(r, cmd)
                 except RatbagCapabilityError as e:
                     print(f"Error: {e}", file=sys.stderr)
+                    return 1
+                except ValueError as e:
+                    print(f"Error: {e}", file=sys.stderr)
+                    return 2
+    return 0
 
 
 if __name__ == "__main__":
-    main(sys.argv[1:])
+    ret = main(sys.argv[1:])
+    sys.exit(ret)

--- a/tools/ratbagctl.devel.py.in
+++ b/tools/ratbagctl.devel.py.in
@@ -74,6 +74,8 @@ def main(argv, start_ratbagd=True):
                         time.sleep(0.5)
                     except RatbagCapabilityError as e:
                         print(f"Error: {e}", file=sys.stderr)
+                    except ValueError as e:
+                        print(f"Error: {e}", file=sys.stderr)
     finally:
         try:
             if cmd.keepalive:

--- a/tools/ratbagctl.test.py.in
+++ b/tools/ratbagctl.test.py.in
@@ -29,6 +29,7 @@ import os
 import resource
 import subprocess
 import sys
+import time
 import toolbox
 import unittest
 
@@ -94,6 +95,8 @@ class TestRatbagCtl(unittest.TestCase):
         error = sys.stderr.getvalue()
         sys.stdout = stdout
         sys.stderr = stderr
+        # Small delay as we may not get an updated state on time from ratbagd.
+        time.sleep(0.001)
         toolbox.sync_dbus()
         return returncode, output.rstrip("\n"), error.rstrip("\n")
 

--- a/tools/ratbagctl.test.py.in
+++ b/tools/ratbagctl.test.py.in
@@ -86,6 +86,8 @@ class TestRatbagCtl(unittest.TestCase):
             returncode = e.code
         except AttributeError:
             returncode = 2
+        except ValueError:
+            returncode = 2
         except argparse.ArgumentTypeError:
             returncode = 2
         output = sys.stdout.getvalue()
@@ -140,6 +142,9 @@ class TestRatbagCtl(unittest.TestCase):
         return stdout
 
     def launch_fail_with_exception_test(self, params, exception):
+        global run_ratbagctl_in_subprocess
+        if run_ratbagctl_in_subprocess:
+            return ""
         with self.assertRaises(exception):
             returncode, stdout, stderr = self.run_ratbagctl(params)
         return ""
@@ -177,18 +182,22 @@ class TestRatbagCtlProfile(TestRatbagCtl):
     {
       "profiles": [
         {
-          "is_active": false
+          "is_active": false,
+          "capabilities": [102]
         },
         {
           "name": "test profile x2",
-          "is_active": false
+          "is_active": false,
+          "capabilities": [102]
         },
         {
-          "is_active": true
+          "is_active": true,
+          "capabilities": [102]
         },
         {
           "is_active": false,
-          "is_disabled": true
+          "is_disabled": true,
+          "capabilities": [102]
         }
       ]
     }
@@ -485,16 +494,16 @@ class TestRatbagCtlDPI(TestRatbagCtl):
         self.setProfile(2)
         r = self.launch_good_test("test_device dpi get")
         self.assertEqual(r, "2100x2200dpi")
-        self.launch_good_test("test_device " + command + " 1350x1450")
+        self.launch_good_test("test_device " + command + " 1300x1400")
         r = self.launch_good_test("test_device dpi get")
-        self.assertEqual(r, "1350x1450dpi")
-        self.launch_good_test("test_device " + command + " 2350x2450dpi")
+        self.assertEqual(r, "1300x1400dpi")
+        self.launch_good_test("test_device " + command + " 2300x2400dpi")
         r = self.launch_good_test("test_device dpi get")
-        self.assertEqual(r, "2350x2450dpi")
-        self.launch_good_test("test_device " + command + " 2350")
+        self.assertEqual(r, "2300x2400dpi")
+        self.launch_good_test("test_device " + command + " 2300")
         r = self.launch_good_test("test_device dpi get")
-        self.assertEqual(r, "2350x2350dpi")
-        self.launch_fail_test("test_device " + command + " 2350dpi")
+        self.assertEqual(r, "2300x2300dpi")
+        self.launch_fail_test("test_device " + command + " 2300dpi")
         self.launch_fail_test(command)
         self.launch_fail_test("test_device " + command + " X")
         self.launch_fail_test("test_device " + command + " 100 X")
@@ -628,7 +637,7 @@ class TestRatbagCtlButton(TestRatbagCtl):
         r = self.launch_good_test("test_device button 2 get")
         self.assertEqual(r, "Button: 2 is mapped to 'profile-cycle-up'")
         r = self.launch_good_test("test_device button 3 get")
-        self.assertEqual(r, "Button: 3 is mapped to macro '↕B 300ms'")
+        self.assertEqual(r, "Button: 3 is mapped to macro '↕KEY_B 300ms'")
         self.launch_fail_test("test_device button 1 get 10")
         self.launch_fail_test("test_device button 10 get")
         self.launch_fail_test("test_device button 1 get X")
@@ -671,13 +680,15 @@ class TestRatbagCtlButton(TestRatbagCtl):
         command = "button 2 action set macro "
         self.launch_good_test("test_device " + command + "+KEY_B KEY_A -KEY_B KEY_C")
         r = self.launch_good_test("test_device button 2 get")
-        self.assertEqual(r, "Button: 2 is mapped to macro '↓B ↕A ↑B ↕C'")
+        self.assertEqual(
+            r, "Button: 2 is mapped to macro '↓KEY_B ↕KEY_A ↑KEY_B ↕KEY_C'"
+        )
         self.launch_good_test("test_device " + command + "t100 t200")
         r = self.launch_good_test("test_device button 2 get")
         self.assertEqual(r, "Button: 2 is mapped to macro '100ms 200ms'")
         self.launch_good_test("test_device " + command + "KeY_z")
         r = self.launch_good_test("test_device button 2 get")
-        self.assertEqual(r, "Button: 2 is mapped to macro '↕Z'")
+        self.assertEqual(r, "Button: 2 is mapped to macro '↕KEY_Z'")
         self.launch_good_test("test_device " + command)
         r = self.launch_good_test("test_device button 2 get")
         self.assertEqual(r, "Button: 2 is mapped to macro 'None'")
@@ -697,43 +708,34 @@ class TestRatbagCtlLED(TestRatbagCtl):
       "profiles": [
         { "is_active": true,
           "leds": [
-            { "type": 1,
-              "mode": 0,
+            { "mode": 0,
               "duration": 1000,
               "brightness": 20 },
-            { "type": 1,
-              "mode": 1,
+            { "mode": 1,
               "duration": 333,
               "brightness": 40,
               "color": [255, 0, 0] },
-            { "type": 1,
-              "mode": 2,
+            { "mode": 2,
               "duration": 333,
               "brightness": 40 }
           ]
         },
         {
           "leds": [
-            { "type": 1,
-              "mode": 1 },
-            { "type": 1,
-              "mode": 0 },
-            { "type": 1,
-              "mode": 1 }
+            { "mode": 1 },
+            { "mode": 0 },
+            { "mode": 1 }
           ]
         },
         {
           "leds": [
-            { "type": 1,
-              "mode": 1,
+            { "mode": 1,
               "color": [255, 0, 0],
               "duration": 1000 },
-            { "type": 1,
-              "mode": 2,
+            { "mode": 2,
               "brightness": 40,
               "duration": 333 },
-            { "type": 1,
-              "mode": 1 }
+            { "mode": 1 }
           ]
         }
       ]

--- a/tools/toolbox.py
+++ b/tools/toolbox.py
@@ -21,7 +21,8 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-import imp
+import importlib.util
+import importlib.machinery
 import os
 import subprocess
 import sys
@@ -45,10 +46,13 @@ def import_non_standard_path(name, path):
     # If any of the following calls raises an exception,
     # there's a problem we can't handle -- let the caller handle it.
 
-    with open(path, "rb") as fp:
-        return imp.load_module(
-            name, fp, os.path.basename(path), (".py", "rb", imp.PY_SOURCE)
-        )
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_file_location(name, path, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    loader.exec_module(module)
+
+    return module
 
 
 def start_ratbagd(verbosity=0):
@@ -111,7 +115,7 @@ def sync_dbus():
         main_context.iteration(False)
 
 
-ratbagctl = import_non_standard_path(RATBAGCTL_NAME, RATBAGCTL_PATH)
+import_non_standard_path(RATBAGCTL_NAME, RATBAGCTL_PATH)
 
 from ratbagctl import (  # noqa: E402
     RatbagError,


### PR DESCRIPTION
Random fixes for bugs I encountered during the driver development.
The ratbagctl test is always skipped on github actions because it needs to run as root but with python 3.12 the imp module was removed so it always fails even before it can be skipped due to import error.