### PR TITLE
Support for Logitech G Pro X Superlight 2

### DIFF
--- a/data/devices/logitech-g-pro-x-wireless-superlight-2.device
+++ b/data/devices/logitech-g-pro-x-wireless-superlight-2.device
@@ -1,0 +1,5 @@
+[Device]
+Name=Logitech G Pro X Wireless Superlight 2
+DeviceMatch=usb:046d:c54d;usb:046d:c09b
+DeviceType=mouse
+Driver=hidpp20

--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -1523,6 +1523,8 @@ hidpp20drv_init_profile_8100(struct ratbag_device *device)
 
 	if (drv_data->capabilities & HIDPP_CAP_SWITCHABLE_RESOLUTION_2201)
 		drv_data->num_resolutions = drv_data->profiles->num_modes;
+	else if (drv_data->capabilities & HIDPP_CAP_ADJUSTABLE_RESOLUTION_2202)
+		drv_data->num_resolutions = drv_data->profiles->num_modes;
 	/* We ignore the profile's num_leds and require
 	* HIDPP_PAGE_COLOR_LED_EFFECTS to succeed instead
 	*/

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -2535,6 +2535,9 @@ hidpp20_onboard_profiles_get_current_profile(struct hidpp20_device *device)
 
 	unknown_0 = msg.msg.parameters[0];
 	active_profile_index = msg.msg.parameters[1];
