### PR TITLE
Add lazy profile loading support

### DIFF
--- a/ratbagd/ratbagd-profile.c
+++ b/ratbagd/ratbagd-profile.c
@@ -62,6 +62,11 @@ struct ratbagd_profile {
 	struct ratbagd_led **leds;
 };
 
+static int ratbagd_profile_ensure_loaded(struct ratbagd_profile *profile)
+{
+	return ratbag_profile_load(profile->lib_profile);
+}
+
 static int ratbagd_profile_find_resolution(sd_bus *bus,
 					   const char *path,
 					   const char *interface,
@@ -73,6 +78,8 @@ static int ratbagd_profile_find_resolution(sd_bus *bus,
 	struct ratbagd_profile *profile = userdata;
 	unsigned int index = 0;
 	int r;
+
+	CHECK_CALL(ratbagd_profile_ensure_loaded(profile));
 
 	r = sd_bus_path_decode_many(path,
 				    RATBAGD_OBJ_ROOT "/resolution/%/p%/r%",
@@ -227,6 +234,8 @@ static int ratbagd_profile_find_button(sd_bus *bus,
 	unsigned int index = 0;
 	int r;
 
+	CHECK_CALL(ratbagd_profile_ensure_loaded(profile));
+
 	r = sd_bus_path_decode_many(path,
 				    RATBAGD_OBJ_ROOT "/button/%/p%/b%",
 				    NULL,
@@ -257,6 +266,8 @@ static int ratbagd_profile_find_led(sd_bus *bus,
 	struct ratbagd_profile *profile = userdata;
 	unsigned int index = 0;
 	int r;
+
+	CHECK_CALL(ratbagd_profile_ensure_loaded(profile));
 
 	r = sd_bus_path_decode_many(path,
 				    RATBAGD_OBJ_ROOT "/led/%/p%/l%",
@@ -379,6 +390,7 @@ ratbagd_profile_set_name(sd_bus *bus,
 	int r;
 
 	CHECK_CALL(sd_bus_message_read(m, "s", &name));
+	CHECK_CALL(ratbagd_profile_ensure_loaded(profile));
 
 	r = ratbag_profile_set_name(profile->lib_profile, name);
 
@@ -405,6 +417,8 @@ ratbagd_profile_get_name(sd_bus *bus,
 			 sd_bus_error *error)
 {
 	struct ratbagd_profile *profile = userdata;
+	CHECK_CALL(ratbagd_profile_ensure_loaded(profile));
+
 	const char *name = ratbag_profile_get_name(profile->lib_profile);
 	_cleanup_free_ char *utf8 = NULL;
 
@@ -472,6 +486,8 @@ ratbagd_profile_get_report_rate(sd_bus *bus,
 	struct ratbag_profile *lib_profile = profile->lib_profile;
 	int rate;
 
+	CHECK_CALL(ratbagd_profile_ensure_loaded(profile));
+
 	rate = ratbag_profile_get_report_rate(lib_profile);
 	verify_unsigned_int(rate);
 	return sd_bus_message_append(reply, "u", rate);
@@ -490,6 +506,8 @@ ratbagd_profile_get_angle_snapping(sd_bus *bus,
 	struct ratbag_profile *lib_profile = profile->lib_profile;
 	int value;
 
+	CHECK_CALL(ratbagd_profile_ensure_loaded(profile));
+
 	value = ratbag_profile_get_angle_snapping(lib_profile);
 	return sd_bus_message_append(reply, "i", value);
 }
@@ -506,6 +524,8 @@ ratbagd_profile_get_debounce(sd_bus *bus,
 	struct ratbagd_profile *profile = userdata;
 	struct ratbag_profile *lib_profile = profile->lib_profile;
 	int value;
+
+	CHECK_CALL(ratbagd_profile_ensure_loaded(profile));
 
 	value = ratbag_profile_get_debounce(lib_profile);
 	return sd_bus_message_append(reply, "i", value);
@@ -529,6 +549,8 @@ ratbagd_profile_get_report_rates(sd_bus *bus,
 	r = sd_bus_message_open_container(reply, 'a', "u");
 	if (r < 0)
 		return r;
+
+	CHECK_CALL(ratbagd_profile_ensure_loaded(profile));
 
 	nrates = ratbag_profile_get_report_rate_list(lib_profile,
 						     rates, nrates);
@@ -562,6 +584,8 @@ ratbagd_profile_get_debounces(sd_bus *bus,
 	r = sd_bus_message_open_container(reply, 'a', "u");
 	if (r < 0)
 		return r;
+
+	CHECK_CALL(ratbagd_profile_ensure_loaded(profile));
 
 	ndebounces = ratbag_profile_get_debounce_list(lib_profile, debounces, ndebounces);
 	assert(ndebounces <= ARRAY_LENGTH(debounces));
@@ -600,6 +624,8 @@ ratbagd_profile_set_report_rate(sd_bus *bus,
 		rate = 8000;
 	}
 
+	CHECK_CALL(ratbagd_profile_ensure_loaded(profile));
+
 	r = ratbag_profile_set_report_rate(profile->lib_profile, rate);
 	if (r == 0) {
 		sd_bus_emit_properties_changed(bus,
@@ -630,6 +656,8 @@ ratbagd_profile_set_angle_snapping(sd_bus *bus,
 	r = sd_bus_message_read(m, "i", &value);
 	if (r < 0)
 		return r;
+
+	CHECK_CALL(ratbagd_profile_ensure_loaded(profile));
 
 	r = ratbag_profile_set_angle_snapping(profile->lib_profile, value);
 	if (r == 0) {
@@ -662,6 +690,8 @@ ratbagd_profile_set_debounce(sd_bus *bus,
 	r = sd_bus_message_read(m, "i", &value);
 	if (r < 0)
 		return r;
+
+	CHECK_CALL(ratbagd_profile_ensure_loaded(profile));
 
 	r = ratbag_profile_set_debounce(profile->lib_profile, value);
 	if (r == 0) {

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -178,6 +178,43 @@ struct ratbag_driver {
 	int (*probe)(struct ratbag_device *device);
 
 	/**
+	 * Optional callback to lazily load a profile's current values
+	 * from the device. Called via ratbag_profile_load() the first
+	 * time a profile's data is accessed and the profile has not
+	 * been loaded yet (profile->loaded is false).
+	 *
+	 * Drivers that set this callback may skip populating non-active
+	 * profiles during probe() and instead defer the device reads
+	 * until the profile is actually requested. For profiles that
+	 * are fully populated during probe() (e.g. the active profile),
+	 * the driver must set profile->loaded to true so that
+	 * ratbag_profile_load() does not invoke read_profile again.
+	 *
+	 * Drivers that do not set this callback are unaffected.
+	 *
+	 * probe() must still set up all profiles with structural and
+	 * capability data that does not require reading from the
+	 * device in the profile's context:
+	 *  - resolution DPI ranges (ratbag_resolution_set_dpi_list_from_range)
+	 *  - resolution capabilities (RATBAG_RESOLUTION_CAP_*)
+	 *  - report rate lists (ratbag_profile_set_report_rate_list)
+	 *  - debounce lists
+	 *  - profile capabilities (RATBAG_PROFILE_CAP_*)
+	 *  - LED color depth and supported modes
+	 *  - is_active, is_enabled flags
+	 *
+	 * read_profile() then populates the current values:
+	 *  - active DPI / resolution values
+	 *  - current report rate, angle snapping, debounce
+	 *  - button mappings and macros
+	 *  - LED colors, brightness, effect duration, mode
+	 *  - profile name
+	 *
+	 * If NULL, all profile data must be populated during probe().
+	 */
+	int (*read_profile)(struct ratbag_profile *profile);
+
+	/**
 	 * Callback called right before the struct ratbag_device is
 	 * unref-ed.
 	 *
@@ -281,6 +318,7 @@ struct ratbag_profile {
 	bool is_active_dirty;
 
 	bool is_enabled;
+	bool loaded;      /**< profile data has been read from device */
 	bool dirty;       /**< profile changed since last commit */
 	unsigned long capabilities[NLONGS(MAX_CAP)];
 };

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -236,13 +236,52 @@ ratbag_device_destroy(struct ratbag_device *device)
 	free(device);
 }
 
+static bool
+ratbag_sanity_check_profile(struct ratbag_profile *profile)
+{
+	struct ratbag_device *device = profile->device;
+	struct ratbag *ratbag = device->ratbag;
+	struct ratbag_resolution *resolution;
+	unsigned int vals[300];
+	unsigned int nvals = ARRAY_LENGTH(vals);
+	unsigned int nres;
+
+	nres = ratbag_profile_get_num_resolutions(profile);
+	if (nres > 16) {
+		log_bug_libratbag(ratbag,
+				  "%s: invalid number of resolutions (%d)\n",
+				  device->name,
+				  nres);
+		return false;
+	}
+
+	ratbag_profile_for_each_resolution(profile, resolution) {
+		nvals = ratbag_resolution_get_dpi_list(resolution, vals, nvals);
+		if (nvals == 0) {
+			log_bug_libratbag(ratbag,
+					  "%s: invalid dpi list\n",
+					  device->name);
+			return false;
+		}
+	}
+
+	nvals = ratbag_profile_get_report_rate_list(profile, vals, nvals);
+	if (nvals == 0) {
+		log_bug_libratbag(ratbag,
+				  "%s: invalid report rate list\n",
+				  device->name);
+		return false;
+	}
+
+	return true;
+}
+
 static inline bool
 ratbag_sanity_check_device(struct ratbag_device *device)
 {
 	struct ratbag *ratbag = device->ratbag;
 	struct ratbag_profile *profile = NULL;
 	bool has_active = false;
-	unsigned int nres;
 	bool rc = false;
 
 	/* arbitrary number: max 16 profiles, does any mouse have more? but
@@ -257,10 +296,6 @@ ratbag_sanity_check_device(struct ratbag_device *device)
 	}
 
 	ratbag_device_for_each_profile(device, profile) {
-		struct ratbag_resolution *resolution;
-		unsigned int vals[300];
-		unsigned int nvals = ARRAY_LENGTH(vals);
-
 		/* Allow max 1 active profile */
 		if (profile->is_active) {
 			if (has_active) {
@@ -272,33 +307,13 @@ ratbag_sanity_check_device(struct ratbag_device *device)
 			has_active = true;
 		}
 
-		nres = ratbag_profile_get_num_resolutions(profile);
-		if (nres > 16) {
-				log_bug_libratbag(ratbag,
-						  "%s: invalid number of resolutions (%d)\n",
-						  device->name,
-						  nres);
-				goto out;
-		}
+		/* Skip data validation for profiles not yet loaded by
+		 * drivers that support lazy loading via read_profile. */
+		if (!profile->loaded && device->driver->read_profile)
+			continue;
 
-		ratbag_profile_for_each_resolution(profile, resolution) {
-			nvals = ratbag_resolution_get_dpi_list(resolution, vals, nvals);
-			if (nvals == 0) {
-				log_bug_libratbag(ratbag,
-						  "%s: invalid dpi list\n",
-						  device->name);
-				goto out;
-			}
-
-		}
-
-		nvals = ratbag_profile_get_report_rate_list(profile, vals, nvals);
-		if (nvals == 0) {
-			log_bug_libratbag(ratbag,
-					  "%s: invalid report rate list\n",
-					  device->name);
+		if (!ratbag_sanity_check_profile(profile))
 			goto out;
-		}
 
 		if (profile->dirty) {
 			log_bug_libratbag(ratbag,
@@ -805,6 +820,38 @@ ratbag_profile_set_enabled(struct ratbag_profile *profile, bool enabled)
 	profile->dirty = true;
 
 	return RATBAG_SUCCESS;
+}
+
+LIBRATBAG_EXPORT int
+ratbag_profile_load(struct ratbag_profile *profile)
+{
+	struct ratbag_device *device = profile->device;
+
+	if (profile->loaded)
+		return 0;
+
+	if (!device->driver->read_profile) {
+		profile->loaded = true;
+		return 0;
+	}
+
+	int rc = device->driver->read_profile(profile);
+	if (rc) {
+		log_error(device->ratbag,
+			  "Failed to load profile %d: %d\n",
+			  profile->index, rc);
+		return rc;
+	}
+
+	if (!ratbag_sanity_check_profile(profile)) {
+		log_error(device->ratbag,
+			  "Profile %d failed sanity check after loading\n",
+			  profile->index);
+		return -EINVAL;
+	}
+
+	profile->loaded = true;
+	return 0;
 }
 
 LIBRATBAG_EXPORT bool

--- a/src/libratbag.h
+++ b/src/libratbag.h
@@ -691,6 +691,27 @@ ratbag_device_get_profile(struct ratbag_device *device, unsigned int index);
 /**
  * @ingroup profile
  *
+ * Ensure the profile's data has been loaded from the device.
+ *
+ * For drivers that support lazy profile loading, this triggers the
+ * actual device read the first time it is called. Subsequent calls
+ * are no-ops. For drivers that do not support lazy loading this
+ * function always returns success immediately.
+ *
+ * Callers should invoke this before reading any profile properties
+ * (resolutions, buttons, report rate, etc.) if the profile may not
+ * have been loaded during probe.
+ *
+ * @param profile A previously initialized ratbag profile
+ *
+ * @return 0 on success or a negative errno on failure
+ */
+int
+ratbag_profile_load(struct ratbag_profile *profile);
+
+/**
+ * @ingroup profile
+ *
  * Check if the given profile is the currently active one. Note that some
  * devices allow switching profiles with hardware buttons thus making the
  * use of this function racy.


### PR DESCRIPTION
Some devices require switching the active profile in order to read a non-active profile's data. This temporarily changes device behavior, which is irritating to users. Lazy loading allows drivers to defer reading profile data until the profile is actually accessed by a client.

Add an optional read_profile callback to ratbag_driver and a loaded flag to ratbag_profile. Drivers that set this callback only need to populate structural/capability data (DPI ranges, rate lists, LED colordepth, etc.) for all profiles during probe, and can defer reading current values (DPI, button mappings, LED colors, etc.) to read_profile.

Add ratbag_profile_load() to the public API so consumers can trigger the lazy load explicitly. In ratbagd, call it from all profile property getters and sub-object find callbacks to ensure data is loaded before it is read or written over DBus.

Drivers that do not set read_profile are unaffected.