### PR TITLE
data: add ASUS ROG Keris II Origin (usb:0b05:1c0c)

### DIFF
--- a/data/devices/asus-rog-keris-ii-origin.device
+++ b/data/devices/asus-rog-keris-ii-origin.device
@@ -1,0 +1,14 @@
+[Device]
+Name=ASUS ROG Keris II Origin
+DeviceMatch=usb:0b05:1c0c;bluetooth:0b05:1c0f
+DeviceType=mouse
+Driver=asus
+
+[Driver/asus]
+Profiles=5
+Buttons=8
+Leds=1
+Dpis=4
+Wireless=1
+DpiRange=100:42000@50
+Quirks=SEPARATE_XY_DPI

--- a/test/data-parse-test.py
+++ b/test/data-parse-test.py
@@ -76,7 +76,7 @@ def check_dpi_range_str(string: str):
     steps = float(m.group(3))
 
     assert min >= 0 and min <= 400
-    assert max >= 2000 and max <= 36000
+    assert max >= 2000 and max <= 42000
     assert steps > 0 and steps <= 100
 
     if int(steps) == steps:
@@ -93,7 +93,7 @@ def check_dpi_list_str(string: str):
 
     for idx, entry in enumerate(entries):
         dpi = int(entry)
-        assert dpi >= 0 and dpi <= 12000
+        assert dpi >= 0 and dpi <= 42000
         if idx > 0:
             prev = entries[idx - 1]
             prev_dpi = int(prev)


### PR DESCRIPTION
- This is a relatively new mouse released earlier this year (2025)
- It supports Wired USB, Wireless RF, and Wireless BT
- The device ID here is from Wired USB mode

- Seems to be detected reasonably well with the new file:
```
$> sudo ratbagctl list
hollering-marmot:    ASUSTeK ROG KERIS II ORIGIN 

$> sudo ratbagctl "ASUSTeK ROG KERIS II ORIGIN" info
hollering-marmot - ASUSTeK ROG KERIS II ORIGIN
             Model: usb:0b05:1c0c:0
       Device Type: Mouse
 Number of Buttons: 8
    Number of Leds: 1
Number of Profiles: 5
Profile 0: (active)
  Name: n/a
  Report Rate: 34612Hz
  Resolutions:
    0: 0dpi
    1: 0dpi
    2: 0dpi (active)
    3: 0dpi
  Angle Snapping: False
  Debounce time: 12ms
  Button: 0 is mapped to 'button 1'
  Button: 1 is mapped to 'button 2'
  Button: 2 is mapped to 'button 3'
  Button: 3 is mapped to 'wheel-up'
  Button: 4 is mapped to 'wheel-down'
  Button: 5 is mapped to 'resolution-cycle-up'
  Button: 6 is mapped to 'button 4'
  Button: 7 is mapped to 'button 5'
  LED: 0, depth: rgb, mode: cycle, duration: 0, brightness: 3200
Profile 1:
  Name: n/a
  Report Rate: 34612Hz
  Resolutions:
    0: 0dpi
    1: 0dpi
    2: 0dpi (active)
    3: 0dpi
  Angle Snapping: False
  Debounce time: 12ms
  Button: 0 is mapped to 'button 1'
  Button: 1 is mapped to 'button 2'
  Button: 2 is mapped to 'button 3'
  Button: 3 is mapped to 'wheel-up'
  Button: 4 is mapped to 'wheel-down'
  Button: 5 is mapped to 'resolution-cycle-up'
  Button: 6 is mapped to 'button 4'
  Button: 7 is mapped to 'button 5'
  LED: 0, depth: rgb, mode: breathing, color: ff00ff, duration: 0, brightness: 3200
Profile 2:
  Name: n/a
  Report Rate: 34612Hz
  Resolutions:
    0: 0dpi
    1: 0dpi
    2: 0dpi (active)
    3: 0dpi
  Angle Snapping: False
  Debounce time: 12ms
  Button: 0 is mapped to 'button 1'
  Button: 1 is mapped to 'button 2'
  Button: 2 is mapped to 'button 3'
  Button: 3 is mapped to 'wheel-up'
  Button: 4 is mapped to 'wheel-down'
  Button: 5 is mapped to 'resolution-cycle-up'
  Button: 6 is mapped to 'button 4'
  Button: 7 is mapped to 'button 5'
  LED: 0, depth: rgb, mode: on, color: 0000ff
Profile 3:
  Name: n/a
  Report Rate: 34612Hz
  Resolutions:
    0: 0dpi
    1: 0dpi
    2: 0dpi (active)
    3: 0dpi
  Angle Snapping: False
  Debounce time: 12ms
  Button: 0 is mapped to 'button 1'
  Button: 1 is mapped to 'button 2'
  Button: 2 is mapped to 'button 3'
  Button: 3 is mapped to 'wheel-up'
  Button: 4 is mapped to 'wheel-down'
  Button: 5 is mapped to 'resolution-cycle-up'
  Button: 6 is mapped to 'button 4'
  Button: 7 is mapped to 'button 5'
  LED: 0, depth: rgb, mode: breathing, color: 00ff00, duration: 0, brightness: 3200
Profile 4:
  Name: n/a
  Report Rate: 34612Hz
  Resolutions:
    0: 0dpi
    1: 0dpi
    2: 0dpi (active)
    3: 0dpi
  Angle Snapping: False
  Debounce time: 12ms
  Button: 0 is mapped to 'button 1'
  Button: 1 is mapped to 'button 2'
  Button: 2 is mapped to 'button 3'
  Button: 3 is mapped to 'wheel-up'
  Button: 4 is mapped to 'wheel-down'
  Button: 5 is mapped to 'resolution-cycle-up'
  Button: 6 is mapped to 'button 4'
  Button: 7 is mapped to 'button 5'
  LED: 0, depth: rgb, mode: on, color: ffff00
```
