### PR TITLE
data: add G502 X Plus in wireless mode (usb:046d:4099)

### DIFF
--- a/data/devices/logitech-g502-x-plus.device
+++ b/data/devices/logitech-g502-x-plus.device
@@ -1,6 +1,6 @@
 [Device]
 Name=Logitech G502 X PLUS
-DeviceMatch=usb:046d:4099,usb:046d:c095
+DeviceMatch=usb:046d:4099;usb:046d:c095
 DeviceType=mouse
 Driver=hidpp20
 


### PR DESCRIPTION
To work correctly following driver is required:
https://github.com/Kvalme/hid-logitech-dj
