### PR TITLE
Correct G502 naming conventions

### DIFF
--- a/data/devices/logitech-g502-lightspeed.device
+++ b/data/devices/logitech-g502-lightspeed.device
@@ -1,5 +1,5 @@
 [Device]
-Name=Logitech G502 Hero Wireless
+Name=Logitech G502 Lightspeed
 DeviceMatch=usb:046d:407f;usb:046d:c08d
 Driver=hidpp20
 DeviceType=mouse

--- a/data/devices/logitech-g502-x-lightspeed.device
+++ b/data/devices/logitech-g502-x-lightspeed.device
@@ -1,5 +1,5 @@
 [Device]
-Name=Logitech G502 X Wireless
+Name=Logitech G502 X Lightspeed
 DeviceMatch=usb:046d:c098
 DeviceType=mouse
 Driver=hidpp20

--- a/data/devices/logitech-g502-x-plus.device
+++ b/data/devices/logitech-g502-x-plus.device
@@ -1,8 +1,8 @@
 [Device]
-Name=Logitech G502 X PLUS
-DeviceMatch=usb:046d:c095
+Name=Logitech G502 X PluS
+DeviceMatch=usb:046d:c098;usb:046d:c547
 DeviceType=mouse
 Driver=hidpp20
 
 [Driver/hidpp20]
-Quirk=G502X_PLUS
+DeviceIndex=1

--- a/data/devices/logitech-g502-x.device
+++ b/data/devices/logitech-g502-x.device
@@ -1,5 +1,8 @@
 [Device]
 Name=Logitech G502 X
-DeviceMatch=usb:046d:c099
+DeviceMatch=usb:046d:c099;usb:046d:c095
 DeviceType=mouse
 Driver=hidpp20
+
+[Driver/hidpp20]
+Quirk=G502X

--- a/data/devices/logitech-g705.device
+++ b/data/devices/logitech-g705.device
@@ -5,4 +5,4 @@ Driver=hidpp20
 DeviceType=mouse
 
 [Driver/hidpp20]
-Quirk=G502X_PLUS
+Quirk=G502X

--- a/src/hidpp20.h
+++ b/src/hidpp20.h
@@ -55,7 +55,7 @@ enum hidpp20_quirk {
 	HIDPP20_QUIRK_NONE,
 	HIDPP20_QUIRK_G305,
 	HIDPP20_QUIRK_G602,
-	HIDPP20_QUIRK_G502X_PLUS, // G502X+ uses 2nd LED slot instead of 1st.
+	HIDPP20_QUIRK_G502X, // G502X uses 2nd LED slot instead of 1st.
 };
 
 struct hidpp20_device {


### PR DESCRIPTION
As I am familiarizing myself with the code base, I noticed that the code and commits talk about a "wired" "G502 X Plus". See my comment in response to this commit [here](https://github.com/libratbag/libratbag/commit/65d07ae4d11a6985f445d547ac6d008b6d7f5a35#commitcomment-161929028). However, there is only one X Plus, and it's wireless, see https://www.logitechg.com/en-us/g502-line.html

I've done my best to fix the naming conventions, renaming
`G502 Hero Wireless` => `G502 Lightspeed`
`G502 X Wireless` => `G502 X Plus`
`G502 X Plus` => Merged with `G502 X Wired`. This file was committed [here](https://github.com/libratbag/libratbag/commit/65d07ae4d11a6985f445d547ac6d008b6d7f5a35), but the commit missunderstood the naming conventions of the mouse, and put it in the wrong file. It was clearly meant to go in the file `logitech-g502-x.device`. The one thing *I am not sure about* is that this file already contained a device ID, `046d:c099`, but this linked commit seems to think that an ID of `046d:c095` was required to make the device work, so I've merged these two IDs into what is hopefully the correct final result.


While I was at it, I also fixed the actual `G502 X Plus` mouse (which is wireless) so that it shows up (at least, on `6.15.6-arch1-1`). More work is needed to properly lay out the lights, etc., and at least on my kernal the device *only shows up under the ID of the receiver* (and hence it's name says `Logitech USB Receiver` in `ratbagctl list`). This has the added consequence of the G502 X Plus's SVG not loading in piper. But my understanding is this incorrect ID is from a driver / kernal issue upstream, this is the best this repo can do for now (and, the X Plus was entirely broken before so even though it's half broken now, it's better than it was).


I only own a G502 X Plus and a G502 Lightspeed. I would appreciate if somebody with a `G502 X` would try out this to make sure I didn't break anything. Maybe @Sewer56 ?