### PR TITLE
Support single modifier key macros

### DIFF
--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -460,6 +460,9 @@ ratbag_button_action_match(const struct ratbag_button_action *action,
 int
 ratbag_action_macro_num_keys(const struct ratbag_button_action *action);
 
+bool
+ratbag_action_is_single_modifier_key(const struct ratbag_button_action *action);
+
 int
 ratbag_button_macro_new_from_keycode(struct ratbag_button *button,
 				     unsigned int key,

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -1949,11 +1949,32 @@ ratbag_action_macro_num_keys(const struct ratbag_button_action *action)
 		    event.type == RATBAG_MACRO_EVENT_INVALID) {
 			break;
 		}
+		if (ratbag_key_is_modifier(event.event.key)) {
+			continue;
+		}
 		if (event.type == RATBAG_MACRO_EVENT_KEY_PRESSED) {
 			count += 1;
 		}
 	}
 	return count;
+}
+
+bool
+ratbag_action_is_single_modifier_key(const struct ratbag_button_action *action)
+{
+	const struct ratbag_macro *macro = action->macro;
+	int count = 0;
+	for (int i = 0; i < MAX_MACRO_EVENTS; i++) {
+		struct ratbag_macro_event event = macro->events[i];
+		if (event.type == RATBAG_MACRO_EVENT_NONE ||
+		    event.type == RATBAG_MACRO_EVENT_INVALID) {
+			break;
+		}
+		if (ratbag_key_is_modifier(event.event.key) && event.type == RATBAG_MACRO_EVENT_KEY_PRESSED) {
+			count += 1;
+		}
+	}
+	return count == 1;
 }
 
 int
@@ -1972,13 +1993,9 @@ ratbag_action_keycode_from_macro(const struct ratbag_button_action *action,
 	if (macro->events[0].type == RATBAG_MACRO_EVENT_NONE)
 		return -EINVAL;
 
-	int count = ratbag_action_macro_num_keys(action);
-	if (count == 1 && ratbag_key_is_modifier(macro->events[0].event.key)){
-		key = macro->events[0].event.key;
-		*key_out = key;
-		*modifiers_out = modifiers;
-		return 1;
-	}
+	if (ratbag_action_macro_num_keys(action) != 1)
+		if (!ratbag_action_is_single_modifier_key(action))
+			return -EINVAL;
 
 	for (i = 0; i < MAX_MACRO_EVENTS; i++) {
 		struct ratbag_macro_event event;

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -1949,9 +1949,6 @@ ratbag_action_macro_num_keys(const struct ratbag_button_action *action)
 		    event.type == RATBAG_MACRO_EVENT_INVALID) {
 			break;
 		}
-		if (ratbag_key_is_modifier(event.event.key)) {
-			continue;
-		}
 		if (event.type == RATBAG_MACRO_EVENT_KEY_PRESSED) {
 			count += 1;
 		}
@@ -1975,8 +1972,13 @@ ratbag_action_keycode_from_macro(const struct ratbag_button_action *action,
 	if (macro->events[0].type == RATBAG_MACRO_EVENT_NONE)
 		return -EINVAL;
 
-	if (ratbag_action_macro_num_keys(action) != 1)
-		return -EINVAL;
+	int count = ratbag_action_macro_num_keys(action);
+	if (count == 1 && ratbag_key_is_modifier(macro->events[0].event.key)){
+		key = macro->events[0].event.key;
+		*key_out = key;
+		*modifiers_out = modifiers;
+		return 1;
+	}
 
 	for (i = 0; i < MAX_MACRO_EVENTS; i++) {
 		struct ratbag_macro_event event;


### PR DESCRIPTION
Support single modifier key macros
support:
```bash
ratbagctl
        "$device_name"
button $btn
action set macro
        KEY_LEFTALT   |
        KEY_LEFTCTRL  |
        KEY_LEFTMETA  |
        KEY_LEFTSHIFT |
        KEY_RIGHTALT  |
        KEY_RIGHTCTRL |
        KEY_RIGHTMETA |
        KEY_RIGHTSHIFT
```

> The original version seems to only support key combinations such as `CTRL+C`/`META+W`, specifically, it can only support macro combinations of multiple modifier keys and normal keys (detected using `ratbag_action_keycode_from_macro` and `ratbag_key_is_modifier`).
However for setting a single modifier key macro, it will prompt an error `"failed to update button (-22)"` (I used `ratbagctl - v "$my_device_name" button $btn action set macro KEY_LEFTALT`).
I think as a key macro, it should support a single modifier key macro, so I modified the function `ratbag_action_keycode_from_macro`, which will not affect normal key combinations and can work together with piper

> This is a correction for this [submit](https://github.com/libratbag/libratbag/pull/1630)