### PR TITLE
Add Tronsmart TG007 support

### DIFF
--- a/data/devices/sinowealth-1007.device
+++ b/data/devices/sinowealth-1007.device
@@ -19,3 +19,9 @@ Buttons=6
 DeviceName=Marvo Scorpion G961
 LedType=RGB
 SensorType=PMW3327
+
+[Driver/sinowealth/devices/Y129]
+Buttons=7
+DeviceName=Tronsmart TG007 Mouse
+LedType=RGB
+SensorType=PMW3212


### PR DESCRIPTION
Adds the device indentification so it indentifies the Tronsmart TG007. ([Link for the official website](https://www.tronsmart.com/products/tg007-rgb-gaming-mouse))

I'm unsure about the button quantity though, official site says 9 (Left Click, Right Click, Scroll wheel, DPI adjustment, Light switch, Forward, Backward, Sniper button and Polling rate at the bottom of the device.) 