### PR TITLE
Fix ruff warnings

### DIFF
--- a/tools/ratbagctl.body.py.in
+++ b/tools/ratbagctl.body.py.in
@@ -1939,7 +1939,7 @@ def open_ratbagd(
     return ratbagd
 
 
-def main(argv: List[str]) -> None:
+def main(argv: List[str]) -> int:
     if not argv:
         argv = ["list"]
 


### PR DESCRIPTION
```
[1mtools/ratbagctl.body.py.in[0m[36m:[0m161[36m:[0m15[36m:[0m [1;31mUP032[0m [[36m*[0m] Use f-string instead of `format` call
[1mtools/ratbagctl.body.py.in[0m[36m:[0m168[36m:[0m15[36m:[0m [1;31mUP032[0m [[36m*[0m] Use f-string instead of `format` call
[1mtools/ratbagctl.body.py.in[0m[36m:[0m180[36m:[0m15[36m:[0m [1;31mUP032[0m [[36m*[0m] Use f-string instead of `format` call
[1mtools/ratbagctl.body.py.in[0m[36m:[0m191[36m:[0m15[36m:[0m [1;31mUP032[0m [[36m*[0m] Use f-string instead of `format` call
[1mtools/ratbagctl.body.py.in[0m[36m:[0m740[36m:[0m15[36m:[0m [1;31mUP031[0m Use format specifiers instead of percent format
[1mtools/ratbagctl.body.py.in[0m[36m:[0m750[36m:[0m11[36m:[0m [1;31mUP031[0m Use format specifiers instead of percent format
[1mtools/ratbagctl.body.py.in[0m[36m:[0m770[36m:[0m26[36m:[0m [1;31mUP031[0m Use format specifiers instead of percent format
[1mtools/ratbagctl.body.py.in[0m[36m:[0m1445[36m:[0m16[36m:[0m [1;31mUP032[0m [[36m*[0m] Use f-string instead of `format` call
[1mtools/ratbagctl.body.py.in[0m[36m:[0m1505[36m:[0m16[36m:[0m [1;31mUP032[0m [[36m*[0m] Use f-string instead of `format` call
[1mtools/ratbagctl.body.py.in[0m[36m:[0m1582[36m:[0m16[36m:[0m [1;31mUP032[0m [[36m*[0m] Use f-string instead of `format` call
Found 10 errors.
[[36m*[0m] 7 fixable with the `--fix` option (3 hidden fixes can be enabled with the `--unsafe-fixes` option).
```

Over 180 characters long line is way too much but black doesn't care. :shrug: 