### PR TITLE
feature: Add support for ASUS TUF GAMING M4 AIR

### DIFF
--- a/data/devices/asus-tuf-gaming-m4-air.device
+++ b/data/devices/asus-tuf-gaming-m4-air.device
@@ -1,0 +1,12 @@
+[Device]
+Name=ASUS TUF GAMING M4 AIR
+DeviceMatch=usb:0b05:1a03
+DeviceType=mouse
+Driver=asus
+
+[Driver/asus]
+Profiles=3
+Buttons=6
+Leds=0
+Dpis=4
+DpiRange=100:16000@100


### PR DESCRIPTION
This commit adds support for the TUF GAMING M4 AIR mouse manufactured by ASUS/ASUSTek.