### PR TITLE
add rog harpe ace wireless

### DIFF
--- a/data/devices/asus-rog-harpe-wireless.device
+++ b/data/devices/asus-rog-harpe-wireless.device
@@ -1,0 +1,13 @@
+[Device]
+Name=ASUS ROG Harpe Wireless
+DeviceMatch=usb:0b05:1a92
+DeviceType=mouse
+Driver=asus
+
+[Driver/asus]
+Profiles=5
+Buttons=5
+Leds=1
+Dpis=4
+Wireless=1
+DpiRange=100:36000@50


### PR DESCRIPTION
Adds rog harpe ace wireless. For now it only works plugged in on USB mode. I will update if I can get it to work with the OMNI receiver. 