### PR TITLE
Support for HyperX Pulsefire Haste

### DIFF
--- a/data/devices/hyperx-pulsefire-haste-wireless.device
+++ b/data/devices/hyperx-pulsefire-haste-wireless.device
@@ -8,6 +8,7 @@ Driver=hyperx
 Profiles=1
 Buttons=6
 Leds=1
+ReportRates=125;250;500;1000
 Dpis=5
 DpiRange=200:16000@100
 Wireless=1

--- a/data/devices/hyperx-pulsefire-haste-wireless.device
+++ b/data/devices/hyperx-pulsefire-haste-wireless.device
@@ -1,0 +1,13 @@
+[Device]
+Name=HyperX Pulsefire Haste Wireless
+DeviceMatch=usb:03f0:028e
+DeviceType=mouse
+Driver=hyperx
+
+[Driver/hyperx]
+Profiles=1
+Buttons=6
+Leds=1
+Dpis=5
+DpiRange=200:16000@100
+Wireless=1

--- a/data/devices/hyperx-pulsefire-haste.device
+++ b/data/devices/hyperx-pulsefire-haste.device
@@ -1,0 +1,12 @@
+[Device]
+Name=HyperX Pulsefire Haste
+DeviceMatch=usb:03f0:048e
+DeviceType=mouse
+Driver=hyperx
+
+[Driver/hyperx]
+Profiles=1
+Buttons=6
+Leds=1
+Dpis=5
+DpiRange=200:16000@100

--- a/data/devices/hyperx-pulsefire-haste.device
+++ b/data/devices/hyperx-pulsefire-haste.device
@@ -8,5 +8,6 @@ Driver=hyperx
 Profiles=1
 Buttons=6
 Leds=1
+ReportRates=125;250;500;1000
 Dpis=5
 DpiRange=200:16000@100

--- a/meson.build
+++ b/meson.build
@@ -193,6 +193,7 @@ src_libratbag = [
 	'src/driver-marsgaming/marsgaming-leds.c',
 	'src/driver-marsgaming/marsgaming-probe.c',
 	'src/driver-marsgaming/marsgaming-query.c',
+	'src/driver-hyperx.c',
 	'src/driver-test.c',
 	'src/libratbag.c',
 	'src/libratbag.h',

--- a/src/driver-hyperx.c
+++ b/src/driver-hyperx.c
@@ -35,245 +35,32 @@
 
 #include "driver-hyperx.h"
 
-#define HYPERX_USAGE_PAGE 0xff00
-#define HYPERX_PACKET_SIZE 64
+static inline void
+hyperx_resolution_set_dpi_list_from_range(struct ratbag_resolution *res,
+	unsigned int min_dpi, unsigned int max_dpi, unsigned int stepsize)
+{
+	unsigned int dpi = min_dpi;
+	bool maxed_out = false;
 
-#define HYPERX_LED_PACKET_COUNT 6
+	res->ndpis = 0;
 
-// Magic numbers, no clue what these mean
-#define HYPERX_LED_MODE_VALUE_BEFORE 0x55
-#define HYPERX_LED_MODE_VALUE_AFTER 0x23
+	while (res->ndpis < ARRAY_LENGTH(res->dpis)) {
+		if (dpi > (unsigned) max_dpi) {
+			maxed_out = true;
+			break;
+		}
 
-#define HYPERX_ACTION_DPI_TOGGLE 8
+		res->dpis[res->ndpis] = dpi;
+		res->ndpis++;
 
-#define HYPERX_MAX_MACRO_EVENTS 80
-#define HYPERX_MAX_MACRO_PACKETS 14
-#define HYPERX_MACRO_EVENT_MAX_KEYS 6
-#define HYPERX_MACRO_EVENT_DEFAULT_DELAY htole16(20)
+		dpi += stepsize;
+	}
 
-// Max number of events in a macro data packet
-#define HYPERX_MACRO_DATA_MAX_EVENTS 6
-
-#define hyperx_is_dpi_profile_enabled(profile_bitmask, n) ((profile_bitmask) & (1 << (n)))
-#define hyperx_brightness_value(x) ((int) ((x / 255.0) * 100))
-
-/**
- * Every macro data packet seems to have a sum byte? after the button byte that alternates between adding 1 and 2 each packet.
- * Another way of thinking about it is half of the numbers in the sum are 1 and half are 2.
- *
- * Thus, we get the following formula: (1x / 2) + (2x / 2). Which is simplified to 3x / 2. Note that this is int division, so there would be no fractional part.
- *
- * For example, the sum bytes for 6 packets would be: 0x00, 0x01, 0x03, 0x04, 0x06, 0x07
- */
-#define HYPERX_MACRO_PACKET_SUM(x) ((3*(x)) / 2)
-
-/**
- * The event count byte in odd indexed macro data packets have 0x80 added to it.
- * For example, a packet with 2 events would be 0x02 if it was even, and 0x82 if it was odd.
- */
-#define HYPERX_MACRO_PACKET_EVENT_COUNT(x) (((x) % 2) * 0x80)
-
-#define _Static_assert_bytes_after(expr) _Static_assert(expr, "Incorrect value for 'bytes_after'")
-#define _Static_assert_enum_size(enum_name) _Static_assert(sizeof(enum enum_name) == 1, \
-		"Incorrect size for '" #enum_name "''")
-
-enum hyperx_config_value {
-	HYPERX_CONFIG_POLLING_RATE              = 0xd0,
-	HYPERX_CONFIG_LED_EFFECT                = 0xda,
-	HYPERX_CONDIG_LED_MODE                  = 0xd9,
-	HYPERX_CONFIG_DPI                       = 0xd3,
-	HYPERX_CONFIG_BUTTON_ASSIGNMENT         = 0xd4,
-	HYPERX_CONFIG_MACRO_ASSIGNMENT          = 0xd5,
-	HYPERX_CONFIG_MACRO_DATA                = 0xd6,
-
-	HYPERX_CONFIG_SAVE_SETTINGS             = 0xde
-} __attribute((packed));
-
-_Static_assert_enum_size(hyperx_config_value);
-
-enum hyperx_save_type {
-	HYPERX_SAVE_TYPE_ALL                    = 0xff,
-	HYPERX_SAVE_TYPE_DPI_PROFILES           = 0x03
-} __attribute((packed));
-
-_Static_assert_enum_size(hyperx_save_type);
-
-enum hyperx_dpi_config {
-	HYPERX_DPI_CONFIG_SELECTED_PROFILE	= 0x00,
-	HYPERX_DPI_CONFIG_ENABLED_PROFILES	= 0x01,
-	HYPERX_DPI_CONFIG_DPI_VALUE         = 0x02,
-} __attribute((packed));
-
-_Static_assert_enum_size(hyperx_dpi_config);
-
-enum hyperx_led_mode {
-	HYPERX_LED_MODE_SOLID = 0x01
-} __attribute((packed));
-
-_Static_assert_enum_size(hyperx_led_mode);
-
-enum hyperx_action_type {
-	HYPERX_ACTION_TYPE_DISABLED,
-	HYPERX_ACTION_TYPE_MOUSE,
-	HYPERX_ACTION_TYPE_KEY,
-	HYPERX_ACTION_TYPE_MEDIA,
-	HYPERX_ACTION_TYPE_MACRO,
-	HYPERX_ACTION_TYPE_SHORTCUT,
-	HYPERX_ACTION_TYPE_DPI_TOGGLE = 0x07,
-	HYPERX_ACTION_TYPE_UNKNOWN
-} __attribute((packed));
-
-_Static_assert_enum_size(hyperx_action_type);
-
-enum hyperx_macro_event_type {
-	HYPERX_MACRO_EVENT_TYPE_KEY = 0x1a
-} __attribute((packed));
-
-_Static_assert_enum_size(hyperx_macro_event_type);
-
-enum {
-	HYPERX_BYTES_AFTER_MACRO_ASSIGNMENT = 5,
-	HYPERX_BYTES_AFTER_LED_MODE = 3,
-};
-
-union hyperx_polling_rate_packet {
-	struct {
-		enum hyperx_config_value polling_rate_cmd;
-		uint8_t _padding[2];
-		uint8_t bytes_after;
-		uint8_t rate_index;
-	} __attribute((packed));
-
-	uint8_t data[HYPERX_PACKET_SIZE];
-};
-
-struct hyperx_color {
-	uint8_t red;
-	uint8_t green;
-	uint8_t blue;
-} __attribute((packed));
-
-union hyperx_led_packet {
-	struct {
-		enum hyperx_config_value led_cmd;
-		uint8_t led_mode;
-		uint8_t packet_number;
-		uint8_t bytes_after;
-		struct hyperx_color colors[20];
-	};
-
-	uint8_t data[HYPERX_PACKET_SIZE];
-};
-
-union hyperx_led_mode_packet {
-	struct {
-		enum hyperx_config_value led_mode_cmd;
-		uint8_t _padding[2];
-		uint8_t bytes_after;
-		uint8_t led_mode_value_before;
-		enum hyperx_led_mode led_mode;
-		uint8_t led_mode_value_after;
-	};
-
-	uint8_t data[HYPERX_PACKET_SIZE];
-} __attribute((packed));
-
-union hyperx_dpi_profile_packet {
-	struct {
-		enum hyperx_config_value dpi_cmd;
-		enum hyperx_dpi_config value_type;
-		uint8_t dpi_profile_index;
-		uint8_t bytes_after;
-		uint16_t dpi_step_value;
-	};
-
-	uint8_t data[HYPERX_PACKET_SIZE];
-} __attribute((packed));
-
-union hyperx_dpi_config_packet {
-	struct {
-		enum hyperx_config_value dpi_cmd;
-		enum hyperx_dpi_config config_type;
-		uint8_t _padding[1];
-		uint8_t bytes_after;
-		union {
-			uint8_t enabled_dpi_profiles;
-			uint8_t selected_profile;
-		};
-	};
-
-	uint8_t data[HYPERX_PACKET_SIZE];
-};
-
-struct hyperx_action {
-	uint8_t type;
-	uint8_t action;
-	uint8_t button_index;
-	struct ratbag_macro *macro;
-};
-
-union hyperx_button_packet {
-	struct {
-		enum hyperx_config_value button_cmd;
-		uint8_t button;
-		uint8_t action_type;
-		uint8_t bytes_after;
-		uint8_t action;
-		uint8_t unknown;
-	};
-
-	uint8_t data[HYPERX_PACKET_SIZE];
-};
-
-struct hyperx_macro_event {
-	enum hyperx_macro_event_type event_type;
-	uint8_t modifier;
-	uint8_t keys[HYPERX_MACRO_EVENT_MAX_KEYS];
-	uint16_t delay_next_event;
-} __attribute__((packed));
-
-union hyperx_macro_data_packet {
-	struct {
-		enum hyperx_config_value macro_data_cmd;
-		uint8_t button_index;
-		uint8_t sum_value;
-		uint8_t event_count;
-		struct hyperx_macro_event events[HYPERX_MACRO_DATA_MAX_EVENTS];
-	};
-
-	uint8_t data[HYPERX_PACKET_SIZE];
-};
-
-struct hyperx_macro {
-	int event_count;
-	union hyperx_macro_data_packet macro_packets[HYPERX_MAX_MACRO_PACKETS];
-};
-
-union hyperx_macro_assigment_packet {
-	struct {
-		enum hyperx_config_value macro_assign_cmd;
-		uint8_t button;
-		uint8_t _padding[1];
-		uint8_t bytes_after;
-		uint8_t event_count;
-	};
-
-	uint8_t data[HYPERX_PACKET_SIZE];
-};
-
-union hyperx_save_settings_packet {
-	struct {
-		enum hyperx_config_value save_settings_cmd;
-		enum hyperx_save_type save_type;
-	};
-
-	uint8_t data[HYPERX_PACKET_SIZE];
-};
-
-struct hyperx_drv_data {
-	uint8_t enabled_dpi_profiles; // A 5-bit little-endian number, where the nth bit corresponds to profile n
-	uint8_t active_dpi_profile_index;
-};
+	if (!maxed_out)
+		log_bug_libratbag(res->profile->device->ratbag,
+			"%s: resolution range exceeds available space.\n",
+			res->profile->device->name);
+}
 
 static int
 hyperx_write(struct ratbag_device *device, uint8_t buf[HYPERX_PACKET_SIZE])
@@ -281,6 +68,64 @@ hyperx_write(struct ratbag_device *device, uint8_t buf[HYPERX_PACKET_SIZE])
 	//log_buf_debug(device->ratbag, "hyperx_write output report: ", buf, HYPERX_PACKET_SIZE);
 	//return 0;
 	return ratbag_hidraw_output_report(device, buf, HYPERX_PACKET_SIZE);
+}
+
+static bool
+hyperx_read_filter(uint8_t *buf, size_t len)
+{
+	return buf[0] == buf[-1];
+}
+
+// Request and read an input report
+static int
+hyperx_read(struct ratbag_device *device, struct hyperx_input_report *report)
+{
+	report->report_value = report->data[0];
+
+	int rc = ratbag_hidraw_output_report(device, report->data, HYPERX_PACKET_SIZE);
+	if (rc < 0) return rc;
+
+	return ratbag_hidraw_read_input_report(device, report->data,
+			HYPERX_PACKET_SIZE, hyperx_read_filter);
+}
+
+static struct ratbag_button_action
+hyperx_action_get_ratbag_button_action(struct hyperx_report_button_action *action)
+{
+	int type_mapping[] = {
+		[HYPERX_ACTION_TYPE_DISABLED] = RATBAG_BUTTON_ACTION_TYPE_NONE,
+		[HYPERX_ACTION_TYPE_MOUSE] = RATBAG_BUTTON_ACTION_TYPE_BUTTON,
+		[HYPERX_ACTION_TYPE_KEY] = RATBAG_BUTTON_ACTION_TYPE_KEY,
+		[HYPERX_ACTION_TYPE_DPI_TOGGLE] = RATBAG_BUTTON_ACTION_TYPE_SPECIAL,
+		[HYPERX_ACTION_TYPE_MACRO] = RATBAG_BUTTON_ACTION_TYPE_UNKNOWN,
+		[HYPERX_ACTION_TYPE_MEDIA] = RATBAG_BUTTON_ACTION_TYPE_UNKNOWN,
+		[HYPERX_ACTION_TYPE_SHORTCUT] = RATBAG_BUTTON_ACTION_TYPE_UNKNOWN,
+	};
+
+	struct ratbag_button_action button_action = {
+		.type = type_mapping[action->type]
+	};
+
+	switch (action->type) {
+		case HYPERX_ACTION_TYPE_DISABLED:
+			break;
+		case HYPERX_ACTION_TYPE_MOUSE:
+			button_action.action.button = action->action;
+			break;
+		case HYPERX_ACTION_TYPE_KEY:
+			button_action.action.key = ratbag_hidraw_get_keycode_from_keyboard_usage(NULL, action->action);
+			break;
+		case HYPERX_ACTION_TYPE_MACRO:
+		case HYPERX_ACTION_TYPE_MEDIA:
+		case HYPERX_ACTION_TYPE_SHORTCUT:
+		case HYPERX_ACTION_TYPE_INVALID:
+			break;
+		case HYPERX_ACTION_TYPE_DPI_TOGGLE:
+			button_action.action.special = RATBAG_BUTTON_ACTION_SPECIAL_RESOLUTION_CYCLE_UP;
+			break;
+	}
+
+	return button_action;
 }
 
 static struct hyperx_action
@@ -297,10 +142,6 @@ hyperx_button_action_get_raw_action(struct ratbag_button *button)
 		[RATBAG_BUTTON_ACTION_TYPE_MACRO] = HYPERX_ACTION_TYPE_MACRO,
 	};
 
