### PR TITLE
DeviceMatch updated for g502x wireless dongle

### DIFF
--- a/data/devices/logitech-g502-x-wireless.device
+++ b/data/devices/logitech-g502-x-wireless.device
@@ -1,5 +1,8 @@
 [Device]
 Name=Logitech G502 X Wireless
-DeviceMatch=usb:046d:c098
+DeviceMatch=usb:046d:c098;usb:046d:c547
 DeviceType=mouse
 Driver=hidpp20
+
+[Driver/hidpp20]
+DeviceIndex=1


### PR DESCRIPTION
Greetings!
A small PR to update the DeviceMatch used for Logitech G502X Wireless dongle.
Change is tested locally to be working.
[Related PR for updating the SVG match in Piper](https://github.com/libratbag/piper/pull/965).