+	/* TODO: profile index offset starts at 1? refer to set_current_profile, but prevent wrapping */
+	if (active_profile_index > 0)
+		active_profile_index = active_profile_index - 1;
 
 	hidpp_log_raw(
 	    &device->base,

--- a/src/hidpp20.h
+++ b/src/hidpp20.h
@@ -961,6 +961,7 @@ struct hidpp20_profiles {
 	uint8_t sector_count;
 	uint16_t sector_size;
 	uint8_t active_profile_index;
+	uint8_t format_id;
 	struct hidpp20_profile *profiles;
 };
 

--- a/src/hidpp20.h
+++ b/src/hidpp20.h
@@ -421,6 +421,29 @@ int hidpp20_adjustable_dpi_set_sensor_dpi(struct hidpp20_device *device,
 					  struct hidpp20_sensor *sensor, uint16_t dpi);
 
 /* -------------------------------------------------------------------------- */
+/* 0x2202: Extended Adjustable DPI                                            */
+/* -------------------------------------------------------------------------- */
+
+#define HIDPP_PAGE_EXTENDED_ADJUSTABLE_DPI		0x2202
+
+/**
+ * allocates a list of sensors that has to be freed by the caller.
+ *
+ * returns the elements in the list or a negative error
+ */
+int hidpp20_ext_adjustable_dpi_get_sensors(struct hidpp20_device *device,
+					   struct hidpp20_sensor **sensors_list);
+
+/**
+ * set the current dpi of the provided sensor. sensor must have been
+ * allocated by hidpp20_ext_adjustable_dpi_get_sensors()
+ */
+int hidpp20_ext_adjustable_dpi_set_sensor_dpi(struct hidpp20_device *device,
+					      struct hidpp20_sensor *sensor,
+					      uint16_t dpi_x, uint16_t dpi_y,
+					      uint8_t lod);
+
+/* -------------------------------------------------------------------------- */
 /* 0x8060 - Adjustable Report Rate                                            */
 /* -------------------------------------------------------------------------- */
 
@@ -438,6 +461,28 @@ int hidpp20_adjustable_report_rate_get_report_rate(struct hidpp20_device *device
 
 int hidpp20_adjustable_report_rate_set_report_rate(struct hidpp20_device *device,
 						   uint8_t rate_ms);
+
+/* -------------------------------------------------------------------------- */
+/* 0x8061 - Extended Adjustable Report Rate                                   */
+/* -------------------------------------------------------------------------- */
+
+#define HIDPP_PAGE_EXTENDED_ADJUSTABLE_REPORT_RATE	0x8061
+
+unsigned hidpp20_ext_adjustable_report_rate_to_hz(uint8_t rate_ms);
+uint8_t hidpp20_ext_adjustable_report_rate_from_hz(unsigned rate_hz);
+
+/**
+ * set the bitmap_ms to the supported report rates. Bits enabled reflect a
+ * supported report rate (non-linearly).
+ */
+int hidpp20_ext_adjustable_report_rate_get_report_rate_list(struct hidpp20_device *device,
+							uint16_t *bitflags);
+
+int hidpp20_ext_adjustable_report_rate_get_report_rate(struct hidpp20_device *device,
+						   uint8_t *rate);
+
+int hidpp20_ext_adjustable_report_rate_set_report_rate(struct hidpp20_device *device,
+						   uint8_t rate);
 
 /* -------------------------------------------------------------------------- */
 /* 0x8070v4 - Color LED effects                                               */

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -273,6 +273,7 @@ ratbag_sanity_check_device(struct ratbag_device *device)
 		}
 
 		nres = ratbag_profile_get_num_resolutions(profile);
+		log_debug(profile->device->ratbag, "%s: resolutions = %d\n", __func__, nres);
 		if (nres > 16) {
 				log_bug_libratbag(ratbag,
 						  "%s: invalid number of resolutions (%d)\n",
@@ -283,6 +284,7 @@ ratbag_sanity_check_device(struct ratbag_device *device)
 
 		ratbag_profile_for_each_resolution(profile, resolution) {
 			nvals = ratbag_resolution_get_dpi_list(resolution, vals, nvals);
+			log_debug(profile->device->ratbag, "%s: resolution values = %d\n", __func__, nvals);
 			if (nvals == 0) {
 				log_bug_libratbag(ratbag,
 						  "%s: invalid dpi list\n",
@@ -293,6 +295,7 @@ ratbag_sanity_check_device(struct ratbag_device *device)
 		}
 
 		nvals = ratbag_profile_get_report_rate_list(profile, vals, nvals);
+		log_debug(profile->device->ratbag, "%s: rates = %d\n", __func__, nvals);
 		if (nvals == 0) {
 			log_bug_libratbag(ratbag,
 					  "%s: invalid report rate list\n",
@@ -922,6 +925,8 @@ ratbag_profile_set_active(struct ratbag_profile *profile)
 LIBRATBAG_EXPORT unsigned int
 ratbag_profile_get_num_resolutions(const struct ratbag_profile *profile)
 {
+	log_debug(profile->device->ratbag, "%s: profile->num_resolution = %d\n", profile->device->name, profile->num_resolutions);
+
 	return profile->num_resolutions;
 }
 
@@ -1156,6 +1161,9 @@ ratbag_profile_get_report_rate_list(const struct ratbag_profile *profile,
 				    size_t nrates)
 {
 	_Static_assert(sizeof(*rates) == sizeof(*profile->rates), "type mismatch");
+
+	log_debug(profile->device->ratbag, "%s: nrates = %ld\n", profile->device->name, nrates);
+	log_debug(profile->device->ratbag, "%s: profile->nrates = %ld\n", profile->device->name, profile->nrates);
 
 	assert(nrates > 0);
 


### PR DESCRIPTION
The Logitech G Pro X Superlight 2 is different from the existing models (e.g. the older non-2 model) and other similar Logitech devices. Specifically it implements only the extended adjustable DPI feature (0x2202, for X, Y and lift-off-distance/LOD configuration), extended report rate feature (0x8061) as well as a new profile format that is very different from the existing profiles in order to support the data for the aforementioned features. None of these features are currently implemented in libratbag.

This pull request is a draft/work in progress containing the required support for the HID++ 2.0 features needed for this device. I am publishing this draft pull request in order to get any feedback, please disregard any obvious or unnecessary debug/work in progress code changes.

Implemented WIP support:
* Feature 0x2202 - Extended Adjustable DPI
  * Handling of X/Y/LOD fields, using the current DPI singular value from profile structures to populate both X/Y and defaulting LOD to "Medium"
* Feature 0x8061 - Extended Report Rate
* Support for onboard profile type `0x6`
  * Extended DPI and report rates
  * Power save timeouts
  * Mouse button mappings

Things that are not implemented/tested:
* Address remaining TODO comments included in this pull request
* Configuration over the wireless receiver (currently plug it in via USB to use ratbag to edit profiles)
* DPI for Y/LOD
* Support for onboard profile type `0x6`
  * Non-mouse button mappings
  * Profile names (UTF-16 encoded)
  * Determine remaining unknown fields in the profile format
  * LEDs? (device does not have any, but the format structure has them defined)
* Piper

This pull request intends to resolve #1572 and #1519.