### PR TITLE
Feature: Add support for ASUS Omni wireless receiver device

### DIFF
--- a/data/devices/asus-rog-omni-receiver.device
+++ b/data/devices/asus-rog-omni-receiver.device
@@ -1,0 +1,17 @@
+[Device]
+Name=ASUS ROG OMNI Receiver
+DeviceMatch=usb:0b05:1ace
+DeviceType=mouse
+Driver=asus
+
+# This is a generic configuration for the ASUS Omni wireless receiver
+# The actual device name will be identified during probe
+
+[Driver/asus]
+Profiles=5
+Buttons=8
+Leds=3
+Dpis=4
+Wireless=1
+DpiRange=100:36000@100
+Quirks=OMNI_RECEIVER;RAW_BRIGHTNESS

--- a/src/asus.c
+++ b/src/asus.c
@@ -141,13 +141,13 @@ asus_query(struct ratbag_device *device,
 	int rc;
 	uint32_t quirks = ratbag_device_data_asus_get_quirks(device->data);
 	uint8_t omni_tx_buf[ASUS_PACKET_SIZE];
-    	uint8_t omni_rx_buf[ASUS_PACKET_SIZE];
+	uint8_t omni_rx_buf[ASUS_PACKET_SIZE];
 
 	if (quirks & ASUS_QUIRK_OMNI_RECEIVER) {
 		memset(omni_tx_buf, 0, ASUS_PACKET_SIZE);
-        omni_tx_buf[0] = 0x03;
-       		memcpy(omni_tx_buf + 1, request->raw, ASUS_PACKET_SIZE - 1);
-        	rc = ratbag_hidraw_output_report(device, omni_tx_buf, ASUS_PACKET_SIZE);
+	omni_tx_buf[0] = 0x03;
+		memcpy(omni_tx_buf + 1, request->raw, ASUS_PACKET_SIZE - 1);
+		rc = ratbag_hidraw_output_report(device, omni_tx_buf, ASUS_PACKET_SIZE);
 	} else {
 		rc = ratbag_hidraw_output_report(device, request->raw, ASUS_PACKET_SIZE);
 	}
@@ -158,9 +158,9 @@ asus_query(struct ratbag_device *device,
 
 	if (quirks & ASUS_QUIRK_OMNI_RECEIVER) {
 		rc = ratbag_hidraw_read_input_report(device, omni_rx_buf, ASUS_PACKET_SIZE, NULL);
-        	if (rc >= 0) {
-            	memcpy(response->raw, omni_rx_buf + 1, ASUS_PACKET_SIZE - 1);
-        	}
+		if (rc >= 0) {
+		memcpy(response->raw, omni_rx_buf + 1, ASUS_PACKET_SIZE - 1);
+		}
 	} else {
 		rc = ratbag_hidraw_read_input_report(device, response->raw, ASUS_PACKET_SIZE, NULL);
 		if (rc < 0)

--- a/src/asus.c
+++ b/src/asus.c
@@ -564,13 +564,6 @@ asus_omni_identify_mouse(struct ratbag_device *device)
 	char signature[13] = {0};
 	memcpy(signature, &omni_rx_buf[5], 12);
 
-	log_debug(device->ratbag, "Omni mouse signature: '%s' (hex: %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x)\n",
-		  signature,
-		  omni_rx_buf[5], omni_rx_buf[6], omni_rx_buf[7],
-		  omni_rx_buf[8], omni_rx_buf[9], omni_rx_buf[10],
-		  omni_rx_buf[11], omni_rx_buf[12], omni_rx_buf[13],
-		  omni_rx_buf[14], omni_rx_buf[15], omni_rx_buf[16]);
-
 	/* Match device name based on signature prefix */
 	const char *device_name = NULL;
 
@@ -635,8 +628,6 @@ asus_omni_identify_mouse(struct ratbag_device *device)
 		/* Default fallback - could not identify specific model */
 		device_name = "Unknown ASUS Omni Device";
 	}
-
-	log_debug(device->ratbag, "Omni receiver identified device: %s\n", device_name);
 
 	return strdup(device_name);
 }

--- a/src/asus.c
+++ b/src/asus.c
@@ -26,6 +26,7 @@
 #include "asus.h"
 
 #include <assert.h>
+#include <string.h>
 
 #include "libratbag-data.h"
 #include "libratbag-private.h"
@@ -138,15 +139,33 @@ asus_query(struct ratbag_device *device,
 		union asus_request *request, union asus_response *response)
 {
 	int rc;
+	uint32_t quirks = ratbag_device_data_asus_get_quirks(device->data);
+	uint8_t omni_tx_buf[ASUS_PACKET_SIZE];
+    	uint8_t omni_rx_buf[ASUS_PACKET_SIZE];
 
-	rc = ratbag_hidraw_output_report(device, request->raw, ASUS_PACKET_SIZE);
+	if (quirks & ASUS_QUIRK_OMNI_RECEIVER) {
+		memset(omni_tx_buf, 0, ASUS_PACKET_SIZE);
+        omni_tx_buf[0] = 0x03;
+       		memcpy(omni_tx_buf + 1, request->raw, ASUS_PACKET_SIZE - 1);
+        	rc = ratbag_hidraw_output_report(device, omni_tx_buf, ASUS_PACKET_SIZE);
+	} else {
+		rc = ratbag_hidraw_output_report(device, request->raw, ASUS_PACKET_SIZE);
+	}
 	if (rc < 0)
 		return rc;
 
 	memset(response, 0, sizeof(union asus_response));
-	rc = ratbag_hidraw_read_input_report(device, response->raw, ASUS_PACKET_SIZE, NULL);
-	if (rc < 0)
-		return rc;
+
+	if (quirks & ASUS_QUIRK_OMNI_RECEIVER) {
+		rc = ratbag_hidraw_read_input_report(device, omni_rx_buf, ASUS_PACKET_SIZE, NULL);
+        	if (rc >= 0) {
+            	memcpy(response->raw, omni_rx_buf + 1, ASUS_PACKET_SIZE - 1);
+        	}
+	} else {
+		rc = ratbag_hidraw_read_input_report(device, response->raw, ASUS_PACKET_SIZE, NULL);
+		if (rc < 0)
+			return rc;
+	}
 
 	/* invalid state, disconnected or sleeping */
 	if (response->data.code == ASUS_STATUS_ERROR) {
@@ -510,4 +529,114 @@ asus_set_led(struct ratbag_device *device,
 		return rc;
 
 	return 0;
+}
+
+/* identify omni */
+char *
+asus_omni_identify_mouse(struct ratbag_device *device)
+{
+	/* Omni signature query must be done directly with output/input reports
+	 * Not through the standard asus_query() function.
+	 * Format: 03 12 12 02 (report_id, then three command bytes) */
+	uint8_t omni_tx_buf[ASUS_PACKET_SIZE];
+	uint8_t omni_rx_buf[ASUS_PACKET_SIZE];
+	int rc;
+
+	memset(omni_tx_buf, 0, ASUS_PACKET_SIZE);
+	omni_tx_buf[0] = 0x03;  /* report ID */
+	omni_tx_buf[1] = 0x12;  /* command byte 1 */
+	omni_tx_buf[2] = 0x12;  /* command byte 2 */
+	omni_tx_buf[3] = 0x02;  /* parameter */
+
+	rc = ratbag_hidraw_output_report(device, omni_tx_buf, ASUS_PACKET_SIZE);
+	if (rc < 0) {
+		log_error(device->ratbag, "Failed to send Omni signature query (rc=%d)\n", rc);
+		return NULL;
+	}
+
+	rc = ratbag_hidraw_read_input_report(device, omni_rx_buf, ASUS_PACKET_SIZE, NULL);
+	if (rc < 0) {
+		log_error(device->ratbag, "Failed to read Omni signature response (rc=%d)\n", rc);
+		return NULL;
+	}
+
+	/* Extract signature from response (offset 5, 12 bytes) */
+	char signature[13] = {0};
+	memcpy(signature, &omni_rx_buf[5], 12);
+
+	log_debug(device->ratbag, "Omni mouse signature: '%s' (hex: %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x)\n",
+		  signature,
+		  omni_rx_buf[5], omni_rx_buf[6], omni_rx_buf[7],
+		  omni_rx_buf[8], omni_rx_buf[9], omni_rx_buf[10],
+		  omni_rx_buf[11], omni_rx_buf[12], omni_rx_buf[13],
+		  omni_rx_buf[14], omni_rx_buf[15], omni_rx_buf[16]);
+
+	/* Match device name based on signature prefix */
+	const char *device_name = NULL;
+
+	if (strncmp(signature, "B23", 3) == 0) {
+		/* B23072800062 */
+		device_name = "ASUS ROG Harpe Ace Aim Lab Edition";
+	} else if (strncmp(signature, "B241", 4) == 0) {
+		/* B24122666771 */
+		device_name = "ASUS ROG Harpe Ace Aim Lab Edition";
+	} else if (strncmp(signature, "B2501", 5) == 0) {
+		/* B25010476524 */
+		device_name = "ASUS ROG Harpe Ace Aim Lab Edition";
+	} else if (strncmp(signature, "B24", 3) == 0) {
+		/* B24082550833 */
+		device_name = "ASUS ROG Harpe Ace Mini";
+	} else if (strncmp(signature, "B25", 3) == 0) {
+		/* B25030817186 */
+		device_name = "ASUS ROG Harpe Ace Mini";
+	} else if (strncmp(signature, "R1", 2) == 0) {
+		/* R13121351391 */
+		device_name = "ASUS ROG Keris Wireless Aimpoint";
+	} else if (strncmp(signature, "F24", 3) == 0) {
+		/* F24B21DD03F4 */
+		device_name = "ASUS ROG Keris Wireless Aimpoint";
+	} else if (strncmp(signature, "FB", 2) == 0) {
+		/* FBA0CC1D6F9C */
+		device_name = "ASUS ROG Keris Wireless Aimpoint";
+	} else if (strncmp(signature, "024", 3) == 0) {
+		/* 024031316969 */
+		device_name = "ASUS ROG Keris Ace II";
+	} else if (strncmp(signature, "02501", 5) == 0) {
+		/* 0250105027981 */
+		device_name = "ASUS ROG Keris Ace II";
+	} else if (strncmp(signature, "025", 3) == 0) {
+		/* 025050613700 */
+		device_name = "ASUS ROG Keris II Origin";
+	} else if (strncmp(signature, "20", 2) == 0) {
+		/* 202405290700 */
+		device_name = "ASUS ROG Strix Impact III Wireless";
+	} else if (strncmp(signature, "R8", 2) == 0) {
+		/* R82020155689 */
+		device_name = "ASUS ROG Gladius III Aimpoint";
+	} else if (strncmp(signature, "R6", 2) == 0) {
+		/* R60120331787 */
+		device_name = "ASUS ROG Gladius III Aimpoint";
+	} else if (strncmp(signature, "RC", 2) == 0) {
+		/* RC1519430455 */
+		device_name = "ASUS ROG Gladius III Aimpoint";
+	} else if (strncmp(signature, "R903", 4) == 0) {
+		/* R90319215881 */
+		device_name = "ASUS ROG Gladius III Aimpoint";
+	} else if (strncmp(signature, "R923", 4) == 0) {
+		/* R92307410710 */
+		device_name = "ASUS ROG Gladius III Aimpoint";
+	} else if (strncmp(signature, "R9", 2) == 0) {
+		/* R90518300572 */
+		device_name = "ASUS ROG Keris Wireless Aimpoint";
+	} else if (strncmp(signature, "T5", 2) == 0) {
+		/* T5MPKR018406 */
+		device_name = "ASUS ROG Harpe Ace Extreme";
+	} else {
+		/* Default fallback - could not identify specific model */
+		device_name = "Unknown ASUS Omni Device";
+	}
+
+	log_debug(device->ratbag, "Omni receiver identified device: %s\n", device_name);
+
+	return strdup(device_name);
 }

--- a/src/asus.h
+++ b/src/asus.h
@@ -13,6 +13,7 @@
 #define ASUS_QUIRK_SEPARATE_XY_DPI 1 << 4
 #define ASUS_QUIRK_SEPARATE_LEDS 1 << 5
 #define ASUS_QUIRK_BUTTONS_SECONDARY 1 << 6
+#define ASUS_QUIRK_OMNI_RECEIVER 1 << 7
 
 #define ASUS_PACKET_SIZE 64
 #define ASUS_BUTTON_ACTION_TYPE_KEY 0  /* keyboard key */
@@ -270,3 +271,7 @@ int
 asus_set_led(struct ratbag_device *device,
 		uint8_t index, uint8_t mode, uint8_t brightness,
 		struct ratbag_color color);
+
+/* ASUS Omni Receiver */
+char *
+asus_omni_identify_mouse(struct ratbag_device *device);

--- a/src/driver-asus.c
+++ b/src/driver-asus.c
@@ -515,10 +515,25 @@ asus_driver_probe(struct ratbag_device *device)
 	struct ratbag_button *button;
 	struct ratbag_resolution *resolution;
 	struct ratbag_led *led;
+	uint32_t quirks = ratbag_device_data_asus_get_quirks(device->data);
+
 
 	rc = ratbag_open_hidraw(device);
 	if (rc)
 		return rc;
+
+
+	/* Identify actual mouse if using ASUS Omni receiver */
+	if (quirks & ASUS_QUIRK_OMNI_RECEIVER) {
+		char *actual_name = asus_omni_identify_mouse(device);
+		if (actual_name) {
+			free(device->name);
+			device->name = actual_name;
+			log_info(device->ratbag, "ASUS Omni receiver identified device: %s\n", device->name);
+		} else {
+			log_error(device->ratbag, "Failed to identify mouse on ASUS Omni receiver\n");
+		}
+	}
 
 	rc = asus_get_profile_data(device, &profile_data);
 	if (rc) {

--- a/src/libratbag-data.c
+++ b/src/libratbag-data.c
@@ -447,6 +447,8 @@ init_data_asus(struct ratbag *ratbag,
 				data->asus.quirks |= ASUS_QUIRK_SEPARATE_LEDS;
 			} else if (streq(quirks[i], "BUTTONS_SECONDARY")) {
 				data->asus.quirks |= ASUS_QUIRK_BUTTONS_SECONDARY;
+			} else if (streq(quirks[i], "OMNI_RECEIVER")) {
+				data->asus.quirks |= ASUS_QUIRK_OMNI_RECEIVER;
 			} else {
 				log_error(ratbag, "%s is invalid quirk. Ignoring...\n", quirks[i]);
 			}


### PR DESCRIPTION
## Description

This PR adds support for the ASUS Omni wireless receiver (VID:PID 0b05:1ace), 
a single USB dongle that supports multiple wireless mice models. The challenge 
is that all mice share the same USB identifier, making device identification 
impossible using VID:PID alone.

The solution implements dynamic device identification by querying a unique 
12-byte signature from each connected mouse during driver probe.

## Problem Statement

- ASUS Omni receiver creates a single USB device (0b05:1ace) for all mice
- Different mouse models need different driver configurations
- Without proper identification, all mice appear as generic "ASUS ROG OMNI RECEIVER"
- Users cannot configure device-specific features

## Solution

1. **Device Identification**: Query device signature via HID command (0x03 0x12 0x12 0x02)
2. **Signature Matching**: Map 12-byte signature to 10 known mouse models
3. **Dynamic Naming**: Replace generic name with actual device model during probe
4. **Unified Configuration**: Use generic config file with maximum values for all Omni mice

## Details

### New Quirk Flag
- `ASUS_QUIRK_OMNI_RECEIVER`: Special handling for Omni receiver protocol

### HID Protocol Handling
- Output reports: Prepend report ID 0x03 to command
- Input reports: Skip first byte (report ID) from response
- Signature location: Offset 5, 12 bytes (ASCII string)

### Supported Devices (10 models)
- ASUS ROG Harpe Ace Aim Lab Edition (B23*, B241*, B2501*) 
- ASUS ROG Harpe Ace Mini (B24*, B25*)
- ASUS ROG Harpe Ace Extreme (T5*)
- ASUS ROG Keris Wireless Aimpoint (R1*, F24*, FB*, R9*)
- ASUS ROG Keris Ace II (024*, 02501*)
- ASUS ROG Keris II Origin (025*) 
- ASUS ROG Strix Impact III Wireless (20*) 
- ASUS ROG Gladius III Aimpoint (R6*, R8*, RC*, R903*, R923*)

## Changes

### Code Changes
- `src/asus.h`: Add ASUS_QUIRK_OMNI_RECEIVER flag and function declaration
- `src/asus.c`: 
  - Modify `asus_query()` for Omni HID protocol
  - Implement `asus_omni_identify_mouse()` for signature matching
- `src/driver-asus.c`: Call identification in probe, update device name
- `src/libratbag-data.c`: Add quirk parsing

### Configuration
- `data/devices/asus-rog-omni-receiver.device`: Generic config for all Omni mice

### Tested Devices ✅
- **ASUS ROG Strix Impact III Wireless** (signature: 202405290700)
  - Device correctly identified with proper name
  - Configuration loaded successfully
  - All features functional

### Untested Devices ⚠️
The following 9 device models are **NOT YET TESTED**:
- ASUS ROG Harpe Ace Aim Lab Edition
- ASUS ROG Harpe Ace Mini
- ASUS ROG Harpe Ace Extreme
- ASUS ROG Keris Wireless Aimpoint
- ASUS ROG Keris Ace II
- ASUS ROG Keris II Origin
- ASUS ROG Gladius III Aimpoint

## Known Limitations

### Current Approach
Using a single generic configuration file for all devices but has trade-offs:
- ✅ Simple, maintainable single config file
- ✅ All devices supported immediately
- ⚠️ May expose unavailable features (e.g., 8 buttons when mouse has 6)
- ⚠️ Not ideal for device-specific configurations


## References

- Cross-referenced with [G-Helper](https://github.com/seerge/g-helper) implementation

## Breaking Changes

None. This is a backward-compatible addition that only affects Omni receiver devices.

## Related Issues

https://github.com/libratbag/libratbag/issues/1793
https://github.com/libratbag/libratbag/issues/1771

## Feedback Needed

- Device testing: Help from users with other Omni-compatible mice
- Configuration approach: Suggestions for per-device configuration implementation
- Feature detection: Any known differences in button/LED counts between models

---