### PR TITLE
data: add Logitech MX Anywhere 3S

### DIFF
--- a/data/devices/logitech-MX-Anywhere-3S.device
+++ b/data/devices/logitech-MX-Anywhere-3S.device
@@ -1,0 +1,6 @@
+# Logitech MX Anywhere 3S
+[Device]
+Name=Logitech MX Anywhere 3S
+DeviceMatch=bluetooth:046d:b037
+DeviceType=mouse
+Driver=hidpp20


### PR DESCRIPTION
I add device file for logitech mx anywhere 3s (it's silent version of mx anywhere 3). Tested it on arch linux. Not sure why anywhere3.device contains usb filter, it works fine without it.