### PR TITLE
Add DM4 Evo (sinowealth-1007)

### DIFF
--- a/data/devices/sinowealth-1007.device
+++ b/data/devices/sinowealth-1007.device
@@ -19,3 +19,11 @@ Buttons=6
 DeviceName=Marvo Scorpion G961
 LedType=RGB
 SensorType=PMW3327
+
+# https://dreammachines.pl/en/dm4evo
+[Driver/sinowealth/devices/M303]
+Buttons=7
+Profiles=1
+DeviceName=DM4 Evo
+LedType=RGB
+SensorType=PMW3327


### PR DESCRIPTION
Mouse is available at https://dreammachines.pl/en/dm4evo.

Changing settings in Piper works fine, but there are few missing
bits/differences compared to the official Windows app (it can be found
at the mouse page):
- official app has an option to set DPI independently for X and Y axis
- official app allows to set DPI up to 26000 DPI although mouse
  specification says it has 16000 DPI sensor, so maybe it is a mistake
- Piper allows setting 4 modes of RGB lighting:
  + solid
  + cycle
  + breathing
  + off

  Official app has many more:
  - colourful tail
  - neon
  - colourful solid
  - flicker
  - tail
  - wave
- official app allows setting sensitivity, scrolling speed and two-click
  speed
- there is a macro editor, but I don't know how to use it, and probably
  macros are not stored directly on the mouse, but I'm adding it to the
  list for the completeness sake

I don't know if (some) of these omission are deliberate or not. I can
try to capture packets sent by the official app if needed.