### PR TITLE
Adding Logitech G502 X LIGHTSPEED to device list

### DIFF
--- a/data/devices/logitech-g502-x-lightspeed.device
+++ b/data/devices/logitech-g502-x-lightspeed.device
@@ -1,0 +1,5 @@
+[Device]
+Name=Logitech G502 X LIGHTSPEED
+DeviceMatch=usb:046d:c098
+DeviceType=mouse
+Driver=hidpp20


### PR DESCRIPTION
Only works while mouse is being connected via usb-c. Dongle not supported.
Tested via [Piper](https://github.com/libratbag/piper).