### PR TITLE
data: add Glorious Model O Eternal (usb:3794:a000)

### DIFF
--- a/data/devices/glorious-model-o-eternal.device
+++ b/data/devices/glorious-model-o-eternal.device
@@ -1,0 +1,11 @@
+[Device]
+Name=Glorious Model O Eternal
+DeviceMatch=usb:3794:a000
+Driver=sinowealth
+DeviceType=mouse
+
+[Driver/sinowealth/devices/1009]
+ButtonCount=6
+LedType=RGB
+DeviceName=Glorious Model O Eternal
+SensorType=PMW3360

--- a/data/devices/glorious-model-o-eternal.device
+++ b/data/devices/glorious-model-o-eternal.device
@@ -1,0 +1,11 @@
+[Device]
+Name=Glorious Model O Eternal
+DeviceMatch=usb:3794:a000
+Driver=sinowealth
+DeviceType=mouse
+
+[Driver/sinowealth/devices/1009]
+Buttons=6
+LedType=RBG
+DeviceName=Glorious Model O Eternal
+SensorType=PMW3360


### PR DESCRIPTION
Fixes https://github.com/libratbag/libratbag/issues/1796

<details>
So i got a glorious model o eternal today and had to spend a few hours messing around with this to get it to work. Its not perfect as ratbagctl lists it as SINOWELTH model o eternal instead of glorious model o eternal and i only just made it so there might be some issues but i mostly just want the next guy to buy this mouse and use it on linux to not have the headache i did.
</details>
