### PR TITLE
Additional ID for ASUS ROG Keris Wireless AimPoint

### DIFF
--- a/data/devices/asus-rog-keris-wireless-aimpoint.device
+++ b/data/devices/asus-rog-keris-wireless-aimpoint.device
@@ -1,6 +1,6 @@
 [Device]
 Name=ASUS ROG Keris Wireless AimPoint
-DeviceMatch=usb:0b05:1a68
+DeviceMatch=usb:0b05:1a68;usb:0b05:1a66
 DeviceType=mouse
 Driver=asus
 


### PR DESCRIPTION
Hey guys,

I received my ASUS ROG Keris Wireless AimPoint today and after not working with piper/llibratbag I figured out that it had a different ID, so I added mine to the corresponding device file (PID 1a66 instead of 1a68).

bliepp