### PR TITLE
data: add G502 X Wireless support via Lightspeed receiver

### DIFF
--- a/data/devices/logitech-g502-x-wireless.device
+++ b/data/devices/logitech-g502-x-wireless.device
@@ -1,5 +1,8 @@
 [Device]
 Name=Logitech G502 X Wireless
-DeviceMatch=usb:046d:c098
+DeviceMatch=usb:046d:c098;usb:046d:409f;usb:046d:c547
 DeviceType=mouse
 Driver=hidpp20
+
+[Driver/hidpp20]
+DeviceIndex=1


### PR DESCRIPTION
## Summary

- Adds support for the Logitech G502 X Wireless (Lightspeed) when connected via the c547 Lightspeed receiver
- Adds wireless PID `409f` to DeviceMatch
- Adds `DeviceIndex=1` to communicate with the mouse on the receiver

## Background

The c547 Lightspeed receiver doesn't expose paired devices as separate HID devices in the kernel - it only shows the receiver itself. This means libratbag needs to:
1. Match on the receiver ID (`c547`) 
2. Use `DeviceIndex=1` to communicate with the paired mouse rather than the receiver

This is similar to how `logitech-g-pro-wireless.device` handles the same situation.

## Test plan

- [x] Verified `ratbagctl list` detects the device
- [x] Verified `ratbagctl info` shows all 11 buttons, 5 profiles, and DPI settings
- [ ] Note: `test/receiver-check.py` will fail because c547 is a known receiver ID - this may need an exception added

## Device info

```
hooting-chinchilla - Logitech USB Receiver
             Model: usb:046d:c547:0
       Device Type: Mouse
 Number of Buttons: 11
    Number of Leds: 0
Number of Profiles: 5
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)