### PR TITLE
data: add Logitech G502 X Wireless through LS dongle (046d:409f)

### DIFF
--- a/data/devices/logitech-g502-x-wireless.device
+++ b/data/devices/logitech-g502-x-wireless.device
@@ -1,5 +1,5 @@
 [Device]
 Name=Logitech G502 X Wireless
-DeviceMatch=usb:046d:c098
+DeviceMatch=usb:046d:c098;usb:046d:409f
 DeviceType=mouse
 Driver=hidpp20


### PR DESCRIPTION
Added USB ID 046d:409f, this is the ID when connected through the LS dongle. USB ID 046d:c098 is the ID when wired. 