### PR TITLE
Add quirk for Logitech G733 to handle LED zone count

### DIFF
--- a/data/devices/logitech-g733.device
+++ b/data/devices/logitech-g733.device
@@ -6,3 +6,4 @@ Driver=hidpp20
 
 [Driver/hidpp20]
 Buttons=0
+Quirk=G733

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -112,6 +112,7 @@ hidpp20_get_quirk_string(enum hidpp20_quirk quirk)
 	CASE_RETURN_STRING(HIDPP20_QUIRK_G602);
 	CASE_RETURN_STRING(HIDPP20_QUIRK_G502X_PLUS);
 	CASE_RETURN_STRING(HIDPP20_QUIRK_INDEX_OFFSET);
+	CASE_RETURN_STRING(HIDPP20_QUIRK_G733);
 	}
 
 	abort();
@@ -2982,8 +2983,16 @@ hidpp20_onboard_profiles_write_profile(struct hidpp20_device *device,
 
 	rc = hidpp20_onboard_profiles_write_sector(device, sector, sector_size, data, true);
 	if (rc < 0) {
-		hidpp_log_error(&device->base, "failed to write profile\n");
-		return rc;
+		/* Some G733 firmware (USB ID 046d:0afe) returns ERR_LOGITECH_INTERNAL
+		 * for GET_INFO even though the hardware has 2 LED zones. Fall back to
+		 * probing the known zone count so LEDs are still exposed. */
+		if (device->quirk == HIDPP20_QUIRK_G733) {
+			hidpp_log_debug(&device->base,
+					"GET_INFO failed, using G733 hardcoded zone count of 2\n");
+			ledinfo.zone_count = 2;
+		} else {
+			return rc;
+		}
 	}
 
 	return 0;

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -948,8 +948,18 @@ hidpp20_color_led_effects_get_zone_infos(struct hidpp20_device *device,
 		return -ENOTSUP;
 
 	rc = hidpp20_color_led_effects_get_info(device, &ledinfo);
-	if (rc < 0)
-		return rc;
+	if (rc < 0) {
+		/* Some G733 firmware (USB ID 046d:0afe) returns ERR_LOGITECH_INTERNAL
+		 * for GET_INFO even though the hardware has 2 LED zones. Fall back to
+		 * a hardcoded zone count so LEDs are still exposed. */
+		if (device->quirk == HIDPP20_QUIRK_G733) {
+			hidpp_log_debug(&device->base,
+					"GET_INFO failed, using G733 hardcoded zone count of 2\n");
+			ledinfo.zone_count = 2;
+		} else {
+			return rc;
+		}
+	}
 
 	num_infos = ledinfo.zone_count;
 	if (num_infos == 0) {
@@ -2983,16 +2993,8 @@ hidpp20_onboard_profiles_write_profile(struct hidpp20_device *device,
 
 	rc = hidpp20_onboard_profiles_write_sector(device, sector, sector_size, data, true);
 	if (rc < 0) {
-		/* Some G733 firmware (USB ID 046d:0afe) returns ERR_LOGITECH_INTERNAL
-		 * for GET_INFO even though the hardware has 2 LED zones. Fall back to
-		 * probing the known zone count so LEDs are still exposed. */
-		if (device->quirk == HIDPP20_QUIRK_G733) {
-			hidpp_log_debug(&device->base,
-					"GET_INFO failed, using G733 hardcoded zone count of 2\n");
-			ledinfo.zone_count = 2;
-		} else {
-			return rc;
-		}
+		hidpp_log_error(&device->base, "failed to write profile\n");
+		return rc;
 	}
 
 	return 0;

--- a/src/hidpp20.h
+++ b/src/hidpp20.h
@@ -57,6 +57,7 @@ enum hidpp20_quirk {
 	HIDPP20_QUIRK_G602,
 	HIDPP20_QUIRK_G502X_PLUS, // G502X+ uses 2nd LED slot instead of 1st.
 	HIDPP20_QUIRK_INDEX_OFFSET, // Device returns 1-indexed profile, decrement by 1.
+	HIDPP20_QUIRK_G733, // Device returns ERR_LOGITECH_INTERNAL for GET_INFO even though the hardware has 2 LED zones.
 };
 
 struct hidpp20_device {

--- a/src/libratbag-data.c
+++ b/src/libratbag-data.c
@@ -229,6 +229,8 @@ init_data_hidpp20(struct ratbag *ratbag,
 			data->hidpp20.quirk = HIDPP20_QUIRK_G502X_PLUS;
 		else if(streq(str, "INDEX_OFFSET"))
 			data->hidpp20.quirk = HIDPP20_QUIRK_INDEX_OFFSET;
+		else if(streq(str, "G733"))
+			data->hidpp20.quirk = HIDPP20_QUIRK_G733;
 	}
 }
 


### PR DESCRIPTION
The G733 wired variant (USB ID `046d:0afe`) returns `ERR_LOGITECH_INTERNAL` when queried with `GET_INFO` (feature 0x8070, fn0), causing LED initialization to abort and exposing 0 LEDs despite the hardware having 2 RGB zones.

Added `HIDPP20_QUIRK_G733` which falls back to a hardcoded zone count of 2 when `GET_INFO` fails. Individual zone queries (`GET_ZONE_INFO`) succeed normally, so both LED zones are exposed and controllable. The fallback only activates on failure, leaving the wireless variant (046d:0ab5) unaffected.

Fixes the issue reported with `ratbagctl` info showing `Number of Leds: 0` on the G733 wired headset (see #1823).

Tested on my G733 by running the following and observing the colours change:
```
ratbagctl "bellowing-paca" led 0 set mode on color ff0000                                                         
ratbagctl "bellowing-paca" led 1 set mode on color 0000ff
```