### PR TITLE
Create steelseries-rival-110.device

### DIFF
--- a/data/devices/steelseries-rival-110.device
+++ b/data/devices/steelseries-rival-110.device
@@ -1,0 +1,12 @@
+[Device]
+Name=SteelSeries Rival 110
+DeviceMatch=usb:1038:1729
+Driver=steelseries
+DeviceType=mouse
+
+[Driver/steelseries]
+DeviceVersion=1
+Buttons=6
+Leds=1
+DpiRange=200:7200@100
+MacroLength=1


### PR DESCRIPTION
The correct file/driver for the SteelSeries Rival 110 (my gaming mouse). Tested and working. The others didn't work.