### PR TITLE
dynamically allocate debounce values list

### DIFF
--- a/ratbagd/ratbagd-profile.c
+++ b/ratbagd/ratbagd-profile.c
@@ -555,22 +555,28 @@ ratbagd_profile_get_debounces(sd_bus *bus,
 {
 	struct ratbagd_profile *profile = userdata;
 	struct ratbag_profile *lib_profile = profile->lib_profile;
-	unsigned int debounces[8];
-	unsigned int ndebounces = ARRAY_LENGTH(debounces);
+	unsigned int dummy;
+	unsigned int ndebounces;
 	int r;
 
 	r = sd_bus_message_open_container(reply, 'a', "u");
 	if (r < 0)
 		return r;
 
-	ndebounces = ratbag_profile_get_debounce_list(lib_profile, debounces, ndebounces);
-	assert(ndebounces <= ARRAY_LENGTH(debounces));
+	ndebounces = ratbag_profile_get_debounce_list(lib_profile, &dummy, 1);
+	if (ndebounces > 0) {
+		unsigned int *debounces = zalloc(ndebounces * sizeof(*debounces));
+		ratbag_profile_get_debounce_list(lib_profile, debounces, ndebounces);
 
-	for (unsigned int i = 0; i < ndebounces; i++) {
-		verify_unsigned_int(debounces[i]);
-		r = sd_bus_message_append(reply, "u", debounces[i]);
-		if (r < 0)
-			return r;
+		for (unsigned int i = 0; i < ndebounces; i++) {
+			verify_unsigned_int(debounces[i]);
+			r = sd_bus_message_append(reply, "u", debounces[i]);
+			if (r < 0) {
+				free(debounces);
+				return r;
+			}
+		}
+		free(debounces);
 	}
 
 	return sd_bus_message_close_container(reply);

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -272,7 +272,7 @@ struct ratbag_profile {
 
 	int debounce;	/**< debounce time in ms */
 	bool debounce_dirty;
-	unsigned int debounces[8];	/**< debounce times available */
+	unsigned int *debounces;	/**< debounce times available */
 	size_t ndebounces;		/**< number of entries in debounces */
 
 	unsigned int num_resolutions;
@@ -552,14 +552,12 @@ ratbag_profile_set_debounce_list(struct ratbag_profile *profile,
 				 const unsigned int *values,
 				 size_t nvalues)
 {
-	assert(nvalues <= ARRAY_LENGTH(profile->debounces));
-	_Static_assert(sizeof(*values) == sizeof(*profile->debounces), "Mismatching size");
+	for (size_t i = 1; i < nvalues; i++)
+		assert(values[i] > values[i - 1]);
 
-	for (size_t i = 0; i < nvalues; i++) {
-		profile->debounces[i] = values[i];
-		if (i > 0)
-			assert(values[i] > values[i - 1]);
-	}
+	free(profile->debounces);
+	profile->debounces = zalloc(nvalues * sizeof(*profile->debounces));
+	memcpy(profile->debounces, values, nvalues * sizeof(*values));
 	profile->ndebounces = nvalues;
 }
 

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -753,6 +753,7 @@ ratbag_profile_destroy(struct ratbag_profile *profile)
 		ratbag_resolution_destroy(res);
 
 	free(profile->name);
+	free(profile->debounces);
 
 	list_remove(&profile->link);
 	free(profile);


### PR DESCRIPTION
Replace the fixed-size debounce array with a dynamically allocated one to support devices with more than 8 debounce values.