### PR TITLE
data: additional USB ID for Logitech MX Vertical

### DIFF
--- a/data/devices/logitech-MX-Vertical.device
+++ b/data/devices/logitech-MX-Vertical.device
@@ -1,5 +1,5 @@
 [Device]
 Name=Logitech MX Vertical
-DeviceMatch=bluetooth:046d:b020;usb:046d:407b;usb:046d:c08a
+DeviceMatch=bluetooth:046d:b020;usb:046d:407b;usb:046d:c08a;usb:046d:c077
 Driver=hidpp20
 DeviceType=mouse


### PR DESCRIPTION
I got a new Logitech MX Vertical today, which has a different USB ID than the ones already in the data file. It works fine with libratbag/piper once the ID is added.

`lsusb -d 046d:c077 --verbose`

```
Bus 003 Device 032: ID 046d:c077 Logitech, Inc. Mouse
Device Descriptor:
  bLength                18
  bDescriptorType         1
  bcdUSB               2.00
  bDeviceClass            0 [unknown]
  bDeviceSubClass         0 [unknown]
  bDeviceProtocol         0 
  bMaxPacketSize0         8
  idVendor           0x046d Logitech, Inc.
  idProduct          0xc077 Mouse
  bcdDevice           72.00
  iManufacturer           1 Logitech
  iProduct                2 USB Optical Mouse
  iSerial                 0 
  bNumConfigurations      1
  Configuration Descriptor:
    bLength                 9
    bDescriptorType         2
    wTotalLength       0x0022
    bNumInterfaces          1
    bConfigurationValue     1
    iConfiguration          0 
    bmAttributes         0xa0
      (Bus Powered)
      Remote Wakeup
    MaxPower              100mA
    Interface Descriptor:
      bLength                 9
      bDescriptorType         4
      bInterfaceNumber        0
      bAlternateSetting       0
      bNumEndpoints           1
      bInterfaceClass         3 Human Interface Device
      bInterfaceSubClass      1 Boot Interface Subclass
      bInterfaceProtocol      2 Mouse
      iInterface              0 
        HID Device Descriptor:
          bLength                 9
          bDescriptorType        33
          bcdHID               1.11
          bCountryCode            0 Not supported
          bNumDescriptors         1
          bDescriptorType        34 Report
          wDescriptorLength      46
          Report Descriptors: 
            ** UNAVAILABLE **
      Endpoint Descriptor:
        bLength                 7
        bDescriptorType         5
        bEndpointAddress     0x81  EP 1 IN
        bmAttributes            3
          Transfer Type            Interrupt
          Synch Type               None
          Usage Type               Data
        wMaxPacketSize     0x0004  1x 4 bytes
        bInterval              10
Device Status:     0x0000
  (Bus Powered)
```

`dmesg`

```
[42982.181812] usb 3-1.1.3.2: new full-speed USB device number 33 using xhci_hcd
[42982.331521] usb 3-1.1.3.2: New USB device found, idVendor=046d, idProduct=c52b, bcdDevice=12.11
[42982.331537] usb 3-1.1.3.2: New USB device strings: Mfr=1, Product=2, SerialNumber=0
[42982.331543] usb 3-1.1.3.2: Product: USB Receiver
[42982.331548] usb 3-1.1.3.2: Manufacturer: Logitech
[42982.452213] logitech-djreceiver 0003:046D:C52B.0019: hiddev97,hidraw5: USB HID v1.11 Device [Logitech USB Receiver] on usb-0000:07:00.3-1.1.3.2/input2
[42982.567705] input: Logitech MX Vertical as /devices/pci0000:00/0000:00:08.1/0000:07:00.3/usb3/3-1/3-1.1/3-1.1.3/3-1.1.3.2/3-1.1.3.2:1.2/0003:046D:C52B.0019/0003:046D:407B.001A/input/input50
[42982.632998] logitech-hidpp-device 0003:046D:407B.001A: input,hidraw6: USB HID v1.11 Keyboard [Logitech MX Vertical] on usb-0000:07:00.3-1.1.3.2/input2:1
[42991.769507] logitech-hidpp-device 0003:046D:407B.001A: HID++ 4.5 device connected.
```