-	if (action.type == RATBAG_BUTTON_ACTION_TYPE_UNKNOWN) {
-		return (struct hyperx_action) {.type = HYPERX_ACTION_TYPE_UNKNOWN};
-	}
-
 	struct hyperx_action raw_action = {
 		.type = type_mapping[action.type],
 		.button_index = button->index
@@ -313,13 +154,13 @@ hyperx_button_action_get_raw_action(struct ratbag_button *button)
 		case RATBAG_BUTTON_ACTION_TYPE_BUTTON:
 			raw_action.action = action.action.button;
 			if (raw_action.action >= device->num_buttons) {
-				raw_action.type = HYPERX_ACTION_TYPE_UNKNOWN;
+				raw_action.type = HYPERX_ACTION_TYPE_INVALID;
 			}
 
 			break;
 		case RATBAG_BUTTON_ACTION_TYPE_SPECIAL:
 			if (action.action.special != RATBAG_BUTTON_ACTION_SPECIAL_RESOLUTION_CYCLE_UP) {
-				raw_action.type = HYPERX_ACTION_TYPE_UNKNOWN;
+				raw_action.type = HYPERX_ACTION_TYPE_INVALID;
 			}
 
 			raw_action.action = HYPERX_ACTION_DPI_TOGGLE;
@@ -396,7 +237,7 @@ hyperx_write_dpi_configuration(struct ratbag_device *device, struct ratbag_profi
 	if (rc < 0) return rc;
 
 	buf.config_type = HYPERX_DPI_CONFIG_SELECTED_PROFILE;
-	buf.selected_profile = drv_data->active_dpi_profile_index;
+	buf.selected_profile = drv_data->selected_dpi_profile_index;
 
 	rc = hyperx_write(device, buf.data);
 	if (rc < 0) return rc;
@@ -421,7 +262,7 @@ hyperx_write_resolution(struct ratbag_resolution *resolution)
 	log_debug(device->ratbag, "\nChanging resolution %d\nEnabled profiles: %b\n", resolution->index, drv_data->enabled_dpi_profiles);
 
 	if (resolution->is_active) {
-		drv_data->active_dpi_profile_index = resolution->index;
+		drv_data->selected_dpi_profile_index = resolution->index;
 	}
 
 	union hyperx_dpi_profile_packet buf = {
@@ -429,7 +270,7 @@ hyperx_write_resolution(struct ratbag_resolution *resolution)
 		.value_type = HYPERX_DPI_CONFIG_DPI_VALUE,
 		.dpi_profile_index = resolution->index,
 		.bytes_after = sizeof(buf.dpi_step_value),
-		.dpi_step_value = htole16(ratbag_resolution_get_dpi(resolution) / 100),
+		.dpi_step_value = htole16(ratbag_resolution_get_dpi(resolution) / HYPERX_DPI_STEP),
 	};
 
 	_Static_assert_bytes_after(sizeof(buf.dpi_step_value) == 2);
@@ -472,7 +313,8 @@ static void hyperx_initialize_macro(struct hyperx_macro *macro, uint8_t button_i
 	}
 }
 
-static void hyperx_macro_event_add_key(struct hyperx_macro_event *event, unsigned int keycode,
+static void
+hyperx_macro_event_add_key(struct hyperx_macro_event *event, unsigned int keycode,
 	int *keys_down_count_ref, int *event_key_count_ref, int *event_index_ref)
 {
 	if (*keys_down_count_ref == 0) {
@@ -601,8 +443,6 @@ hyperx_get_macro_events(struct ratbag_device *device, struct ratbag_macro *macro
 static struct hyperx_macro *
 hyperx_parse_macro(struct ratbag_device *device, struct ratbag_macro *macro, uint8_t button_index)
 {
-	int packet_index = 0;
-	int event_index = 0;
 	int event_count = 0;
 
 	struct hyperx_macro *hyperx_macro = zalloc(sizeof(*hyperx_macro));
@@ -614,8 +454,8 @@ hyperx_parse_macro(struct ratbag_device *device, struct ratbag_macro *macro, uin
 	union hyperx_macro_data_packet *packet;
 
 	for (int i = 0; i < event_count; i++) {
-		packet_index = i / HYPERX_MACRO_DATA_MAX_EVENTS;
-		event_index = i % HYPERX_MACRO_DATA_MAX_EVENTS;
+		int packet_index = i / HYPERX_MACRO_DATA_MAX_EVENTS;
+		int event_index = i % HYPERX_MACRO_DATA_MAX_EVENTS;
 		packet = hyperx_macro->macro_packets + packet_index;
 
 		packet->events[event_index] = hyperx_events[i];
@@ -673,8 +513,10 @@ hyperx_write_button_action(struct ratbag_button *button)
 
 	log_debug(device->ratbag, "Changing action for button %d\n", button->index);
 
+	if (button->action.type == RATBAG_BUTTON_ACTION_TYPE_UNKNOWN) return 0;
+
 	struct hyperx_action action = hyperx_button_action_get_raw_action(button);
-	if (action.type == HYPERX_ACTION_TYPE_UNKNOWN) return -EINVAL;
+	if (action.type == HYPERX_ACTION_TYPE_INVALID) return 0;
 
 	if (action.type == HYPERX_ACTION_TYPE_MACRO) {
 		log_debug(device->ratbag, "Macro name: %s\n", button->action.macro->name);
@@ -716,7 +558,7 @@ hyperx_write_led(struct ratbag_led *led)
 	}
 
 	union hyperx_led_mode_packet led_mode = {
-		.led_mode_cmd = HYPERX_CONDIG_LED_MODE,
+		.led_mode_cmd = HYPERX_CONFIG_LED_MODE,
 		.bytes_after = HYPERX_BYTES_AFTER_LED_MODE,
 		.led_mode_value_before = HYPERX_LED_MODE_VALUE_BEFORE,
 		.led_mode = HYPERX_LED_MODE_SOLID,
@@ -730,10 +572,72 @@ hyperx_write_led(struct ratbag_led *led)
 	return 0;
 }
 
-/**
- * Reading settings from the mouse is not implemented, so we load default settings.
- */
-static void
+static int
+hyperx_read_settings(struct ratbag_profile *profile)
+{
+	struct ratbag_device *device = profile->device;
+	struct hyperx_drv_data *drv_data = ratbag_get_drv_data(device);
+	struct hyperx_device_settings_report *device_settings = &drv_data->device_settings;
+
+	const struct data_hyperx *device_data = ratbag_device_data_hyperx_get_data(device->data);
+
+	uint8_t *settings_member_address = drv_data->device_settings.settings_data;
+
+	device_settings->dpi_step_values = (uint16_t *) settings_member_address;
+	settings_member_address += sizeof(*device_settings->dpi_step_values) * device_data->dpi_count;
+
+	device_settings->dpi_indicator_colors = (struct hyperx_color *) settings_member_address;
+	settings_member_address += sizeof(*device_settings->dpi_indicator_colors) * device_data->dpi_count;
+
+	device_settings->button_actions = (struct hyperx_report_button_action *) settings_member_address;
+	settings_member_address += sizeof(*device_settings->button_actions) * device->num_buttons;
+
+	device_settings->polling_rate_index = settings_member_address;
+
+	device_settings->info_report_value = HYPERX_REPORT_DEVICE_INFO;
+	device_settings->info_type = HYPERX_REPORT_DEVICE_INFO_SETTINGS;
+
+	int rc = hyperx_read(device, (struct hyperx_input_report *) device_settings);
+	if (rc < 0) return rc;
+
+	struct hyperx_dpi_settings_report dpi_settings = {
+		.dpi_settings_report_value = HYPERX_RPEORT_DPI_SETTINGS
+	};
+
+	rc = hyperx_read(device, (struct hyperx_input_report *) &dpi_settings);
+	if (rc < 0) return rc;
+
+	drv_data->selected_dpi_profile_index = dpi_settings.selected_dpi_profile_index;
+	drv_data->enabled_dpi_profiles = dpi_settings.enabled_dpi_profiles;
+
+	return 0;
+}
+
+static inline void
+hyperx_read_resolution(struct ratbag_resolution *resolution) {
+	struct ratbag_device *device = resolution->profile->device;
+	struct hyperx_drv_data *drv_data = ratbag_get_drv_data(device);
+	const struct data_hyperx *device_data = ratbag_device_data_hyperx_get_data(device->data);
+
+	ratbag_resolution_set_cap(resolution, RATBAG_RESOLUTION_CAP_DISABLE);
+
+	hyperx_resolution_set_dpi_list_from_range(resolution,
+		device_data->dpi_range->min, device_data->dpi_range->max, device_data->dpi_range->step);
+
+	unsigned int dpi_step_value = le16toh(drv_data->device_settings.dpi_step_values[resolution->index]);
+	ratbag_resolution_set_dpi(resolution, dpi_step_value * HYPERX_DPI_STEP);
+
+	ratbag_resolution_set_disabled(resolution,
+		!hyperx_is_dpi_profile_enabled(drv_data->enabled_dpi_profiles, resolution->index));
+
+	if (resolution->index == drv_data->selected_dpi_profile_index) {
+		ratbag_resolution_set_active(resolution);
+	}
+
+	resolution->dirty = false;
+}
+
+static int
 hyperx_read_profile(struct ratbag_profile *profile)
 {
 	struct ratbag_device *device = profile->device;
@@ -744,44 +648,22 @@ hyperx_read_profile(struct ratbag_profile *profile)
 
 	const struct data_hyperx *device_data = ratbag_device_data_hyperx_get_data(device->data);
 
-	struct ratbag_button_action default_actions[] = {
-		BUTTON_ACTION_BUTTON(1),
-		BUTTON_ACTION_BUTTON(2),
-		BUTTON_ACTION_BUTTON(3),
-		BUTTON_ACTION_BUTTON(4),
-		BUTTON_ACTION_BUTTON(5),
-		BUTTON_ACTION_SPECIAL(RATBAG_BUTTON_ACTION_SPECIAL_RESOLUTION_CYCLE_UP),
-	};
-
-	const uint8_t default_enabled_dpi_profiles = 0b01111;
-	const int polling_rate = 1000;
-	const int dpi_levels[] = { 400, 800, 1600, 3200, 6000 };
+	int rc = hyperx_read_settings(profile);
+	if (rc < 0) return rc;
 
 	profile->is_active = true;
+	profile->is_active_dirty = false;
 
-	ratbag_profile_set_cap(profile, RATBAG_PROFILE_CAP_WRITE_ONLY);
+	//ratbag_profile_set_cap(profile, RATBAG_PROFILE_CAP_WRITE_ONLY);
 	ratbag_profile_set_report_rate_list(profile, device_data->rates,
 		device_data->nrates);
 
-	ratbag_profile_set_report_rate(profile, polling_rate);
-
-	drv_data->enabled_dpi_profiles = default_enabled_dpi_profiles;
-	drv_data->active_dpi_profile_index = 0;
+	ratbag_profile_set_report_rate(profile,
+		profile->rates[*drv_data->device_settings.polling_rate_index]);
+	profile->rate_dirty = false;
 
 	ratbag_profile_for_each_resolution(profile, resolution) {
-		ratbag_resolution_set_cap(resolution, RATBAG_RESOLUTION_CAP_DISABLE);
-
-		ratbag_resolution_set_dpi_list_from_range(resolution,
-			device_data->dpi_range->min, device_data->dpi_range->max);
-		ratbag_resolution_set_dpi(resolution, dpi_levels[resolution->index]);
-
-		ratbag_resolution_set_disabled(resolution,
-			!hyperx_is_dpi_profile_enabled(default_enabled_dpi_profiles, resolution->index));
-
-		if (resolution->index == drv_data->active_dpi_profile_index) {
-			ratbag_resolution_set_active(resolution);
-			ratbag_resolution_set_default(resolution);
-		}
+		hyperx_read_resolution(resolution);
 	}
 
 	ratbag_profile_for_each_button(profile, button) {
@@ -791,8 +673,9 @@ hyperx_read_profile(struct ratbag_profile *profile)
 		ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_SPECIAL);
 		ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_MACRO);
 
-		ratbag_button_set_action(button, default_actions + button->index);
-		button->dirty = true;
+		struct ratbag_button_action action = hyperx_action_get_ratbag_button_action(
+			&drv_data->device_settings.button_actions[button->index]);
+		ratbag_button_set_action(button, &action);
 	}
 
 	ratbag_profile_for_each_led(profile, led) {
@@ -800,13 +683,13 @@ hyperx_read_profile(struct ratbag_profile *profile)
 		ratbag_led_set_mode_capability(led, RATBAG_LED_OFF);
 
 		ratbag_led_set_mode(led, RATBAG_LED_ON);
-		ratbag_led_set_color(led, (struct ratbag_color) {
-			.red = 0xff,
-			.green = 0,
-			.blue = 0
-		});
+		ratbag_led_set_color(led, (struct ratbag_color) {.red = 0xff});
 		ratbag_led_set_brightness(led, 0xff);
 	}
+
+	profile->dirty = false;
+
+	return 0;
 }
 
 static int
@@ -817,7 +700,10 @@ hyperx_probe(struct ratbag_device *device)
 	struct hyperx_drv_data *drv_data;
 
 	device_data = ratbag_device_data_hyperx_get_data(device->data);
-	assert(device_data->dpi_range != NULL && device_data->rates != NULL);
+	assert(device_data->dpi_range != NULL && "Invalid/missing value for DpiRange in device file");
+	assert(device_data->rates != NULL     && "Invalid/missing value for ReportRates in device file");
+	assert(device_data->button_count > 0  && "Invalid/missing value for Buttons in device file");
+	assert(device_data->dpi_count > 0     && "Invalid/missing value for Buttons in device file");
 
 	int rc = ratbag_open_hidraw(device);
 	if (rc) return rc;
@@ -838,7 +724,8 @@ hyperx_probe(struct ratbag_device *device)
 	ratbag_set_drv_data(device, drv_data);
 
 	ratbag_device_for_each_profile(device, profile) {
-		hyperx_read_profile(profile);
+		rc = hyperx_read_profile(profile);
+		if (rc < 0) return rc;
 	}
 
 	return 0;

--- a/src/driver-hyperx.c
+++ b/src/driver-hyperx.c
@@ -81,6 +81,8 @@
 #define HYPERX_MACRO_PACKET_EVENT_COUNT(x) (((x) % 2) * 0x80)
 
 #define _Static_assert_bytes_after(expr) _Static_assert(expr, "Incorrect value for 'bytes_after'")
+#define _Static_assert_enum_size(enum_name) _Static_assert(sizeof(enum enum_name) == 1, \
+		"Incorrect size for '" #enum_name "''")
 
 enum hyperx_config_value {
 	HYPERX_CONFIG_POLLING_RATE              = 0xd0,
@@ -92,22 +94,30 @@ enum hyperx_config_value {
 	HYPERX_CONFIG_MACRO_DATA                = 0xd6,
 
 	HYPERX_CONFIG_SAVE_SETTINGS             = 0xde
-};
+} __attribute((packed));
+
+_Static_assert_enum_size(hyperx_config_value);
 
 enum hyperx_save_byte {
 	HYPERX_SAVE_BYTE_ALL                    = 0xff,
 	HYPERX_SAVE_BYTE_DPI_PROFILE_INDICATORS = 0x03
-};
+} __attribute((packed));
+
+_Static_assert_enum_size(hyperx_save_byte);
 
 enum hyperx_dpi_config {
 	HYPERX_DPI_CONFIG_SELECTED_PROFILE	= 0x00,
 	HYPERX_DPI_CONFIG_ENABLED_PROFILES	= 0x01,
 	HYPERX_DPI_CONFIG_DPI_VALUE         = 0x02,
-};
+} __attribute((packed));
+
+_Static_assert_enum_size(hyperx_dpi_config);
 
 enum hyperx_led_mode {
 	HYPERX_LED_MODE_SOLID = 0x01
-};
+} __attribute((packed));
+
+_Static_assert_enum_size(hyperx_led_mode);
 
 enum hyperx_action_type {
 	HYPERX_ACTION_TYPE_DISABLED,
@@ -118,13 +128,17 @@ enum hyperx_action_type {
 	HYPERX_ACTION_TYPE_SHORTCUT,
 	HYPERX_ACTION_TYPE_DPI_TOGGLE = 0x07,
 	HYPERX_ACTION_TYPE_UNKNOWN
-};
+} __attribute((packed));
+
+_Static_assert_enum_size(hyperx_action_type);
 
 enum hyperx_macro_event_type {
 	HYPERX_MACRO_EVENT_TYPE_KEY = 0x1a
-};
+} __attribute((packed));
 
-enum hyperx_bytes_after {
+_Static_assert_enum_size(hyperx_macro_event_type);
+
+enum {
 	HYPERX_BYTES_AFTER_MACRO_ASSIGNMENT = 5,
 	HYPERX_BYTES_AFTER_LED_MODE = 3,
 };
@@ -133,11 +147,11 @@ struct hyperx_color {
 	uint8_t red;
 	uint8_t green;
 	uint8_t blue;
-};
+} __attribute((packed));
 
 union hyperx_led_packet {
 	struct {
-		uint8_t led_cmd;
+		enum hyperx_config_value led_cmd;
 		uint8_t led_mode;
 		uint8_t packet_number;
 		uint8_t bytes_after;
@@ -149,7 +163,7 @@ union hyperx_led_packet {
 
 union hyperx_dpi_profile_packet {
 	struct {
-		uint8_t dpi_cmd;
+		enum hyperx_config_value dpi_cmd;
 		uint8_t value_type; // A HYPERX_DPI_CONFIG value
 		uint8_t dpi_profile_index;
 		uint8_t bytes_after;
@@ -161,7 +175,7 @@ union hyperx_dpi_profile_packet {
 
 union hyperx_dpi_config_packet {
 	struct {
-		uint8_t dpi_cmd;
+		enum hyperx_config_value dpi_cmd;
 		uint8_t config_type; // A HYPERX_DPI_CONFIG value
 		uint8_t _padding;
 		uint8_t bytes_after;
@@ -183,7 +197,7 @@ struct hyperx_action {
 
 union hyperx_button_packet {
 	struct {
-		uint8_t button_cmd;
+		enum hyperx_config_value button_cmd;
 		uint8_t button;
 		uint8_t action_type;
 		uint8_t bytes_after;
@@ -197,7 +211,7 @@ union hyperx_button_packet {
 };
 
 struct hyperx_macro_event {
-	uint8_t event_type;
+	enum hyperx_macro_event_type event_type;
 	uint8_t modifier;
 	uint8_t keys[HYPERX_MACRO_EVENT_MAX_KEYS];
 	uint16_t delay_next_event;
@@ -205,7 +219,7 @@ struct hyperx_macro_event {
 
 union hyperx_macro_data_packet {
 	struct {
-		uint8_t macro_data_cmd;
+		enum hyperx_config_value macro_data_cmd;
 		uint8_t button_index;
 		uint8_t sum_value;
 		uint8_t event_count;
@@ -222,7 +236,7 @@ struct hyperx_macro {
 
 union hyperx_macro_assigment_packet {
 	struct {
-		uint8_t macro_assign_cmd;
+		enum hyperx_config_value macro_assign_cmd;
 		uint8_t button;
 		uint8_t _padding;
 		uint8_t bytes_after;

--- a/src/driver-hyperx.c
+++ b/src/driver-hyperx.c
@@ -59,6 +59,7 @@
 // Max number of events in a macro data packet
 #define HYPERX_MACRO_DATA_MAX_EVENTS 6
 
+#define hyperx_is_dpi_profile_enabled(profile_bitmask, n) ((profile_bitmask) & (1 << (n)))
 #define hyperx_brightness_value(x) ((int) ((x / 255.0) * 100))
 
 /**
@@ -744,6 +745,7 @@ hyperx_read_profile(struct ratbag_profile *profile)
 		BUTTON_ACTION_SPECIAL(RATBAG_BUTTON_ACTION_SPECIAL_RESOLUTION_CYCLE_UP),
 	};
 
+	const uint8_t default_enabled_dpi_profiles = 0b01111;
 	const int polling_rate = 1000;
 	const int dpi_levels[] = { 400, 800, 1600, 3200, 6000 };
 	const unsigned int report_rates[] = { 125, 250, 500, 1000 };
@@ -756,6 +758,9 @@ hyperx_read_profile(struct ratbag_profile *profile)
 
 	ratbag_profile_set_report_rate(profile, polling_rate);
 
+	drv_data->enabled_dpi_profiles = default_enabled_dpi_profiles;
+	drv_data->active_dpi_profile_index = 0;
+
 	ratbag_profile_for_each_resolution(profile, resolution) {
 		ratbag_resolution_set_cap(resolution, RATBAG_RESOLUTION_CAP_DISABLE);
 
@@ -763,18 +768,14 @@ hyperx_read_profile(struct ratbag_profile *profile)
 			HYPERX_MIN_DPI, HYPERX_MAX_DPI);
 		ratbag_resolution_set_dpi(resolution, dpi_levels[resolution->index]);
 
-		ratbag_resolution_set_disabled(resolution, true);
+		ratbag_resolution_set_disabled(resolution,
+			!hyperx_is_dpi_profile_enabled(default_enabled_dpi_profiles, resolution->index));
 
-		if (resolution->index == 0) {
-			ratbag_resolution_set_disabled(resolution, false);
+		if (resolution->index == drv_data->active_dpi_profile_index) {
 			ratbag_resolution_set_active(resolution);
 			ratbag_resolution_set_default(resolution);
 		}
 	}
-
-	// Enable first profile only
-	drv_data->enabled_dpi_profiles = 1;
-	drv_data->active_dpi_profile_index = 0;
 
 	ratbag_profile_for_each_button(profile, button) {
 		ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_NONE);

--- a/src/driver-hyperx.c
+++ b/src/driver-hyperx.c
@@ -45,6 +45,8 @@
 
 #define hyperx_led_value(x) ((int) ((x / 100.0) * 255))
 
+#define BYTES_AFTER
+
 enum {
 	HYPERX_CONFIG_POLLING_RATE              = 0xd0,
 	HYPERX_CONFIG_LED                       = 0xd2,
@@ -62,6 +64,57 @@ enum {
 	HYPERX_SAVE_BYTE_DPI_PROFILE_INDICATORS = 0x03
 };
 
+static int
+hyperx_write_polling_rate(struct ratbag_profile *profile)
+{
+	struct ratbag_device *device = profile->device;
+	log_debug(device->ratbag, "Changing polling rate to %d\n", profile->hz);
+
+	int rate_count = profile->nrates;
+	bool valid_polling_rate = false;
+
+	int rate_index;
+	for (rate_index = 0; rate_index < rate_count; rate_index++) {
+		if (profile->hz == profile->rates[rate_index]) {
+			valid_polling_rate = true;
+			break;
+		}
+	}
+
+	if (!valid_polling_rate) return -EINVAL;
+
+	uint8_t buf[HYPERX_PACKET_SIZE] = {
+		HYPERX_CONFIG_POLLING_RATE,
+		0,
+		0,
+		BYTES_AFTER 1,
+		rate_index
+	};
+
+	int rc = ratbag_hidraw_output_report(device, buf, HYPERX_PACKET_SIZE);
+	if (rc < 0) return rc;
+
+	log_debug(device->ratbag, "Changed polling rate successfully\n");
+	return 0;
+}
+
+static int
+hyperx_write_resolution(struct ratbag_resolution *resolution)
+{
+	return 0;
+}
+
+static int
+hyperx_write_button(struct ratbag_button *button)
+{
+	return 0;
+}
+
+static int
+hyperx_write_led(struct ratbag_led *led)
+{
+	return 0;
+}
 /**
  * Reading settings from the mouse is not implemented, so we load default settings.
  */
@@ -163,6 +216,41 @@ hyperx_remove(struct ratbag_device *device)
 static int
 hyperx_commit(struct ratbag_device *device)
 {
+	struct ratbag_profile *profile;
+	struct ratbag_resolution *resolution;
+	struct ratbag_button *button;
+	struct ratbag_led *led;
+
+	int rc;
+
+	ratbag_device_for_each_profile(device, profile) {
+		if (profile->rate_dirty) {
+			rc = hyperx_write_polling_rate(profile);
+			if (rc) return rc;
+		}
+
+		ratbag_profile_for_each_resolution(profile, resolution) {
+			if (!resolution->dirty) continue;
+
+			rc = hyperx_write_resolution(resolution);
+			if (rc) return rc;
+		}
+
+		ratbag_profile_for_each_button(profile, button) {
+			if (!button->dirty) continue;
+
+			rc = hyperx_write_button(button);
+			if (rc) return rc;
+		}
+
+		ratbag_profile_for_each_led(profile, led) {
+			if (!led->dirty) continue;
+
+			rc = hyperx_write_led(led);
+			if (rc) return rc;
+		}
+	}
+
 	return 0;
 }
 

--- a/src/driver-hyperx.c
+++ b/src/driver-hyperx.c
@@ -438,7 +438,7 @@ hyperx_write_resolution(struct ratbag_resolution *resolution)
 }
 
 static int
-hyperx_write_assignment(struct ratbag_device *device, struct hyperx_action *action)
+hyperx_write_button_assignment(struct ratbag_device *device, struct hyperx_action *action)
 {
 	union hyperx_button_packet buf = {
 		.button_cmd = HYPERX_CONFIG_BUTTON_ASSIGNMENT,
@@ -637,7 +637,7 @@ hyperx_write_macro(struct ratbag_device *device, struct hyperx_action *action)
 	const int events_per_packet = ARRAY_LENGTH(hyperx_macro->macro_packets->events);
 	uint8_t packet_count = ceil(hyperx_macro->event_count / (double) events_per_packet);
 
-	int rc = hyperx_write_assignment(device, action);
+	int rc = hyperx_write_button_assignment(device, action);
 	if (rc < 0) goto free_macro;
 
 	for (int i = 0; i < packet_count; i++) {
@@ -661,7 +661,7 @@ hyperx_write_macro(struct ratbag_device *device, struct hyperx_action *action)
 }
 
 static int
-hyperx_write_button(struct ratbag_button *button)
+hyperx_write_button_action(struct ratbag_button *button)
 {
 	struct ratbag_device *device = button->profile->device;
 
@@ -674,7 +674,7 @@ hyperx_write_button(struct ratbag_button *button)
 		return hyperx_write_macro(device, &action);
 	}
 
-	return hyperx_write_assignment(device, &action);
+	return hyperx_write_button_assignment(device, &action);
 }
 
 static int
@@ -744,10 +744,9 @@ hyperx_read_profile(struct ratbag_profile *profile)
 		BUTTON_ACTION_SPECIAL(RATBAG_BUTTON_ACTION_SPECIAL_RESOLUTION_CYCLE_UP),
 	};
 
-	int dpi_levels[] = { 400, 800, 1600, 3200, 6000 };
-	unsigned int report_rates[] = { 125, 250, 500, 1000 };
-
-	int polling_rate = 1000;
+	const int polling_rate = 1000;
+	const int dpi_levels[] = { 400, 800, 1600, 3200, 6000 };
+	const unsigned int report_rates[] = { 125, 250, 500, 1000 };
 
 	profile->is_active = true;
 
@@ -755,7 +754,7 @@ hyperx_read_profile(struct ratbag_profile *profile)
 	ratbag_profile_set_report_rate_list(profile, report_rates,
 		ARRAY_LENGTH(report_rates));
 
-	profile->hz = polling_rate;
+	ratbag_profile_set_report_rate(profile, polling_rate);
 
 	ratbag_profile_for_each_resolution(profile, resolution) {
 		ratbag_resolution_set_cap(resolution, RATBAG_RESOLUTION_CAP_DISABLE);
@@ -797,7 +796,7 @@ hyperx_read_profile(struct ratbag_profile *profile)
 			.green = 0,
 			.blue = 0
 		});
-		ratbag_led_set_brightness(led, 255);
+		ratbag_led_set_brightness(led, 0xff);
 	}
 }
 
@@ -876,7 +875,7 @@ hyperx_commit(struct ratbag_device *device)
 		ratbag_profile_for_each_button(profile, button) {
 			if (!button->dirty) continue;
 
-			rc = hyperx_write_button(button);
+			rc = hyperx_write_button_action(button);
 			if (rc) return rc;
 		}
 

--- a/src/driver-hyperx.c
+++ b/src/driver-hyperx.c
@@ -677,6 +677,7 @@ hyperx_write_button_action(struct ratbag_button *button)
 	if (action.type == HYPERX_ACTION_TYPE_UNKNOWN) return -EINVAL;
 
 	if (action.type == HYPERX_ACTION_TYPE_MACRO) {
+		log_debug(device->ratbag, "Macro name: %s\n", button->action.macro->name);
 		return hyperx_write_macro(device, &action);
 	}
 
@@ -755,13 +756,12 @@ hyperx_read_profile(struct ratbag_profile *profile)
 	const uint8_t default_enabled_dpi_profiles = 0b01111;
 	const int polling_rate = 1000;
 	const int dpi_levels[] = { 400, 800, 1600, 3200, 6000 };
-	const unsigned int report_rates[] = { 125, 250, 500, 1000 };
 
 	profile->is_active = true;
 
 	ratbag_profile_set_cap(profile, RATBAG_PROFILE_CAP_WRITE_ONLY);
-	ratbag_profile_set_report_rate_list(profile, report_rates,
-		ARRAY_LENGTH(report_rates));
+	ratbag_profile_set_report_rate_list(profile, device_data->rates,
+		device_data->nrates);
 
 	ratbag_profile_set_report_rate(profile, polling_rate);
 
@@ -817,7 +817,7 @@ hyperx_probe(struct ratbag_device *device)
 	struct hyperx_drv_data *drv_data;
 
 	device_data = ratbag_device_data_hyperx_get_data(device->data);
-	assert(device_data->dpi_range != NULL);
+	assert(device_data->dpi_range != NULL && device_data->rates != NULL);
 
 	int rc = ratbag_open_hidraw(device);
 	if (rc) return rc;

--- a/src/driver-hyperx.c
+++ b/src/driver-hyperx.c
@@ -43,6 +43,8 @@
 #define HYPERX_USAGE_PAGE 0xff00
 #define HYPERX_PACKET_SIZE 64
 
+#define hyperx_led_value(x) ((int) ((x / 100.0) * 255))
+
 enum {
 	HYPERX_CONFIG_POLLING_RATE              = 0xd0,
 	HYPERX_CONFIG_LED                       = 0xd2,
@@ -60,28 +62,68 @@ enum {
 	HYPERX_SAVE_BYTE_DPI_PROFILE_INDICATORS = 0x03
 };
 
+/**
+ * Reading settings from the mouse is not implemented, so we load default settings.
+ */
 static void
 hyperx_read_profile(struct ratbag_profile *profile)
 {
+	struct ratbag_resolution *resolution;
+	struct ratbag_button *button;
+	struct ratbag_led *led;
+
+	struct ratbag_button_action default_actions[] = {
+		BUTTON_ACTION_BUTTON(1),
+		BUTTON_ACTION_BUTTON(2),
+		BUTTON_ACTION_BUTTON(3),
+		BUTTON_ACTION_BUTTON(4),
+		BUTTON_ACTION_BUTTON(5),
+		BUTTON_ACTION_SPECIAL(RATBAG_BUTTON_ACTION_SPECIAL_RESOLUTION_CYCLE_UP),
+	};
+
+	int dpi_levels[] = { 400, 800, 1600, 3200, 6000 };
 	unsigned int report_rates[] = { 125, 250, 500, 1000 };
 
-	struct ratbag_resolution *resolution;
-	int dpi = 500;
 	int polling_rate = 1000;
 
-	ratbag_profile_for_each_resolution(profile, resolution) {
-		ratbag_resolution_set_resolution(resolution, dpi, dpi);
-		ratbag_resolution_set_dpi_list_from_range(resolution,
-			HYPERX_MIN_DPI, HYPERX_MAX_DPI);
+	profile->is_active = true;
 
-		resolution->is_active = resolution->index == 0;
-	}
-
+	ratbag_profile_set_cap(profile, RATBAG_PROFILE_CAP_WRITE_ONLY);
 	ratbag_profile_set_report_rate_list(profile, report_rates,
 		ARRAY_LENGTH(report_rates));
+
 	profile->hz = polling_rate;
 
-	profile->is_active = true;
+	ratbag_profile_for_each_resolution(profile, resolution) {
+		ratbag_resolution_set_dpi_list_from_range(resolution,
+			HYPERX_MIN_DPI, HYPERX_MAX_DPI);
+		ratbag_resolution_set_dpi(resolution, dpi_levels[resolution->index]);
+
+		if (resolution->index == 0) {
+			resolution->is_active = true;
+			ratbag_resolution_set_default(resolution);
+		}
+	}
+
+	ratbag_profile_for_each_button(profile, button) {
+		ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_NONE);
+		ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_BUTTON);
+		ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_KEY);
+		ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_SPECIAL);
+		ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_MACRO);
+
+		ratbag_button_set_action(button, default_actions + button->index);
+	}
+
+	ratbag_profile_for_each_led(profile, led) {
+		ratbag_led_set_mode(led, RATBAG_LED_ON);
+		ratbag_led_set_color(led, (struct ratbag_color) {
+			.red = 0xff,
+			.green = 0,
+			.blue = 0
+		});
+		ratbag_led_set_brightness(led, hyperx_led_value(50));
+	}
 }
 
 static int

--- a/src/driver-hyperx.c
+++ b/src/driver-hyperx.c
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2025 Evan Razzaque.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "config.h"
+#include <assert.h>
+#include <errno.h>
+#include <libevdev/libevdev.h>
+#include <linux/input.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "libratbag-private.h"
+#include "libratbag-hidraw.h"
+
+#define HYPERX_PROFILE_COUNT 1
+#define HYPERX_BUTTON_COUNT 6
+#define HYPERX_NUM_DPI 5
+#define HYPERX_MIN_DPI 200
+#define HYPERX_MAX_DPI 16000
+#define HYPERX_LED_COUNT 1
+
+#define HYPERX_USAGE_PAGE 0xff00
+#define HYPERX_PACKET_SIZE 64
+
+enum {
+	HYPERX_CONFIG_POLLING_RATE              = 0xd0,
+	HYPERX_CONFIG_LED                       = 0xd2,
+	HYPERX_CONFIG_DPI                       = 0xd3,
+	HYPERX_CONFIG_BUTTON_ASSIGNMENT         = 0xd4,
+	HYPERX_CONFIG_MACRO_ASSIGNMENT          = 0xd5,
+	HYPERX_CONFIG_MACRO_DATA                = 0xd6,
+
+	HYPERX_CONFIG_SAVE_SETTINGS_LED         = 0xda,
+	HYPERX_CONFIG_SAVE_SETTINGS             = 0xde
+};
+
+enum {
+	HYPERX_SAVE_BYTE_ALL                    = 0xff,
+	HYPERX_SAVE_BYTE_DPI_PROFILE_INDICATORS = 0x03
+};
+
+static void
+hyperx_read_profile(struct ratbag_profile *profile)
+{
+	unsigned int report_rates[] = { 125, 250, 500, 1000 };
+
+	struct ratbag_resolution *resolution;
+	int dpi = 500;
+	int polling_rate = 1000;
+
+	ratbag_profile_for_each_resolution(profile, resolution) {
+		ratbag_resolution_set_resolution(resolution, dpi, dpi);
+		ratbag_resolution_set_dpi_list_from_range(resolution,
+			HYPERX_MIN_DPI, HYPERX_MAX_DPI);
+
+		resolution->is_active = resolution->index == 0;
+	}
+
+	ratbag_profile_set_report_rate_list(profile, report_rates,
+		ARRAY_LENGTH(report_rates));
+	profile->hz = polling_rate;
+
+	profile->is_active = true;
+}
+
+static int
+hyperx_probe(struct ratbag_device *device)
+{
+	struct ratbag_profile *profile;
+	int rc;
+
+	rc = ratbag_open_hidraw(device);
+	if (rc) return rc;
+
+	if (ratbag_hidraw_get_usage_page(device, 0) != HYPERX_USAGE_PAGE) {
+		ratbag_close_hidraw(device);
+		return -ENODEV;
+	}
+
+	ratbag_device_init_profiles(device,
+		HYPERX_PROFILE_COUNT,
+		HYPERX_NUM_DPI,
+		HYPERX_BUTTON_COUNT,
+		HYPERX_LED_COUNT
+	);
+
+	ratbag_device_for_each_profile(device, profile) {
+		hyperx_read_profile(profile);
+	}
+
+	return 0;
+}
+
+static void
+hyperx_remove(struct ratbag_device *device)
+{
+	ratbag_close_hidraw(device);
+}
+
+static int
+hyperx_commit(struct ratbag_device *device)
+{
+	return 0;
+}
+
+struct ratbag_driver hyperx_driver = {
+	.name = "HP HyperX",
+	.id = "hyperx",
+	.probe = hyperx_probe,
+	.remove = hyperx_remove,
+	.commit = hyperx_commit
+};

--- a/src/driver-hyperx.c
+++ b/src/driver-hyperx.c
@@ -96,12 +96,12 @@ enum hyperx_config_value {
 
 _Static_assert_enum_size(hyperx_config_value);
 
-enum hyperx_save_byte {
-	HYPERX_SAVE_BYTE_ALL                    = 0xff,
-	HYPERX_SAVE_BYTE_DPI_PROFILE_INDICATORS = 0x03
+enum hyperx_save_type {
+	HYPERX_SAVE_TYPE_ALL                    = 0xff,
+	HYPERX_SAVE_TYPE_DPI_PROFILES           = 0x03
 } __attribute((packed));
 
-_Static_assert_enum_size(hyperx_save_byte);
+_Static_assert_enum_size(hyperx_save_type);
 
 enum hyperx_dpi_config {
 	HYPERX_DPI_CONFIG_SELECTED_PROFILE	= 0x00,
@@ -261,6 +261,15 @@ union hyperx_macro_assigment_packet {
 		uint8_t _padding[1];
 		uint8_t bytes_after;
 		uint8_t event_count;
+	};
+
+	uint8_t data[HYPERX_PACKET_SIZE];
+};
+
+union hyperx_save_settings_packet {
+	struct {
+		enum hyperx_config_value save_settings_cmd;
+		enum hyperx_save_type save_type;
 	};
 
 	uint8_t data[HYPERX_PACKET_SIZE];
@@ -887,6 +896,14 @@ hyperx_commit(struct ratbag_device *device)
 			if (rc) return rc;
 		}
 	}
+
+	union hyperx_save_settings_packet buf = {
+		.save_settings_cmd = HYPERX_CONFIG_SAVE_SETTINGS,
+		.save_type = HYPERX_SAVE_TYPE_ALL
+	};
+
+	rc = hyperx_write(device, buf.data);
+	if (rc < 0) return rc;
 
 	log_debug(device->ratbag, "Commit successful\n\n");
 

--- a/src/driver-hyperx.c
+++ b/src/driver-hyperx.c
@@ -23,10 +23,8 @@
 
 #include "config.h"
 #include <assert.h>
-#include <errno.h>
 #include <libevdev/libevdev.h>
 #include <linux/input.h>
-#include <stdlib.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <string.h>
@@ -55,8 +53,8 @@
 #define BYTES_AFTER
 #define PADDING 0
 
-enum {
-	HYPERX_CONFIG_POLLING_RATE              = 0xd0,
+enum HYPERX_CONFIG_VALUE {
+	HYPERX_CONFIG_POLLING_RATE              = 0xd1,
 	HYPERX_CONFIG_LED_EFFECT                = 0xda,
 	HYPERX_CONDIG_LED_MODE                  = 0xd9,
 	HYPERX_CONFIG_DPI                       = 0xd3,
@@ -67,12 +65,18 @@ enum {
 	HYPERX_CONFIG_SAVE_SETTINGS             = 0xde
 };
 
-enum {
+enum HYPERX_SAVE_BYTE {
 	HYPERX_SAVE_BYTE_ALL                    = 0xff,
 	HYPERX_SAVE_BYTE_DPI_PROFILE_INDICATORS = 0x03
 };
 
-enum {
+enum HYPERX_DPI_CONFIG {
+	HYPERX_DPI_CONFIG_SELECTED_PROFILE  = 0x00,
+	HYPERX_DPI_CONFIG_ENABLED_PROFILES  = 0x01,
+	HYPERX_DPI_CONFIG_DPI_VALUE         = 0x02,
+};
+
+enum HYPERX_LED_MODE {
 	HYPERX_LED_MODE_SOLID = 0x01
 };
 
@@ -93,6 +97,44 @@ union hyperx_led_packet {
 
 	uint8_t data[HYPERX_PACKET_SIZE];
 };
+
+union hyperx_dpi_profile_packet {
+	struct {
+		uint8_t dpi_cmd;
+		uint8_t value_type; // A HYPERX_DPI_CONFIG value
+		uint8_t dpi_profile_index;
+		uint8_t bytes_after;
+		uint16_t dpi_step_value;
+	};
+
+	uint8_t data[HYPERX_PACKET_SIZE];
+};
+
+union hyperx_dpi_config_packet {
+	struct {
+		uint8_t dpi_cmd;
+		uint8_t config_type; // A HYPERX_DPI_CONFIG value
+		uint8_t _padding;
+		uint8_t bytes_after;
+		union {
+			uint8_t enabled_dpi_profiles;
+			uint8_t selected_profile;
+		};
+	};
+
+	uint8_t data[HYPERX_PACKET_SIZE];
+};
+
+struct hyperx_data {
+	uint8_t enabled_dpi_profiles; // A 5-bit (little-endian) number, where the nth bit corresponds to profile n
+	uint8_t active_dpi_profile_index;
+};
+
+static int
+hyperx_write(struct ratbag_device *device, uint8_t buf[HYPERX_PACKET_SIZE])
+{
+	return ratbag_hidraw_output_report(device, buf, HYPERX_PACKET_SIZE);
+}
 
 static int
 hyperx_write_polling_rate(struct ratbag_profile *profile)
@@ -121,16 +163,79 @@ hyperx_write_polling_rate(struct ratbag_profile *profile)
 		rate_index
 	};
 
-	int rc = ratbag_hidraw_output_report(device, buf, HYPERX_PACKET_SIZE);
+	int rc = hyperx_write(device, buf);
 	if (rc < 0) return rc;
 
 	log_debug(device->ratbag, "Changed polling rate successfully\n");
 	return 0;
 }
 
+
+/**
+ * @brief Sets the enabled dpi profiles and the selected dpi profile.
+ */
+static int
+hyperx_write_dpi_configuration(struct ratbag_device *device, struct ratbag_profile *profile) {
+	struct hyperx_data *drv_data = ratbag_get_drv_data(device);
+
+	log_debug(device->ratbag, "Writing dpi configuration\n");
+
+	union hyperx_dpi_config_packet buf = {
+		.dpi_cmd = HYPERX_CONFIG_DPI,
+		.config_type = HYPERX_DPI_CONFIG_ENABLED_PROFILES,
+		.bytes_after = sizeof(buf.enabled_dpi_profiles),
+		.enabled_dpi_profiles = drv_data->enabled_dpi_profiles
+	};
+
+	_Static_assert(sizeof(buf.enabled_dpi_profiles) == 1, "Incorrect value for 'bytes_after'");
+
+	int rc = hyperx_write(device, buf.data);
+	if (rc < 0) return rc;
+
+	buf.config_type = HYPERX_DPI_CONFIG_SELECTED_PROFILE;
+	buf.selected_profile = drv_data->active_dpi_profile_index;
+
+	rc = hyperx_write(device, buf.data);
+	if (rc < 0) return rc;
+
+	log_debug(device->ratbag, "Wrote dpi configuration successfully\n");
+	return 0;
+}
+
 static int
 hyperx_write_resolution(struct ratbag_resolution *resolution)
 {
+	struct ratbag_device *device = resolution->profile->device;
+	struct hyperx_data *drv_data = ratbag_get_drv_data(device);
+
+	if (resolution->is_disabled) {
+		drv_data->enabled_dpi_profiles &= ~(1 << resolution->index);
+		return 0;
+	} else {
+		drv_data->enabled_dpi_profiles |= 1 << resolution->index;
+	}
+
+	log_debug(device->ratbag, "\nChanging resolution %d\nEnabled profiles: %b\n", resolution->index, drv_data->enabled_dpi_profiles);
+
+	if (resolution->is_active) {
+		drv_data->active_dpi_profile_index = resolution->index;
+	}
+
+	union hyperx_dpi_profile_packet buf = {
+		.dpi_cmd = HYPERX_CONFIG_DPI,
+		.value_type = HYPERX_DPI_CONFIG_DPI_VALUE,
+		.dpi_profile_index = resolution->index,
+		.bytes_after = sizeof(buf.dpi_step_value),
+		.dpi_step_value = htole16(ratbag_resolution_get_dpi(resolution) / 100),
+	};
+
+	_Static_assert(sizeof(buf.dpi_step_value) == 2, "Incorrect value for 'bytes_after'");
+
+	int rc = hyperx_write(device, buf.data);
+	if (rc < 0) return rc;
+
+	log_debug(device->ratbag, "Changed resolution successfully\n");
+
 	return 0;
 }
 
@@ -164,7 +269,7 @@ hyperx_write_led(struct ratbag_led *led)
 	assert(led_effect.bytes_after == 60);
 
 	for (int i = 0; i < HYPERX_LED_PACKET_COUNT; i++) {
-		int rc = ratbag_hidraw_output_report(device, led_effect.data, HYPERX_PACKET_SIZE);
+		int rc = hyperx_write(device, led_effect.data);
 		if (rc < 0) return rc;
 
 		memset(&led_effect.colors, 0, led_effect.bytes_after);
@@ -181,7 +286,7 @@ hyperx_write_led(struct ratbag_led *led)
 		HYPERX_LED_MODE_VALUE_AFTER
 	};
 
-	int rc = ratbag_hidraw_output_report(device, led_mode, HYPERX_PACKET_SIZE);
+	int rc = hyperx_write(device, led_mode);
 	if (rc < 0) return rc;
 
 	log_debug(device->ratbag, "Changed led successfully\n");
@@ -194,6 +299,8 @@ hyperx_write_led(struct ratbag_led *led)
 static void
 hyperx_read_profile(struct ratbag_profile *profile)
 {
+	struct ratbag_device *device = profile->device;
+	struct hyperx_data *drv_data = ratbag_get_drv_data(device);
 	struct ratbag_resolution *resolution;
 	struct ratbag_button *button;
 	struct ratbag_led *led;
@@ -221,15 +328,24 @@ hyperx_read_profile(struct ratbag_profile *profile)
 	profile->hz = polling_rate;
 
 	ratbag_profile_for_each_resolution(profile, resolution) {
+		ratbag_resolution_set_cap(resolution, RATBAG_RESOLUTION_CAP_DISABLE);
+
 		ratbag_resolution_set_dpi_list_from_range(resolution,
 			HYPERX_MIN_DPI, HYPERX_MAX_DPI);
 		ratbag_resolution_set_dpi(resolution, dpi_levels[resolution->index]);
 
+		ratbag_resolution_set_disabled(resolution, true);
+
 		if (resolution->index == 0) {
-			resolution->is_active = true;
+			ratbag_resolution_set_disabled(resolution, false);
+			ratbag_resolution_set_active(resolution);
 			ratbag_resolution_set_default(resolution);
 		}
 	}
+
+	// Enable first profile only
+	drv_data->enabled_dpi_profiles = 1;
+	drv_data->active_dpi_profile_index = 0;
 
 	ratbag_profile_for_each_button(profile, button) {
 		ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_NONE);
@@ -259,6 +375,8 @@ static int
 hyperx_probe(struct ratbag_device *device)
 {
 	struct ratbag_profile *profile;
+	struct hyperx_data *drv_data;
+
 	int rc;
 
 	rc = ratbag_open_hidraw(device);
@@ -276,6 +394,9 @@ hyperx_probe(struct ratbag_device *device)
 		HYPERX_LED_COUNT
 	);
 
+	drv_data = zalloc(sizeof(*drv_data));
+	ratbag_set_drv_data(device, drv_data);
+
 	ratbag_device_for_each_profile(device, profile) {
 		hyperx_read_profile(profile);
 	}
@@ -287,6 +408,7 @@ static void
 hyperx_remove(struct ratbag_device *device)
 {
 	ratbag_close_hidraw(device);
+	free(ratbag_get_drv_data(device));
 }
 
 static int
@@ -301,16 +423,24 @@ hyperx_commit(struct ratbag_device *device)
 	log_debug(device->ratbag, "Commiting settings\n");
 
 	ratbag_device_for_each_profile(device, profile) {
+		if (!profile->dirty) continue;
+
 		if (profile->rate_dirty) {
 			rc = hyperx_write_polling_rate(profile);
 			if (rc) return rc;
 		}
 
+		int changed_resolutions = 0;
 		ratbag_profile_for_each_resolution(profile, resolution) {
 			if (!resolution->dirty) continue;
+			changed_resolutions++;
 
 			rc = hyperx_write_resolution(resolution);
 			if (rc) return rc;
+		}
+
+		if (changed_resolutions > 0) {
+			hyperx_write_dpi_configuration(device, profile);
 		}
 
 		ratbag_profile_for_each_button(profile, button) {

--- a/src/driver-hyperx.c
+++ b/src/driver-hyperx.c
@@ -32,6 +32,7 @@
 
 #include "libratbag-private.h"
 #include "libratbag-hidraw.h"
+#include "libratbag-data.h"
 
 #include "driver-hyperx.h"
 

--- a/src/driver-hyperx.c
+++ b/src/driver-hyperx.c
@@ -55,7 +55,7 @@
 #define BYTES_AFTER
 #define PADDING 0
 
-enum HYPERX_CONFIG_VALUE {
+enum hyperx_config_value {
 	HYPERX_CONFIG_POLLING_RATE              = 0xd0,
 	HYPERX_CONFIG_LED_EFFECT                = 0xda,
 	HYPERX_CONDIG_LED_MODE                  = 0xd9,
@@ -67,18 +67,18 @@ enum HYPERX_CONFIG_VALUE {
 	HYPERX_CONFIG_SAVE_SETTINGS             = 0xde
 };
 
-enum HYPERX_SAVE_BYTE {
+enum hyperx_save_byte {
 	HYPERX_SAVE_BYTE_ALL                    = 0xff,
 	HYPERX_SAVE_BYTE_DPI_PROFILE_INDICATORS = 0x03
 };
 
-enum HYPERX_DPI_CONFIG {
+enum hyperx_dpi_config {
 	HYPERX_DPI_CONFIG_SELECTED_PROFILE	= 0x00,
 	HYPERX_DPI_CONFIG_ENABLED_PROFILES	= 0x01,
 	HYPERX_DPI_CONFIG_DPI_VALUE         = 0x02,
 };
 
-enum HYPERX_LED_MODE {
+enum hyperx_led_mode {
 	HYPERX_LED_MODE_SOLID = 0x01
 };
 

--- a/src/driver-hyperx.c
+++ b/src/driver-hyperx.c
@@ -48,13 +48,15 @@
 #define HYPERX_LED_MODE_VALUE_BEFORE 0x55
 #define HYPERX_LED_MODE_VALUE_AFTER 0x23
 
+#define HYPERX_ACTION_DPI_TOGGLE 8
+
 #define hyperx_brightness_value(x) ((int) ((x / 255.0) * 100))
 
 #define BYTES_AFTER
 #define PADDING 0
 
 enum HYPERX_CONFIG_VALUE {
-	HYPERX_CONFIG_POLLING_RATE              = 0xd1,
+	HYPERX_CONFIG_POLLING_RATE              = 0xd0,
 	HYPERX_CONFIG_LED_EFFECT                = 0xda,
 	HYPERX_CONDIG_LED_MODE                  = 0xd9,
 	HYPERX_CONFIG_DPI                       = 0xd3,
@@ -71,8 +73,8 @@ enum HYPERX_SAVE_BYTE {
 };
 
 enum HYPERX_DPI_CONFIG {
-	HYPERX_DPI_CONFIG_SELECTED_PROFILE  = 0x00,
-	HYPERX_DPI_CONFIG_ENABLED_PROFILES  = 0x01,
+	HYPERX_DPI_CONFIG_SELECTED_PROFILE	= 0x00,
+	HYPERX_DPI_CONFIG_ENABLED_PROFILES	= 0x01,
 	HYPERX_DPI_CONFIG_DPI_VALUE         = 0x02,
 };
 
@@ -80,10 +82,26 @@ enum HYPERX_LED_MODE {
 	HYPERX_LED_MODE_SOLID = 0x01
 };
 
+enum {
+	HYPERX_ACTION_TYPE_DISABLED,
+	HYPERX_ACTION_TYPE_MOUSE,
+	HYPERX_ACTION_TYPE_KEY,
+	HYPERX_ACTION_TYPE_MEDIA,
+	HYPERX_ACTION_TYPE_MACRO,
+	HYPERX_ACTION_TYPE_SHORTCUT,
+	HYPERX_ACTION_TYPE_DPI_TOGGLE = 0x07,
+	HYPERX_ACTION_TYPE_UNKNOWN
+};
+
 struct hyperx_color {
 	uint8_t red;
 	uint8_t green;
 	uint8_t blue;
+};
+
+struct hyperx_action {
+	uint8_t type;
+	uint8_t action;
 };
 
 union hyperx_led_packet {
@@ -125,6 +143,22 @@ union hyperx_dpi_config_packet {
 	uint8_t data[HYPERX_PACKET_SIZE];
 };
 
+union hyperx_button_packet {
+	struct {
+		uint8_t button_cmd;
+		uint8_t button;
+		uint8_t action_type;
+		uint8_t bytes_after;
+		union {
+			uint8_t macro_button; // The mouse button that a macro is assigned to
+			uint8_t action;
+		};
+		uint8_t unknown;
+	};
+
+	uint8_t data[HYPERX_PACKET_SIZE];
+};
+
 struct hyperx_data {
 	uint8_t enabled_dpi_profiles; // A 5-bit (little-endian) number, where the nth bit corresponds to profile n
 	uint8_t active_dpi_profile_index;
@@ -134,6 +168,59 @@ static int
 hyperx_write(struct ratbag_device *device, uint8_t buf[HYPERX_PACKET_SIZE])
 {
 	return ratbag_hidraw_output_report(device, buf, HYPERX_PACKET_SIZE);
+}
+
+static inline struct hyperx_action
+hyperx_button_action_get_raw_action(struct ratbag_button *button)
+{
+	struct ratbag_device *device = button->profile->device;
+	struct ratbag_button_action action = button->action;
+
+	uint8_t type_mapping[] = {
+		[RATBAG_BUTTON_ACTION_TYPE_NONE] = HYPERX_ACTION_TYPE_DISABLED,
+		[RATBAG_BUTTON_ACTION_TYPE_BUTTON] = HYPERX_ACTION_TYPE_MOUSE,
+		[RATBAG_BUTTON_ACTION_TYPE_KEY] = HYPERX_ACTION_TYPE_KEY,
+		[RATBAG_BUTTON_ACTION_TYPE_SPECIAL] = HYPERX_ACTION_TYPE_DPI_TOGGLE,
+		[RATBAG_BUTTON_ACTION_TYPE_MACRO] = HYPERX_ACTION_TYPE_MACRO,
+	};
+
+	if (action.type == RATBAG_BUTTON_ACTION_TYPE_UNKNOWN) {
+		return (struct hyperx_action) {.type = HYPERX_ACTION_TYPE_UNKNOWN};
+	}
+
+	struct hyperx_action raw_action = {
+		.type = type_mapping[action.type]
+	};
+
+	switch (action.type) {
+		case RATBAG_BUTTON_ACTION_TYPE_NONE:
+			raw_action.action = 0;
+			break;
+		case RATBAG_BUTTON_ACTION_TYPE_BUTTON:
+			raw_action.action = action.action.button;
+			if (raw_action.action >= HYPERX_BUTTON_COUNT) {
+				raw_action.type = HYPERX_ACTION_TYPE_UNKNOWN;
+			}
+
+			break;
+		case RATBAG_BUTTON_ACTION_TYPE_SPECIAL:
+			if (action.action.special != RATBAG_BUTTON_ACTION_SPECIAL_RESOLUTION_CYCLE_UP) {
+				raw_action.type = HYPERX_ACTION_TYPE_UNKNOWN;
+			}
+
+			raw_action.action = HYPERX_ACTION_DPI_TOGGLE;
+			break;
+		case RATBAG_BUTTON_ACTION_TYPE_KEY:
+			raw_action.action = ratbag_hidraw_get_keyboard_usage_from_keycode(device, action.action.key);
+			break;
+		case RATBAG_BUTTON_ACTION_TYPE_MACRO:
+			raw_action.action = button->index;
+			break;
+		default:
+			break;
+	}
+
+	return raw_action;
 }
 
 static int
@@ -175,7 +262,8 @@ hyperx_write_polling_rate(struct ratbag_profile *profile)
  * @brief Sets the enabled dpi profiles and the selected dpi profile.
  */
 static int
-hyperx_write_dpi_configuration(struct ratbag_device *device, struct ratbag_profile *profile) {
+hyperx_write_dpi_configuration(struct ratbag_device *device, struct ratbag_profile *profile)
+{
 	struct hyperx_data *drv_data = ratbag_get_drv_data(device);
 
 	log_debug(device->ratbag, "Writing dpi configuration\n");
@@ -240,8 +328,38 @@ hyperx_write_resolution(struct ratbag_resolution *resolution)
 }
 
 static int
+hyperx_write_macro(struct ratbag_button *button)
+{
+	return 0;
+}
+
+static int
 hyperx_write_button(struct ratbag_button *button)
 {
+	struct ratbag_device *device = button->profile->device;
+
+	log_debug(device->ratbag, "Changing action for button %d\n", button->index);
+
+	struct hyperx_action raw_action = hyperx_button_action_get_raw_action(button);
+	if (raw_action.type == HYPERX_ACTION_TYPE_UNKNOWN) return -EINVAL;
+
+	union hyperx_button_packet buf = {
+		.button_cmd = HYPERX_CONFIG_BUTTON_ASSIGNMENT,
+		.button = button->index,
+		.action_type = raw_action.type,
+		.bytes_after = sizeof(buf.action) + sizeof(buf.unknown),
+		.action = raw_action.action
+	};
+
+	int rc = hyperx_write(device, buf.data);
+	if (rc < 0) return rc;
+
+	if (raw_action.type == HYPERX_ACTION_TYPE_MACRO) {
+		return hyperx_write_macro(button);
+	}
+
+	log_debug(device->ratbag, "Button assignment successful\n");
+
 	return 0;
 }
 
@@ -352,7 +470,6 @@ hyperx_read_profile(struct ratbag_profile *profile)
 		ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_BUTTON);
 		ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_KEY);
 		ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_SPECIAL);
-		ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_MACRO);
 
 		ratbag_button_set_action(button, default_actions + button->index);
 	}

--- a/src/driver-hyperx.c
+++ b/src/driver-hyperx.c
@@ -794,6 +794,7 @@ hyperx_read_profile(struct ratbag_profile *profile)
 		ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_MACRO);
 
 		ratbag_button_set_action(button, default_actions + button->index);
+		button->dirty = true;
 	}
 
 	ratbag_profile_for_each_led(profile, led) {

--- a/src/driver-hyperx.c
+++ b/src/driver-hyperx.c
@@ -28,6 +28,7 @@
 #include <linux/input.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <stddef.h>
 #include <string.h>
 
 #include "libratbag-private.h"
@@ -43,25 +44,54 @@
 #define HYPERX_USAGE_PAGE 0xff00
 #define HYPERX_PACKET_SIZE 64
 
-#define hyperx_led_value(x) ((int) ((x / 100.0) * 255))
+#define HYPERX_LED_PACKET_COUNT 6
+
+// Magic numbers, no clue what these mean
+#define HYPERX_LED_MODE_VALUE_BEFORE 0x55
+#define HYPERX_LED_MODE_VALUE_AFTER 0x23
+
+#define hyperx_brightness_value(x) ((int) ((x / 255.0) * 100))
 
 #define BYTES_AFTER
+#define PADDING 0
 
 enum {
 	HYPERX_CONFIG_POLLING_RATE              = 0xd0,
-	HYPERX_CONFIG_LED                       = 0xd2,
+	HYPERX_CONFIG_LED_EFFECT                = 0xda,
+	HYPERX_CONDIG_LED_MODE                  = 0xd9,
 	HYPERX_CONFIG_DPI                       = 0xd3,
 	HYPERX_CONFIG_BUTTON_ASSIGNMENT         = 0xd4,
 	HYPERX_CONFIG_MACRO_ASSIGNMENT          = 0xd5,
 	HYPERX_CONFIG_MACRO_DATA                = 0xd6,
 
-	HYPERX_CONFIG_SAVE_SETTINGS_LED         = 0xda,
 	HYPERX_CONFIG_SAVE_SETTINGS             = 0xde
 };
 
 enum {
 	HYPERX_SAVE_BYTE_ALL                    = 0xff,
 	HYPERX_SAVE_BYTE_DPI_PROFILE_INDICATORS = 0x03
+};
+
+enum {
+	HYPERX_LED_MODE_SOLID = 0x01
+};
+
+struct hyperx_color {
+	uint8_t red;
+	uint8_t green;
+	uint8_t blue;
+};
+
+union hyperx_led_packet {
+	struct {
+		uint8_t led_cmd;
+		uint8_t led_mode;
+		uint8_t packet_number;
+		uint8_t bytes_after;
+		struct hyperx_color colors[20];
+	};
+
+	uint8_t data[HYPERX_PACKET_SIZE];
 };
 
 static int
@@ -85,8 +115,8 @@ hyperx_write_polling_rate(struct ratbag_profile *profile)
 
 	uint8_t buf[HYPERX_PACKET_SIZE] = {
 		HYPERX_CONFIG_POLLING_RATE,
-		0,
-		0,
+		PADDING,
+		PADDING,
 		BYTES_AFTER 1,
 		rate_index
 	};
@@ -113,8 +143,51 @@ hyperx_write_button(struct ratbag_button *button)
 static int
 hyperx_write_led(struct ratbag_led *led)
 {
+	struct ratbag_device *device = led->profile->device;
+	log_debug(device->ratbag, "Changing led\n");
+
+	uint8_t brightness = hyperx_brightness_value(led->brightness);
+	if (led->mode == RATBAG_LED_OFF) brightness = 0;
+
+	uint8_t red = led->color.red * ((float) brightness / 100);
+	uint8_t green = led->color.green * ((float) brightness / 100);
+	uint8_t blue = led->color.blue * ((float) brightness / 100);
+
+	union hyperx_led_packet led_effect = {
+		.led_cmd = HYPERX_CONFIG_LED_EFFECT,
+		.led_mode = HYPERX_LED_MODE_SOLID,
+		.packet_number = 0,
+		.bytes_after = sizeof(led_effect.colors),
+		.colors = {{.red = red, .green = green, .blue = blue}}
+	};
+
+	assert(led_effect.bytes_after == 60);
+
+	for (int i = 0; i < HYPERX_LED_PACKET_COUNT; i++) {
+		int rc = ratbag_hidraw_output_report(device, led_effect.data, HYPERX_PACKET_SIZE);
+		if (rc < 0) return rc;
+
+		memset(&led_effect.colors, 0, led_effect.bytes_after);
+		led_effect.packet_number = i + 1;
+	}
+
+	uint8_t led_mode[HYPERX_PACKET_SIZE] = {
+		HYPERX_CONDIG_LED_MODE,
+		PADDING,
+		PADDING,
+		BYTES_AFTER 3,
+		HYPERX_LED_MODE_VALUE_BEFORE,
+		HYPERX_LED_MODE_SOLID,
+		HYPERX_LED_MODE_VALUE_AFTER
+	};
+
+	int rc = ratbag_hidraw_output_report(device, led_mode, HYPERX_PACKET_SIZE);
+	if (rc < 0) return rc;
+
+	log_debug(device->ratbag, "Changed led successfully\n");
 	return 0;
 }
+
 /**
  * Reading settings from the mouse is not implemented, so we load default settings.
  */
@@ -169,13 +242,16 @@ hyperx_read_profile(struct ratbag_profile *profile)
 	}
 
 	ratbag_profile_for_each_led(profile, led) {
+		ratbag_led_set_mode_capability(led, RATBAG_LED_ON);
+		ratbag_led_set_mode_capability(led, RATBAG_LED_OFF);
+
 		ratbag_led_set_mode(led, RATBAG_LED_ON);
 		ratbag_led_set_color(led, (struct ratbag_color) {
 			.red = 0xff,
 			.green = 0,
 			.blue = 0
 		});
-		ratbag_led_set_brightness(led, hyperx_led_value(50));
+		ratbag_led_set_brightness(led, 255);
 	}
 }
 
@@ -222,6 +298,7 @@ hyperx_commit(struct ratbag_device *device)
 	struct ratbag_led *led;
 
 	int rc;
+	log_debug(device->ratbag, "Commiting settings\n");
 
 	ratbag_device_for_each_profile(device, profile) {
 		if (profile->rate_dirty) {
@@ -250,6 +327,8 @@ hyperx_commit(struct ratbag_device *device)
 			if (rc) return rc;
 		}
 	}
+
+	log_debug(device->ratbag, "Commit successful\n");
 
 	return 0;
 }

--- a/src/driver-hyperx.c
+++ b/src/driver-hyperx.c
@@ -33,12 +33,7 @@
 #include "libratbag-private.h"
 #include "libratbag-hidraw.h"
 
-#define HYPERX_PROFILE_COUNT 1
-#define HYPERX_BUTTON_COUNT 6
-#define HYPERX_NUM_DPI 5
-#define HYPERX_MIN_DPI 200
-#define HYPERX_MAX_DPI 16000
-#define HYPERX_LED_COUNT 1
+#include "driver-hyperx.h"
 
 #define HYPERX_USAGE_PAGE 0xff00
 #define HYPERX_PACKET_SIZE 64
@@ -275,7 +270,7 @@ union hyperx_save_settings_packet {
 	uint8_t data[HYPERX_PACKET_SIZE];
 };
 
-struct hyperx_data {
+struct hyperx_drv_data {
 	uint8_t enabled_dpi_profiles; // A 5-bit little-endian number, where the nth bit corresponds to profile n
 	uint8_t active_dpi_profile_index;
 };
@@ -317,7 +312,7 @@ hyperx_button_action_get_raw_action(struct ratbag_button *button)
 			break;
 		case RATBAG_BUTTON_ACTION_TYPE_BUTTON:
 			raw_action.action = action.action.button;
-			if (raw_action.action >= HYPERX_BUTTON_COUNT) {
+			if (raw_action.action >= device->num_buttons) {
 				raw_action.type = HYPERX_ACTION_TYPE_UNKNOWN;
 			}
 
@@ -384,7 +379,7 @@ hyperx_write_polling_rate(struct ratbag_profile *profile)
 static int
 hyperx_write_dpi_configuration(struct ratbag_device *device, struct ratbag_profile *profile)
 {
-	struct hyperx_data *drv_data = ratbag_get_drv_data(device);
+	struct hyperx_drv_data *drv_data = ratbag_get_drv_data(device);
 
 	log_debug(device->ratbag, "Writing dpi configuration\n");
 
@@ -414,7 +409,7 @@ static int
 hyperx_write_resolution(struct ratbag_resolution *resolution)
 {
 	struct ratbag_device *device = resolution->profile->device;
-	struct hyperx_data *drv_data = ratbag_get_drv_data(device);
+	struct hyperx_drv_data *drv_data = ratbag_get_drv_data(device);
 
 	if (resolution->is_disabled) {
 		drv_data->enabled_dpi_profiles &= ~(1 << resolution->index);
@@ -589,7 +584,8 @@ hyperx_get_macro_events(struct ratbag_device *device, struct ratbag_macro *macro
 
 	loop_end:
 
-	if (keys_down_count > 0 || (event_index + 1) > HYPERX_MAX_MACRO_EVENTS) {
+	bool event_index_in_range = event_index >= 0 && event_index < HYPERX_MAX_MACRO_EVENTS;
+	if (keys_down_count > 0 || !event_index_in_range) {
 		goto invalid_macro;
 	}
 
@@ -740,10 +736,12 @@ static void
 hyperx_read_profile(struct ratbag_profile *profile)
 {
 	struct ratbag_device *device = profile->device;
-	struct hyperx_data *drv_data = ratbag_get_drv_data(device);
+	struct hyperx_drv_data *drv_data = ratbag_get_drv_data(device);
 	struct ratbag_resolution *resolution;
 	struct ratbag_button *button;
 	struct ratbag_led *led;
+
+	const struct data_hyperx *device_data = ratbag_device_data_hyperx_get_data(device->data);
 
 	struct ratbag_button_action default_actions[] = {
 		BUTTON_ACTION_BUTTON(1),
@@ -774,7 +772,7 @@ hyperx_read_profile(struct ratbag_profile *profile)
 		ratbag_resolution_set_cap(resolution, RATBAG_RESOLUTION_CAP_DISABLE);
 
 		ratbag_resolution_set_dpi_list_from_range(resolution,
-			HYPERX_MIN_DPI, HYPERX_MAX_DPI);
+			device_data->dpi_range->min, device_data->dpi_range->max);
 		ratbag_resolution_set_dpi(resolution, dpi_levels[resolution->index]);
 
 		ratbag_resolution_set_disabled(resolution,
@@ -814,12 +812,14 @@ hyperx_read_profile(struct ratbag_profile *profile)
 static int
 hyperx_probe(struct ratbag_device *device)
 {
+	const struct data_hyperx *device_data;
 	struct ratbag_profile *profile;
-	struct hyperx_data *drv_data;
+	struct hyperx_drv_data *drv_data;
 
-	int rc;
+	device_data = ratbag_device_data_hyperx_get_data(device->data);
+	assert(device_data->dpi_range != NULL);
 
-	rc = ratbag_open_hidraw(device);
+	int rc = ratbag_open_hidraw(device);
 	if (rc) return rc;
 
 	if (ratbag_hidraw_get_usage_page(device, 0) != HYPERX_USAGE_PAGE) {
@@ -828,10 +828,10 @@ hyperx_probe(struct ratbag_device *device)
 	}
 
 	ratbag_device_init_profiles(device,
-		HYPERX_PROFILE_COUNT,
-		HYPERX_NUM_DPI,
-		HYPERX_BUTTON_COUNT,
-		HYPERX_LED_COUNT
+		device_data->profile_count,
+		device_data->dpi_count,
+		device_data->button_count,
+		device_data->led_count
 	);
 
 	drv_data = zalloc(sizeof(*drv_data));

--- a/src/driver-hyperx.c
+++ b/src/driver-hyperx.c
@@ -25,6 +25,7 @@
 #include <assert.h>
 #include <libevdev/libevdev.h>
 #include <linux/input.h>
+#include <math.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <string.h>
@@ -50,10 +51,36 @@
 
 #define HYPERX_ACTION_DPI_TOGGLE 8
 
+#define HYPERX_MAX_MACRO_EVENTS 80
+#define HYPERX_MAX_MACRO_PACKETS 14
+#define HYPERX_MACRO_EVENT_MAX_KEYS 6
+#define HYPERX_MACRO_EVENT_DEFAULT_DELAY htole16(20)
+
+// Max number of events in a macro data packet
+#define HYPERX_MACRO_DATA_MAX_EVENTS 6
+
 #define hyperx_brightness_value(x) ((int) ((x / 255.0) * 100))
 
 #define BYTES_AFTER
 #define PADDING 0
+
+/**
+ * Every macro data packet seems to have a sum byte? after the button byte that alternates between adding 1 and 2 each packet.
+ * Another way of thinking about it is half of the numbers in the sum are 1 and half are 2.
+ *
+ * Thus, we get the following formula: (1x / 2) + (2x / 2). Which is simplified to 3x / 2. Note that this is int division, so there would be no fractional part.
+ *
+ * For example, the sum bytes for 6 packets would be: 0x00, 0x01, 0x03, 0x04, 0x06, 0x07
+ */
+#define HYPERX_MACRO_PACKET_SUM(x) ((3*(x)) / 2)
+
+/**
+ * The event count byte in odd indexed macro data packets have 0x80 added to it.
+ * For example, a packet with 2 events would be 0x02 if it was even, and 0x82 if it was odd.
+ */
+#define HYPERX_MACRO_PACKET_EVENT_COUNT(x) (((x) % 2) * 0x80)
+
+#define _Static_assert_bytes_after(expr) _Static_assert(expr, "Incorrect value for 'bytes_after'")
 
 enum hyperx_config_value {
 	HYPERX_CONFIG_POLLING_RATE              = 0xd0,
@@ -82,7 +109,7 @@ enum hyperx_led_mode {
 	HYPERX_LED_MODE_SOLID = 0x01
 };
 
-enum {
+enum hyperx_action_type {
 	HYPERX_ACTION_TYPE_DISABLED,
 	HYPERX_ACTION_TYPE_MOUSE,
 	HYPERX_ACTION_TYPE_KEY,
@@ -93,15 +120,19 @@ enum {
 	HYPERX_ACTION_TYPE_UNKNOWN
 };
 
+enum hyperx_macro_event_type {
+	HYPERX_MACRO_EVENT_TYPE_KEY = 0x1a
+};
+
+enum hyperx_bytes_after {
+	HYPERX_BYTES_AFTER_MACRO_ASSIGNMENT = 5,
+	HYPERX_BYTES_AFTER_LED_MODE = 3,
+};
+
 struct hyperx_color {
 	uint8_t red;
 	uint8_t green;
 	uint8_t blue;
-};
-
-struct hyperx_action {
-	uint8_t type;
-	uint8_t action;
 };
 
 union hyperx_led_packet {
@@ -126,7 +157,7 @@ union hyperx_dpi_profile_packet {
 	};
 
 	uint8_t data[HYPERX_PACKET_SIZE];
-};
+} __attribute((packed));
 
 union hyperx_dpi_config_packet {
 	struct {
@@ -143,6 +174,13 @@ union hyperx_dpi_config_packet {
 	uint8_t data[HYPERX_PACKET_SIZE];
 };
 
+struct hyperx_action {
+	uint8_t type;
+	uint8_t action;
+	uint8_t button_index;
+	struct ratbag_macro *macro;
+};
+
 union hyperx_button_packet {
 	struct {
 		uint8_t button_cmd;
@@ -150,7 +188,6 @@ union hyperx_button_packet {
 		uint8_t action_type;
 		uint8_t bytes_after;
 		union {
-			uint8_t macro_button; // The mouse button that a macro is assigned to
 			uint8_t action;
 		};
 		uint8_t unknown;
@@ -159,18 +196,56 @@ union hyperx_button_packet {
 	uint8_t data[HYPERX_PACKET_SIZE];
 };
 
+struct hyperx_macro_event {
+	uint8_t event_type;
+	uint8_t modifier;
+	uint8_t keys[HYPERX_MACRO_EVENT_MAX_KEYS];
+	uint16_t delay_next_event;
+} __attribute__((packed));
+
+union hyperx_macro_data_packet {
+	struct {
+		uint8_t macro_data_cmd;
+		uint8_t button_index;
+		uint8_t sum_value;
+		uint8_t event_count;
+		struct hyperx_macro_event events[HYPERX_MACRO_DATA_MAX_EVENTS];
+	};
+
+	uint8_t data[HYPERX_PACKET_SIZE];
+};
+
+struct hyperx_macro {
+	int event_count;
+	union hyperx_macro_data_packet macro_packets[HYPERX_MAX_MACRO_PACKETS];
+};
+
+union hyperx_macro_assigment_packet {
+	struct {
+		uint8_t macro_assign_cmd;
+		uint8_t button;
+		uint8_t _padding;
+		uint8_t bytes_after;
+		uint8_t event_count;
+	};
+
+	uint8_t data[HYPERX_PACKET_SIZE];
+};
+
 struct hyperx_data {
-	uint8_t enabled_dpi_profiles; // A 5-bit (little-endian) number, where the nth bit corresponds to profile n
+	uint8_t enabled_dpi_profiles; // A 5-bit little-endian number, where the nth bit corresponds to profile n
 	uint8_t active_dpi_profile_index;
 };
 
 static int
 hyperx_write(struct ratbag_device *device, uint8_t buf[HYPERX_PACKET_SIZE])
 {
+	//log_buf_debug(device->ratbag, "hyperx_write output report: ", buf, HYPERX_PACKET_SIZE);
+	//return 0;
 	return ratbag_hidraw_output_report(device, buf, HYPERX_PACKET_SIZE);
 }
 
-static inline struct hyperx_action
+static struct hyperx_action
 hyperx_button_action_get_raw_action(struct ratbag_button *button)
 {
 	struct ratbag_device *device = button->profile->device;
@@ -189,7 +264,8 @@ hyperx_button_action_get_raw_action(struct ratbag_button *button)
 	}
 
 	struct hyperx_action raw_action = {
-		.type = type_mapping[action.type]
+		.type = type_mapping[action.type],
+		.button_index = button->index
 	};
 
 	switch (action.type) {
@@ -215,6 +291,7 @@ hyperx_button_action_get_raw_action(struct ratbag_button *button)
 			break;
 		case RATBAG_BUTTON_ACTION_TYPE_MACRO:
 			raw_action.action = button->index;
+			raw_action.macro = button->action.macro;
 			break;
 		default:
 			break;
@@ -232,7 +309,7 @@ hyperx_write_polling_rate(struct ratbag_profile *profile)
 	int rate_count = profile->nrates;
 	bool valid_polling_rate = false;
 
-	int rate_index;
+	uint8_t rate_index;
 	for (rate_index = 0; rate_index < rate_count; rate_index++) {
 		if (profile->hz == profile->rates[rate_index]) {
 			valid_polling_rate = true;
@@ -246,9 +323,11 @@ hyperx_write_polling_rate(struct ratbag_profile *profile)
 		HYPERX_CONFIG_POLLING_RATE,
 		PADDING,
 		PADDING,
-		BYTES_AFTER 1,
+		BYTES_AFTER sizeof(rate_index),
 		rate_index
 	};
+
+	_Static_assert_bytes_after(sizeof(rate_index) == 1);
 
 	int rc = hyperx_write(device, buf);
 	if (rc < 0) return rc;
@@ -275,7 +354,7 @@ hyperx_write_dpi_configuration(struct ratbag_device *device, struct ratbag_profi
 		.enabled_dpi_profiles = drv_data->enabled_dpi_profiles
 	};
 
-	_Static_assert(sizeof(buf.enabled_dpi_profiles) == 1, "Incorrect value for 'bytes_after'");
+	_Static_assert_bytes_after(sizeof(buf.enabled_dpi_profiles) == 1);
 
 	int rc = hyperx_write(device, buf.data);
 	if (rc < 0) return rc;
@@ -317,7 +396,7 @@ hyperx_write_resolution(struct ratbag_resolution *resolution)
 		.dpi_step_value = htole16(ratbag_resolution_get_dpi(resolution) / 100),
 	};
 
-	_Static_assert(sizeof(buf.dpi_step_value) == 2, "Incorrect value for 'bytes_after'");
+	_Static_assert_bytes_after(sizeof(buf.dpi_step_value) == 2);
 
 	int rc = hyperx_write(device, buf.data);
 	if (rc < 0) return rc;
@@ -328,9 +407,226 @@ hyperx_write_resolution(struct ratbag_resolution *resolution)
 }
 
 static int
-hyperx_write_macro(struct ratbag_button *button)
+hyperx_write_assignment(struct ratbag_device *device, struct hyperx_action *action)
 {
+	union hyperx_button_packet buf = {
+		.button_cmd = HYPERX_CONFIG_BUTTON_ASSIGNMENT,
+		.button = action->button_index,
+		.action_type = action->type,
+		.bytes_after = sizeof(buf.action) + sizeof(buf.unknown),
+		.action = action->action
+	};
+
+	_Static_assert_bytes_after(sizeof(buf.action) + sizeof(buf.unknown) == 2);
+
+	int rc = hyperx_write(device, buf.data);
+	if (rc < 0) return rc;
+
+	log_debug(device->ratbag, "Button assignment successful\n");
 	return 0;
+}
+
+static void hyperx_initialize_macro(struct hyperx_macro *macro, uint8_t button_index)
+{
+	for (int i = 0; i < HYPERX_MAX_MACRO_PACKETS; i++) {
+		macro->macro_packets[i].macro_data_cmd = HYPERX_CONFIG_MACRO_DATA;
+		macro->macro_packets[i].button_index = button_index;
+		macro->macro_packets[i].sum_value = HYPERX_MACRO_PACKET_SUM(i);
+		macro->macro_packets[i].event_count = HYPERX_MACRO_PACKET_EVENT_COUNT(i);
+	}
+}
+
+static void hyperx_macro_event_add_key(struct hyperx_macro_event *event, unsigned int keycode,
+	int *keys_down_count_ref, int *event_key_count_ref, int *event_index_ref)
+{
+	if (*keys_down_count_ref == 0) {
+		*event_index_ref += 1;
+		event++;
+
+		*event = (struct hyperx_macro_event) {
+			.event_type = HYPERX_MACRO_EVENT_TYPE_KEY,
+			.delay_next_event = HYPERX_MACRO_EVENT_DEFAULT_DELAY
+		};
+	}
+
+	const uint8_t modifier_map[] = {
+		[KEY_LEFTCTRL]	 = MODIFIER_LEFTCTRL,
+		[KEY_LEFTSHIFT]  = MODIFIER_LEFTSHIFT,
+		[KEY_LEFTALT]	 = MODIFIER_LEFTALT,
+		[KEY_LEFTMETA]	 = MODIFIER_LEFTMETA,
+		[KEY_RIGHTCTRL]  = MODIFIER_RIGHTCTRL,
+		[KEY_RIGHTSHIFT] = MODIFIER_RIGHTSHIFT,
+		[KEY_RIGHTALT]	 = MODIFIER_RIGHTALT,
+		[KEY_RIGHTMETA]  = MODIFIER_RIGHTMETA
+	};
+
+	uint8_t hid_code = ratbag_hidraw_get_keyboard_usage_from_keycode(NULL, keycode);
+
+	if (ratbag_key_is_modifier(keycode)) {
+		event->modifier |= modifier_map[keycode];
+	} else {
+		event->keys[*event_key_count_ref] = hid_code;
+		*event_key_count_ref += 1;
+	}
+
+	*keys_down_count_ref += 1;
+}
+
+static struct hyperx_macro_event *
+hyperx_get_macro_events(struct ratbag_device *device, struct ratbag_macro *macro, int *out_event_count)
+{
+	struct hyperx_macro_event *hyperx_events = zalloc(sizeof(*hyperx_events) * HYPERX_MAX_MACRO_EVENTS);
+
+	int event_index = -1;
+	int keys_down_count = 0;
+	int event_key_count = 0;
+
+	bool keys_down[UINT8_MAX] = {0};
+	bool event_keys[UINT8_MAX] = {0};
+	bool has_key;
+
+	for (int i = 0; i < MAX_MACRO_EVENTS; i++) {
+		struct ratbag_macro_event *event = macro->events + i;
+		unsigned int key = event->event.key;
+
+		switch (event->type) {
+		case RATBAG_MACRO_EVENT_INVALID:
+			goto invalid_macro;
+		case RATBAG_MACRO_EVENT_NONE:
+			goto loop_end;
+		case RATBAG_MACRO_EVENT_KEY_PRESSED:
+			assert(key <= UINT8_MAX);
+			has_key = keys_down[key] || event_keys[key];
+			if (has_key
+				|| (event_key_count == HYPERX_MACRO_EVENT_MAX_KEYS
+					&& !ratbag_key_is_modifier(key))
+			) {
+				continue;
+			}
+
+			keys_down[key] = true;
+			event_keys[key] = true;
+
+			hyperx_macro_event_add_key(hyperx_events + event_index, key,
+				&keys_down_count, &event_key_count, &event_index);
+
+			break;
+		case RATBAG_MACRO_EVENT_KEY_RELEASED:
+			assert(event->event.key <= UINT8_MAX);
+			has_key = keys_down[key] || event_keys[key];
+			if (!has_key) continue;
+
+			if (keys_down_count == 0) {
+				log_error(device->ratbag, "Lone key up event\n");
+				goto invalid_macro;
+			}
+
+			keys_down[key] = false;
+			keys_down_count--;
+
+			if (keys_down_count > 0) continue;
+
+			event_index++;
+
+			hyperx_events[event_index] = (struct hyperx_macro_event) {
+				.event_type = HYPERX_MACRO_EVENT_TYPE_KEY,
+				.delay_next_event = HYPERX_MACRO_EVENT_DEFAULT_DELAY
+			};
+
+			memset(event_keys, 0, sizeof(bool) * UINT8_MAX);
+			event_key_count = 0;
+
+			break;
+		case RATBAG_MACRO_EVENT_WAIT:
+			if (event_index < 0) continue;
+			if (event->event.timeout > UINT16_MAX) goto invalid_macro;
+
+			hyperx_events[event_index].delay_next_event = htole16(event->event.timeout);
+			break;
+		}
+	}
+
+	loop_end:
+
+	if (keys_down_count > 0 || (event_index + 1) > HYPERX_MAX_MACRO_EVENTS) {
+		goto invalid_macro;
+	}
+
+	*out_event_count = event_index + 1;
+
+	return hyperx_events;
+
+	invalid_macro:
+		free(hyperx_events);
+		return NULL;
+}
+
+static struct hyperx_macro *
+hyperx_parse_macro(struct ratbag_device *device, struct ratbag_macro *macro, uint8_t button_index)
+{
+	int packet_index = 0;
+	int event_index = 0;
+	int event_count = 0;
+
+	struct hyperx_macro *hyperx_macro = zalloc(sizeof(*hyperx_macro));
+	hyperx_initialize_macro(hyperx_macro, button_index);
+
+	struct hyperx_macro_event *hyperx_events = hyperx_get_macro_events(device, macro, &event_count);
+	if (!hyperx_events) goto invalid_macro;
+
+	union hyperx_macro_data_packet *packet;
+
+	for (int i = 0; i < event_count; i++) {
+		packet_index = i / HYPERX_MACRO_DATA_MAX_EVENTS;
+		event_index = i % HYPERX_MACRO_DATA_MAX_EVENTS;
+		packet = hyperx_macro->macro_packets + packet_index;
+
+		packet->events[event_index] = hyperx_events[i];
+		packet->event_count++;
+	}
+
+	hyperx_macro->event_count = event_count;
+	free(hyperx_events);
+
+	return hyperx_macro;
+
+	invalid_macro:
+		free(hyperx_macro);
+		return NULL;
+}
+
+static int
+hyperx_write_macro(struct ratbag_device *device, struct hyperx_action *action)
+{
+	struct ratbag_macro *macro = action->macro;
+	struct hyperx_macro *hyperx_macro = hyperx_parse_macro(device, macro, action->button_index);
+
+	if (!hyperx_macro) return -EINVAL;
+
+	const int events_per_packet = ARRAY_LENGTH(hyperx_macro->macro_packets->events);
+	uint8_t packet_count = ceil(hyperx_macro->event_count / (double) events_per_packet);
+
+	int rc = hyperx_write_assignment(device, action);
+	if (rc < 0) goto free_macro;
+
+	for (int i = 0; i < packet_count; i++) {
+		rc = hyperx_write(device, hyperx_macro->macro_packets[i].data);
+		if (rc < 0) goto free_macro;
+	}
+
+	union hyperx_macro_assigment_packet buf = {
+		.macro_assign_cmd = HYPERX_CONFIG_MACRO_ASSIGNMENT,
+		.button = action->button_index,
+		.bytes_after = HYPERX_BYTES_AFTER_MACRO_ASSIGNMENT,
+		.event_count = hyperx_macro->event_count
+	};
+
+	rc = hyperx_write(device, buf.data);
+
+	free_macro:
+		free(hyperx_macro);
+
+	return rc;
 }
 
 static int
@@ -340,27 +636,14 @@ hyperx_write_button(struct ratbag_button *button)
 
 	log_debug(device->ratbag, "Changing action for button %d\n", button->index);
 
-	struct hyperx_action raw_action = hyperx_button_action_get_raw_action(button);
-	if (raw_action.type == HYPERX_ACTION_TYPE_UNKNOWN) return -EINVAL;
+	struct hyperx_action action = hyperx_button_action_get_raw_action(button);
+	if (action.type == HYPERX_ACTION_TYPE_UNKNOWN) return -EINVAL;
 
-	union hyperx_button_packet buf = {
-		.button_cmd = HYPERX_CONFIG_BUTTON_ASSIGNMENT,
-		.button = button->index,
-		.action_type = raw_action.type,
-		.bytes_after = sizeof(buf.action) + sizeof(buf.unknown),
-		.action = raw_action.action
-	};
-
-	int rc = hyperx_write(device, buf.data);
-	if (rc < 0) return rc;
-
-	if (raw_action.type == HYPERX_ACTION_TYPE_MACRO) {
-		return hyperx_write_macro(button);
+	if (action.type == HYPERX_ACTION_TYPE_MACRO) {
+		return hyperx_write_macro(device, &action);
 	}
 
-	log_debug(device->ratbag, "Button assignment successful\n");
-
-	return 0;
+	return hyperx_write_assignment(device, &action);
 }
 
 static int
@@ -384,7 +667,7 @@ hyperx_write_led(struct ratbag_led *led)
 		.colors = {{.red = red, .green = green, .blue = blue}}
 	};
 
-	assert(led_effect.bytes_after == 60);
+	_Static_assert_bytes_after(sizeof(led_effect.colors) == 60);
 
 	for (int i = 0; i < HYPERX_LED_PACKET_COUNT; i++) {
 		int rc = hyperx_write(device, led_effect.data);
@@ -398,7 +681,7 @@ hyperx_write_led(struct ratbag_led *led)
 		HYPERX_CONDIG_LED_MODE,
 		PADDING,
 		PADDING,
-		BYTES_AFTER 3,
+		HYPERX_BYTES_AFTER_LED_MODE,
 		HYPERX_LED_MODE_VALUE_BEFORE,
 		HYPERX_LED_MODE_SOLID,
 		HYPERX_LED_MODE_VALUE_AFTER
@@ -470,6 +753,7 @@ hyperx_read_profile(struct ratbag_profile *profile)
 		ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_BUTTON);
 		ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_KEY);
 		ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_SPECIAL);
+		ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_MACRO);
 
 		ratbag_button_set_action(button, default_actions + button->index);
 	}
@@ -575,7 +859,7 @@ hyperx_commit(struct ratbag_device *device)
 		}
 	}
 
-	log_debug(device->ratbag, "Commit successful\n");
+	log_debug(device->ratbag, "Commit successful\n\n");
 
 	return 0;
 }

--- a/src/driver-hyperx.c
+++ b/src/driver-hyperx.c
@@ -61,9 +61,6 @@
 
 #define hyperx_brightness_value(x) ((int) ((x / 255.0) * 100))
 
-#define BYTES_AFTER
-#define PADDING 0
-
 /**
  * Every macro data packet seems to have a sum byte? after the button byte that alternates between adding 1 and 2 each packet.
  * Another way of thinking about it is half of the numbers in the sum are 1 and half are 2.
@@ -143,6 +140,17 @@ enum {
 	HYPERX_BYTES_AFTER_LED_MODE = 3,
 };
 
+union hyperx_polling_rate_packet {
+	struct {
+		enum hyperx_config_value polling_rate_cmd;
+		uint8_t _padding[2];
+		uint8_t bytes_after;
+		uint8_t rate_index;
+	} __attribute((packed));
+
+	uint8_t data[HYPERX_PACKET_SIZE];
+};
+
 struct hyperx_color {
 	uint8_t red;
 	uint8_t green;
@@ -161,10 +169,23 @@ union hyperx_led_packet {
 	uint8_t data[HYPERX_PACKET_SIZE];
 };
 
+union hyperx_led_mode_packet {
+	struct {
+		enum hyperx_config_value led_mode_cmd;
+		uint8_t _padding[2];
+		uint8_t bytes_after;
+		uint8_t led_mode_value_before;
+		enum hyperx_led_mode led_mode;
+		uint8_t led_mode_value_after;
+	};
+
+	uint8_t data[HYPERX_PACKET_SIZE];
+} __attribute((packed));
+
 union hyperx_dpi_profile_packet {
 	struct {
 		enum hyperx_config_value dpi_cmd;
-		uint8_t value_type; // A HYPERX_DPI_CONFIG value
+		enum hyperx_dpi_config value_type;
 		uint8_t dpi_profile_index;
 		uint8_t bytes_after;
 		uint16_t dpi_step_value;
@@ -176,8 +197,8 @@ union hyperx_dpi_profile_packet {
 union hyperx_dpi_config_packet {
 	struct {
 		enum hyperx_config_value dpi_cmd;
-		uint8_t config_type; // A HYPERX_DPI_CONFIG value
-		uint8_t _padding;
+		enum hyperx_dpi_config config_type;
+		uint8_t _padding[1];
 		uint8_t bytes_after;
 		union {
 			uint8_t enabled_dpi_profiles;
@@ -201,9 +222,7 @@ union hyperx_button_packet {
 		uint8_t button;
 		uint8_t action_type;
 		uint8_t bytes_after;
-		union {
-			uint8_t action;
-		};
+		uint8_t action;
 		uint8_t unknown;
 	};
 
@@ -238,7 +257,7 @@ union hyperx_macro_assigment_packet {
 	struct {
 		enum hyperx_config_value macro_assign_cmd;
 		uint8_t button;
-		uint8_t _padding;
+		uint8_t _padding[1];
 		uint8_t bytes_after;
 		uint8_t event_count;
 	};
@@ -333,17 +352,15 @@ hyperx_write_polling_rate(struct ratbag_profile *profile)
 
 	if (!valid_polling_rate) return -EINVAL;
 
-	uint8_t buf[HYPERX_PACKET_SIZE] = {
-		HYPERX_CONFIG_POLLING_RATE,
-		PADDING,
-		PADDING,
-		BYTES_AFTER sizeof(rate_index),
-		rate_index
+	union hyperx_polling_rate_packet buf = {
+		.polling_rate_cmd = HYPERX_CONFIG_POLLING_RATE,
+		.bytes_after = sizeof(rate_count),
+		.rate_index = rate_index
 	};
 
-	_Static_assert_bytes_after(sizeof(rate_index) == 1);
+	_Static_assert_bytes_after(sizeof(buf.rate_index) == 1);
 
-	int rc = hyperx_write(device, buf);
+	int rc = hyperx_write(device, buf.data);
 	if (rc < 0) return rc;
 
 	log_debug(device->ratbag, "Changed polling rate successfully\n");
@@ -691,17 +708,15 @@ hyperx_write_led(struct ratbag_led *led)
 		led_effect.packet_number = i + 1;
 	}
 
-	uint8_t led_mode[HYPERX_PACKET_SIZE] = {
-		HYPERX_CONDIG_LED_MODE,
-		PADDING,
-		PADDING,
-		HYPERX_BYTES_AFTER_LED_MODE,
-		HYPERX_LED_MODE_VALUE_BEFORE,
-		HYPERX_LED_MODE_SOLID,
-		HYPERX_LED_MODE_VALUE_AFTER
+	union hyperx_led_mode_packet led_mode = {
+		.led_mode_cmd = HYPERX_CONDIG_LED_MODE,
+		.bytes_after = HYPERX_BYTES_AFTER_LED_MODE,
+		.led_mode_value_before = HYPERX_LED_MODE_VALUE_BEFORE,
+		.led_mode = HYPERX_LED_MODE_SOLID,
+		.led_mode_value_after = HYPERX_LED_MODE_VALUE_AFTER
 	};
 
-	int rc = hyperx_write(device, led_mode);
+	int rc = hyperx_write(device, led_mode.data);
 	if (rc < 0) return rc;
 
 	log_debug(device->ratbag, "Changed led successfully\n");

--- a/src/driver-hyperx.c
+++ b/src/driver-hyperx.c
@@ -703,7 +703,8 @@ hyperx_probe(struct ratbag_device *device)
 	assert(device_data->dpi_range != NULL && "Invalid/missing value for DpiRange in device file");
 	assert(device_data->rates != NULL     && "Invalid/missing value for ReportRates in device file");
 	assert(device_data->button_count > 0  && "Invalid/missing value for Buttons in device file");
-	assert(device_data->dpi_count > 0     && "Invalid/missing value for Buttons in device file");
+	assert(device_data->dpi_count > 0     && "Invalid/missing value for Dpis in device file");
+	assert(device_data->led_count >= 0    && "Invalid/missing value for Leds in device file");
 
 	int rc = ratbag_open_hidraw(device);
 	if (rc) return rc;

--- a/src/driver-hyperx.h
+++ b/src/driver-hyperx.h
@@ -6,6 +6,8 @@ struct data_hyperx {
 	int profile_count;
 	int button_count;
 	int led_count;
+	size_t nrates;
+	unsigned int *rates;
 	int dpi_count;
 	int is_wireless;
 	struct dpi_range *dpi_range;

--- a/src/driver-hyperx.h
+++ b/src/driver-hyperx.h
@@ -308,18 +308,3 @@ struct hyperx_drv_data {
 	uint8_t selected_dpi_profile_index;
 	struct hyperx_device_settings_report device_settings;
 };
-
-struct data_hyperx {
-	int profile_count;
-	int button_count;
-	int led_count;
-	size_t nrates;
-	unsigned int *rates;
-	int dpi_count;
-	int is_wireless;
-	struct dpi_range *dpi_range;
-};
-
-const struct data_hyperx *
-ratbag_device_data_hyperx_get_data(const struct ratbag_device_data *data);
-

--- a/src/driver-hyperx.h
+++ b/src/driver-hyperx.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "libratbag-data.h"
+
+struct data_hyperx {
+	int profile_count;
+	int button_count;
+	int led_count;
+	int dpi_count;
+	int is_wireless;
+	struct dpi_range *dpi_range;
+};
+
+const struct data_hyperx *
+ratbag_device_data_hyperx_get_data(const struct ratbag_device_data *data);

--- a/src/driver-hyperx.h
+++ b/src/driver-hyperx.h
@@ -2,6 +2,313 @@
 
 #include "libratbag-data.h"
 
+
+#define HYPERX_USAGE_PAGE 0xff00
+#define HYPERX_PACKET_SIZE 64
+
+#define HYPERX_LED_PACKET_COUNT 6
+#define	HYPERX_DPI_STEP 100
+#define HYPERX_DPI_COUNT 5
+
+// Magic numbers, no clue what these mean
+#define HYPERX_LED_MODE_VALUE_BEFORE 0x55
+#define HYPERX_LED_MODE_VALUE_AFTER 0x23
+
+#define HYPERX_ACTION_DPI_TOGGLE 8
+
+#define HYPERX_MAX_MACRO_EVENTS 80
+#define HYPERX_MAX_MACRO_PACKETS 14
+#define HYPERX_MACRO_EVENT_MAX_KEYS 6
+#define HYPERX_MACRO_EVENT_DEFAULT_DELAY htole16(20)
+
+// Max number of events in a macro data packet
+#define HYPERX_MACRO_DATA_MAX_EVENTS 6
+
+#define hyperx_is_dpi_profile_enabled(profile_bitmask, n) ((profile_bitmask) & (1 << (n)))
+#define hyperx_brightness_value(x) ((int) ((x / 255.0) * 100))
+
+/**
+ * Every macro data packet seems to have a sum byte? after the button byte that alternates between adding 1 and 2 each packet.
+ * Another way of thinking about it is half of the numbers in the sum are 1 and half are 2.
+ *
+ * Thus, we get the following formula: (1x / 2) + (2x / 2). Which is simplified to 3x / 2. Note that this is int division, so there would be no fractional part.
+ *
+ * For example, the sum bytes for 6 packets would be: 0x00, 0x01, 0x03, 0x04, 0x06, 0x07
+ */
+#define HYPERX_MACRO_PACKET_SUM(x) ((3*(x)) / 2)
+
+/**
+ * The event count byte in odd indexed macro data packets have 0x80 added to it.
+ * For example, a packet with 2 events would be 0x02 if it was even, and 0x82 if it was odd.
+ */
+#define HYPERX_MACRO_PACKET_EVENT_COUNT(x) (((x) % 2) * 0x80)
+
+#define	HYPERX_BYTES_AFTER_MACRO_ASSIGNMENT (5)
+#define	HYPERX_BYTES_AFTER_LED_MODE (3)
+
+#define _Static_assert_bytes_after(expr) _Static_assert(expr, "Incorrect value for 'bytes_after'")
+#define _Static_assert_enum_size(enum_name) _Static_assert(sizeof(enum enum_name) == 1, \
+		"Incorrect size for '" #enum_name "''")
+
+enum hyperx_config_value {
+	HYPERX_CONFIG_POLLING_RATE              = 0xd0,
+	HYPERX_CONFIG_LED_EFFECT                = 0xda,
+	HYPERX_CONFIG_LED_MODE                  = 0xd9,
+	HYPERX_CONFIG_DPI                       = 0xd3,
+	HYPERX_CONFIG_BUTTON_ASSIGNMENT         = 0xd4,
+	HYPERX_CONFIG_MACRO_ASSIGNMENT          = 0xd5,
+	HYPERX_CONFIG_MACRO_DATA                = 0xd6,
+
+	HYPERX_CONFIG_SAVE_SETTINGS             = 0xde
+} __attribute((packed));
+
+_Static_assert_enum_size(hyperx_config_value);
+
+enum hyperx_report_value {
+	HYPERX_REPORT_DEVICE_INFO = 0x50,
+	HYPERX_RPEORT_DPI_SETTINGS = 0x53
+} __attribute((packed));
+
+_Static_assert_enum_size(hyperx_report_value);
+
+enum hyperx_report_device_info_type {
+	HYPERX_REPORT_DEVICE_INFO_HARDWARE = 0x00,
+	HYPERX_REPORT_DEVICE_INFO_SETTINGS = 0x03
+} __attribute((packed));
+
+_Static_assert_enum_size(hyperx_report_device_info_type);
+
+enum hyperx_save_type {
+	HYPERX_SAVE_TYPE_ALL                    = 0xff,
+	HYPERX_SAVE_TYPE_DPI_PROFILES           = 0x03
+} __attribute((packed));
+
+_Static_assert_enum_size(hyperx_save_type);
+
+enum hyperx_dpi_config {
+	HYPERX_DPI_CONFIG_SELECTED_PROFILE	= 0x00,
+	HYPERX_DPI_CONFIG_ENABLED_PROFILES	= 0x01,
+	HYPERX_DPI_CONFIG_DPI_VALUE         = 0x02,
+} __attribute((packed));
+
+_Static_assert_enum_size(hyperx_dpi_config);
+
+enum hyperx_led_mode {
+	HYPERX_LED_MODE_SOLID = 0x01
+} __attribute((packed));
+
+_Static_assert_enum_size(hyperx_led_mode);
+
+enum hyperx_action_type {
+	HYPERX_ACTION_TYPE_DISABLED,
+	HYPERX_ACTION_TYPE_MOUSE,
+	HYPERX_ACTION_TYPE_KEY,
+	HYPERX_ACTION_TYPE_MEDIA,
+	HYPERX_ACTION_TYPE_MACRO,
+	HYPERX_ACTION_TYPE_SHORTCUT,
+	HYPERX_ACTION_TYPE_DPI_TOGGLE = 0x07,
+	HYPERX_ACTION_TYPE_INVALID
+} __attribute((packed));
+
+_Static_assert_enum_size(hyperx_action_type);
+
+enum hyperx_macro_event_type {
+	HYPERX_MACRO_EVENT_TYPE_KEY = 0x1a
+} __attribute((packed));
+
+_Static_assert_enum_size(hyperx_macro_event_type);
+
+union hyperx_polling_rate_packet {
+	struct {
+		enum hyperx_config_value polling_rate_cmd;
+		uint8_t _padding[2];
+		uint8_t bytes_after;
+		uint8_t rate_index;
+	} __attribute((packed));
+
+	uint8_t data[HYPERX_PACKET_SIZE];
+};
+
+struct hyperx_color {
+	uint8_t red;
+	uint8_t green;
+	uint8_t blue;
+} __attribute((packed));
+
+union hyperx_led_packet {
+	struct {
+		enum hyperx_config_value led_cmd;
+		uint8_t led_mode;
+		uint8_t packet_number;
+		uint8_t bytes_after;
+		struct hyperx_color colors[20];
+	};
+
+	uint8_t data[HYPERX_PACKET_SIZE];
+};
+
+union hyperx_led_mode_packet {
+	struct {
+		enum hyperx_config_value led_mode_cmd;
+		uint8_t _padding[2];
+		uint8_t bytes_after;
+		uint8_t led_mode_value_before;
+		enum hyperx_led_mode led_mode;
+		uint8_t led_mode_value_after;
+	};
+
+	uint8_t data[HYPERX_PACKET_SIZE];
+} __attribute((packed));
+
+union hyperx_dpi_profile_packet {
+	struct {
+		enum hyperx_config_value dpi_cmd;
+		enum hyperx_dpi_config value_type;
+		uint8_t dpi_profile_index;
+		uint8_t bytes_after;
+		uint16_t dpi_step_value;
+	};
+
+	uint8_t data[HYPERX_PACKET_SIZE];
+} __attribute((packed));
+
+union hyperx_dpi_config_packet {
+	struct {
+		enum hyperx_config_value dpi_cmd;
+		enum hyperx_dpi_config config_type;
+		uint8_t _padding[1];
+		uint8_t bytes_after;
+		union {
+			uint8_t enabled_dpi_profiles;
+			uint8_t selected_profile;
+		};
+	};
+
+	uint8_t data[HYPERX_PACKET_SIZE];
+};
+
+struct hyperx_action {
+	enum hyperx_action_type type;
+	uint8_t action;
+	uint8_t button_index;
+	struct ratbag_macro *macro;
+};
+
+union hyperx_button_packet {
+	struct {
+		enum hyperx_config_value button_cmd;
+		uint8_t button;
+		uint8_t action_type;
+		uint8_t bytes_after;
+		uint8_t action;
+		uint8_t unknown;
+	};
+
+	uint8_t data[HYPERX_PACKET_SIZE];
+};
+
+struct hyperx_macro_event {
+	enum hyperx_macro_event_type event_type;
+	uint8_t modifier;
+	uint8_t keys[HYPERX_MACRO_EVENT_MAX_KEYS];
+	uint16_t delay_next_event;
+} __attribute__((packed));
+
+union hyperx_macro_data_packet {
+	struct {
+		enum hyperx_config_value macro_data_cmd;
+		uint8_t button_index;
+		uint8_t sum_value;
+		uint8_t event_count;
+		struct hyperx_macro_event events[HYPERX_MACRO_DATA_MAX_EVENTS];
+	};
+
+	uint8_t data[HYPERX_PACKET_SIZE];
+};
+
+struct hyperx_macro {
+	int event_count;
+	union hyperx_macro_data_packet macro_packets[HYPERX_MAX_MACRO_PACKETS];
+};
+
+union hyperx_macro_assigment_packet {
+	struct {
+		enum hyperx_config_value macro_assign_cmd;
+		uint8_t button;
+		uint8_t _padding[1];
+		uint8_t bytes_after;
+		uint8_t event_count;
+	};
+
+	uint8_t data[HYPERX_PACKET_SIZE];
+};
+
+union hyperx_save_settings_packet {
+	struct {
+		enum hyperx_config_value save_settings_cmd;
+		enum hyperx_save_type save_type;
+	};
+
+	uint8_t data[HYPERX_PACKET_SIZE];
+};
+
+struct hyperx_report_button_action {
+	enum hyperx_action_type type;
+	uint8_t action;
+	uint8_t _padding[1];
+};
+
+struct hyperx_input_report {
+	// Should be set to data[0]
+	uint8_t report_value;
+	uint8_t data[HYPERX_PACKET_SIZE];
+};
+
+struct hyperx_device_settings_report {
+	uint8_t _report_value;
+
+	union {
+		struct {
+			enum hyperx_report_value info_report_value;
+			enum hyperx_report_device_info_type info_type;
+			uint8_t _padding[8];
+			uint8_t settings_data[HYPERX_PACKET_SIZE - 10];
+		};
+
+		uint8_t data[HYPERX_PACKET_SIZE];
+	};
+
+	// Each member should be assigned to offsets in settings_data
+	// corresponding to their order and size
+	struct {
+		uint16_t *dpi_step_values; // Array length = dpi count
+		struct hyperx_color *dpi_indicator_colors; // Array length = dpi count
+		struct hyperx_report_button_action *button_actions; // Array length = button count
+		uint8_t *polling_rate_index;
+	};
+};
+
+struct hyperx_dpi_settings_report {
+	uint8_t _report_value;
+
+	union {
+		struct {
+			enum hyperx_report_value dpi_settings_report_value;
+			uint8_t _padding[3];
+			uint8_t selected_dpi_profile_index;
+			uint8_t enabled_dpi_profiles;
+		};
+
+		uint8_t data[HYPERX_PACKET_SIZE];
+	};
+};
+
+struct hyperx_drv_data {
+	uint8_t enabled_dpi_profiles; // A 5-bit little-endian number, where the nth bit corresponds to profile n
+	uint8_t selected_dpi_profile_index;
+	struct hyperx_device_settings_report device_settings;
+};
+
 struct data_hyperx {
 	int profile_count;
 	int button_count;
@@ -15,3 +322,4 @@ struct data_hyperx {
 
 const struct data_hyperx *
 ratbag_device_data_hyperx_get_data(const struct ratbag_device_data *data);
+

--- a/src/libratbag-data.c
+++ b/src/libratbag-data.c
@@ -504,6 +504,14 @@ init_data_hyperx(struct ratbag *ratbag,
 		data->hyperx.led_count = leds;
 	g_clear_error(&error);
 
+	size_t nrates;
+	int *rates = g_key_file_get_integer_list(keyfile, group, "ReportRates", &nrates, &error);
+	if (!error && nrates > 0) {
+		data->hyperx.nrates = nrates;
+		data->hyperx.rates = (unsigned int*) rates;
+	}
+	g_clear_error(&error);
+
 	int dpis = g_key_file_get_integer(keyfile, group, "Dpis", &error);
 	if (!error && dpis >= 0)
 		data->hyperx.dpi_count = dpis;
@@ -597,6 +605,7 @@ ratbag_device_data_destroy(struct ratbag_device_data *data)
 		break;
 	case HYPERX:
 		free(data->hyperx.dpi_range);
+		free(data->hyperx.rates);
 		break;
 	default:
 		break;

--- a/src/libratbag-data.c
+++ b/src/libratbag-data.c
@@ -33,6 +33,7 @@
 #include "asus.h"
 #include "driver-sinowealth.h"
 #include "driver-steelseries.h"
+#include "driver-hyperx.h"
 #include "libratbag.h"
 #include "libratbag-private.h"
 #include "libratbag-data.h"
@@ -124,6 +125,7 @@ struct ratbag_device_data {
 		struct data_sinowealth sinowealth;
 		struct data_steelseries steelseries;
 		struct data_asus asus;
+		struct data_hyperx hyperx;
 	};
 };
 
@@ -473,6 +475,51 @@ init_data_asus(struct ratbag *ratbag,
 	g_clear_error(&error);
 }
 
+static void
+init_data_hyperx(struct ratbag *ratbag,
+		GKeyFile *keyfile,
+		struct ratbag_device_data *data)
+{
+	const char *group = "Driver/hyperx";
+	GError *error = NULL;
+
+	data->hyperx.profile_count = -1;
+	data->hyperx.button_count = -1;
+	data->hyperx.led_count = -1;
+	data->hyperx.dpi_count = -1;
+	data->hyperx.is_wireless = -1;
+
+	int profiles = g_key_file_get_integer(keyfile, group, "Profiles", &error);
+	if (!error && profiles > 0)
+		data->hyperx.profile_count = profiles;
+	g_clear_error(&error);
+
+	int buttons = g_key_file_get_integer(keyfile, group, "Buttons", &error);
+	if (!error && buttons > 0)
+		data->hyperx.button_count = buttons;
+	g_clear_error(&error);
+
+	int leds = g_key_file_get_integer(keyfile, group, "Leds", &error);
+	if (!error && leds >= 0)
+		data->hyperx.led_count = leds;
+	g_clear_error(&error);
+
+	int dpis = g_key_file_get_integer(keyfile, group, "Dpis", &error);
+	if (!error && dpis >= 0)
+		data->hyperx.dpi_count = dpis;
+	g_clear_error(&error);
+
+	_cleanup_(freep) char *dpi_range = g_key_file_get_string(keyfile, group, "DpiRange", &error);
+	if (!error && dpi_range)
+		data->hyperx.dpi_range = dpi_range_from_string(dpi_range);
+	g_clear_error(&error);
+
+	int wireless = g_key_file_get_integer(keyfile, group, "Wireless", &error);
+	if (!error && (wireless == 0 || wireless == 1))
+		data->hyperx.is_wireless = wireless;
+	g_clear_error(&error);
+}
+
 static const struct driver_map {
 	enum driver map;
 	const char *driver;
@@ -495,7 +542,7 @@ static const struct driver_map {
 	{ SINOWEALTH_NUBWO, "sinowealth_nubwo", NULL},
 	{ OPENINPUT, "openinput", NULL },
 	{ MARSGAMING, "marsgaming", NULL },
-	{ HYPERX, "hyperx", NULL },
+	{ HYPERX, "hyperx", init_data_hyperx },
 };
 
 const char *
@@ -547,6 +594,9 @@ ratbag_device_data_destroy(struct ratbag_device_data *data)
 	case STEELSERIES:
 		dpi_list_free(data->steelseries.dpi_list);
 		free(data->steelseries.dpi_range);
+		break;
+	case HYPERX:
+		free(data->hyperx.dpi_range);
 		break;
 	default:
 		break;
@@ -969,4 +1019,13 @@ ratbag_device_data_asus_get_quirks(const struct ratbag_device_data *data)
 {
 	assert(data->drivertype == ASUS);
 	return data->asus.quirks;
+}
+
+/* HyperX */
+
+const struct data_hyperx *
+ratbag_device_data_hyperx_get_data(const struct ratbag_device_data *data)
+{
+	assert(data->drivertype == HYPERX);
+	return &data->hyperx;
 }

--- a/src/libratbag-data.c
+++ b/src/libratbag-data.c
@@ -483,11 +483,11 @@ init_data_hyperx(struct ratbag *ratbag,
 	const char *group = "Driver/hyperx";
 	GError *error = NULL;
 
-	data->hyperx.profile_count = -1;
+	data->hyperx.profile_count = 1;
 	data->hyperx.button_count = -1;
 	data->hyperx.led_count = -1;
 	data->hyperx.dpi_count = -1;
-	data->hyperx.is_wireless = -1;
+	data->hyperx.is_wireless = 0;
 
 	int profiles = g_key_file_get_integer(keyfile, group, "Profiles", &error);
 	if (!error && profiles > 0)
@@ -513,7 +513,7 @@ init_data_hyperx(struct ratbag *ratbag,
 	g_clear_error(&error);
 
 	int dpis = g_key_file_get_integer(keyfile, group, "Dpis", &error);
-	if (!error && dpis >= 0)
+	if (!error && dpis > 0)
 		data->hyperx.dpi_count = dpis;
 	g_clear_error(&error);
 
@@ -523,7 +523,7 @@ init_data_hyperx(struct ratbag *ratbag,
 	g_clear_error(&error);
 
 	int wireless = g_key_file_get_integer(keyfile, group, "Wireless", &error);
-	if (!error && (wireless == 0 || wireless == 1))
+	if (!error && wireless == 1)
 		data->hyperx.is_wireless = wireless;
 	g_clear_error(&error);
 }

--- a/src/libratbag-data.c
+++ b/src/libratbag-data.c
@@ -33,7 +33,6 @@
 #include "asus.h"
 #include "driver-sinowealth.h"
 #include "driver-steelseries.h"
-#include "driver-hyperx.h"
 #include "libratbag.h"
 #include "libratbag-private.h"
 #include "libratbag-data.h"

--- a/src/libratbag-data.c
+++ b/src/libratbag-data.c
@@ -504,6 +504,9 @@ init_data_hyperx(struct ratbag *ratbag,
 		data->hyperx.led_count = leds;
 	g_clear_error(&error);
 
+	// We can't read onboard led settings, so we disable led config (for the time being)
+	data->hyperx.led_count = 0;
+
 	size_t nrates;
 	int *rates = g_key_file_get_integer_list(keyfile, group, "ReportRates", &nrates, &error);
 	if (!error && nrates > 0) {

--- a/src/libratbag-data.c
+++ b/src/libratbag-data.c
@@ -63,6 +63,7 @@ enum driver {
 	SINOWEALTH_NUBWO,
 	OPENINPUT,
 	MARSGAMING,
+	HYPERX,
 };
 
 struct data_hidpp20 {
@@ -494,6 +495,7 @@ static const struct driver_map {
 	{ SINOWEALTH_NUBWO, "sinowealth_nubwo", NULL},
 	{ OPENINPUT, "openinput", NULL },
 	{ MARSGAMING, "marsgaming", NULL },
+	{ HYPERX, "hyperx", NULL },
 };
 
 const char *

--- a/src/libratbag-data.h
+++ b/src/libratbag-data.h
@@ -193,3 +193,20 @@ ratbag_device_data_asus_is_wireless(const struct ratbag_device_data *data);
  */
 uint32_t
 ratbag_device_data_asus_get_quirks(const struct ratbag_device_data *data);
+
+struct data_hyperx {
+	int profile_count;
+	int button_count;
+	int led_count;
+	size_t nrates;
+	unsigned int *rates;
+	int dpi_count;
+	int is_wireless;
+	struct dpi_range *dpi_range;
+};
+
+/**
+ * @return HyperX device data
+ */
+const struct data_hyperx *
+ratbag_device_data_hyperx_get_data(const struct ratbag_device_data *data);

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -598,6 +598,7 @@ extern struct ratbag_driver asus_driver;
 extern struct ratbag_driver sinowealth_driver;
 extern struct ratbag_driver sinowealth_nubwo_driver;
 extern struct ratbag_driver openinput_driver;
+extern struct ratbag_driver hyperx_driver;
 
 struct ratbag_device*
 ratbag_device_new(struct ratbag *ratbag, struct udev_device *udev_device,

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -581,6 +581,7 @@ ratbag_create_context(const struct ratbag_interface *interface,
 	ratbag_register_driver(ratbag, &sinowealth_driver);
 	ratbag_register_driver(ratbag, &sinowealth_nubwo_driver);
 	ratbag_register_driver(ratbag, &openinput_driver);
+	ratbag_register_driver(ratbag, &hyperx_driver);
 
 	return ratbag;
 }

--- a/test/data-parse-test.py
+++ b/test/data-parse-test.py
@@ -258,6 +258,26 @@ def check_section_steelseries(section: configparser.SectionProxy):
         # No such section - not an error.
         pass
 
+def check_section_hyperx(section: configparser.SectionProxy):
+    permitted_keys = (
+        "Profiles",
+        "Buttons",
+        "Leds",
+        "ReportRates",
+        "Dpis",
+        "DpiRange",
+        "Wireless"
+    )
+
+    for key in section:
+        assert key in permitted_keys
+
+    try:
+        check_dpi_range_str(section["DpiRange"])
+    except KeyError:
+        # No such section - not an error.
+        pass
+
 
 def check_section_driver(driver: str, section: configparser.SectionProxy):
     if driver == "asus":
@@ -274,6 +294,10 @@ def check_section_driver(driver: str, section: configparser.SectionProxy):
 
     if driver == "steelseries":
         check_section_steelseries(section)
+        return
+
+    if driver == "hyperx":
+        check_section_hyperx(section)
         return
 
     raise ValueError(f"Unsupported driver section {driver}")


### PR DESCRIPTION
This pull request adds support for the HyperX Pulsefire Haste mouse. Currently, the driver supports changing dpi, polling rate, and button assignments.<br>
However, there are some limitations, which can be categorized by firmware and libratbag.

Firmware limitations (AFAIK):
- LED settings cannot be read from the mouse
- Macros cannot be read from the mouse

Libratbag limitations:
- DPI profile indicators cannot changed
- Media and shortcut actions cannot be assigned, since they can't be represented as an action
- Lift-off distance cannot be set
- Macros cannot contain mouse events

Since we can't import and export profiles, LED config wouldn't be feasible, and macros are currently write only.<br>
For more information about the protocol see [https://github.com/evan-razzaque/open-pulsefire-haste/tree/main/protocol](https://github.com/evan-razzaque/open-pulsefire-haste/tree/main/protocol).

Resolves #1782 and potentially resolves #1778 if the protocol is similar enough.
