### PR TITLE
Add extended mouse features for upcoming Pulsar support

### DIFF
--- a/doc/dbus.rst
+++ b/doc/dbus.rst
@@ -293,6 +293,15 @@ org.freedesktop.ratbag1.Profile
         indicate that the device doesn't support reading and/or writing this
         value.
 
+.. attribute:: RippleControl
+
+        :type: i
+        :flags: read-write, mutable
+
+        Sensor ripple control boolean value as an int (1 or 0), or `-1` to
+        indicate that the device doesn't support reading and/or writing this
+        value.
+
 .. attribute:: Debounce
 
         :type: i

--- a/doc/dbus.rst
+++ b/doc/dbus.rst
@@ -306,6 +306,27 @@ org.freedesktop.ratbag1.Profile
         This list may be empty if the device does not support reading and/or
         writing the debounce time.
 
+.. attribute:: Lod
+
+        :type: d
+        :flags: read-write, mutable
+
+        Sensor lift off distance in mm as a double, or `-1` to indicate that
+        the device doesn't support reading and/or writing this value. This
+        distance must be one of those listed in :attr:`Lods`.
+
+.. attribute:: Lods
+
+        :type: ad
+        :flags: read-write, constant
+
+        A list of permitted lift off distances. Values in this list may be
+        used in the :attr:`Lod` property. This list is always sorted
+        ascending, the lowest lift off distance is the first item in the list.
+
+        This list may be empty if the device does not support reading and/or
+        writing the lift off distance.
+
 .. attribute:: ReportRate
 
         :type: u

--- a/doc/dbus.rst
+++ b/doc/dbus.rst
@@ -185,6 +185,17 @@ known to ratbagd.
         occurs, the :func:`Resync` signal is emitted and all properties are
         updated to the current state.
 
+.. function:: Reset() → ()
+
+        Instructs the device to perform a factory reset, restoring all
+        settings to their hardware defaults. This call is handled
+        asynchronously. A :func:`Resync` signal is always emitted after
+        the reset completes, regardless of success or failure. Clients
+        should re-read all properties after receiving the signal.
+
+        Not all devices support hardware reset. If the device's driver
+        does not implement reset, this call has no effect.
+
 .. function:: Resync()
 
         :type: Signal

--- a/doc/dbus.rst
+++ b/doc/dbus.rst
@@ -552,6 +552,11 @@ org.freedesktop.ratbag1.Button
         |   1     | Key press event                      |
         +---------+--------------------------------------+
 
+        If the ActionType is *DPI Lock*, the variant is an unsigned integer
+        tuple (``(uu)``) where the first element is the X DPI value and the
+        second element is the Y DPI value to lock to while the button is
+        held. For uniform DPI lock, both values are identical.
+
         If the ActionType is *None*, the variant is an unsigned integer
         (``u``) of value 0.
 
@@ -575,6 +580,8 @@ org.freedesktop.ratbag1.Button
         |   3     | Key     | Mapping to a simple key action       |
         +---------+---------+--------------------------------------+
         |   4     | Macro   | Mapping to a macro key sequence      |
+        +---------+---------+--------------------------------------+
+        |   5     | DPILock | Lock DPI to a value while held       |
         +---------+---------+--------------------------------------+
         | 1000    | Unknown | An unknown or unreadable mapping type|
         +---------+---------+--------------------------------------+

--- a/doc/dbus.rst
+++ b/doc/dbus.rst
@@ -284,6 +284,15 @@ org.freedesktop.ratbag1.Profile
         indicate that the device doesn't support reading and/or writing this
         value.
 
+.. attribute:: MotionSync
+
+        :type: i
+        :flags: read-write, mutable
+
+        Sensor motion sync boolean value as an int (1 or 0), or `-1` to
+        indicate that the device doesn't support reading and/or writing this
+        value.
+
 .. attribute:: Debounce
 
         :type: i

--- a/doc/dbus.rst
+++ b/doc/dbus.rst
@@ -345,6 +345,28 @@ org.freedesktop.ratbag1.Profile
         This list may be empty if the device does not support reading and/or
         writing the lift off distance.
 
+.. attribute:: Autosleep
+
+        :type: i
+        :flags: read-write, mutable
+
+        Int for the autosleep timeout in seconds assigned to this profile.
+        This time must be one of those listed in :attr:`Autosleeps`, or ``-1``
+        to indicate that changing the autosleep timeout for this device is not
+        allowed.
+
+.. attribute:: Autosleeps
+
+        :type: au
+        :flags: read-write, constant
+
+        A list of permitted autosleep timeouts. Values in this list may be
+        used in the :attr:`Autosleep` property. This list is always sorted
+        ascending, the lowest autosleep timeout is the first item in the list.
+
+        This list may be empty if the device does not support reading and/or
+        writing the autosleep timeout.
+
 .. attribute:: ReportRate
 
         :type: u

--- a/doc/dbus.rst
+++ b/doc/dbus.rst
@@ -591,6 +591,33 @@ org.freedesktop.ratbag1.Button
 
         Clients must ignore :attr:`ActionTypes` unknown to them.
 
+.. attribute:: MacroRepeat
+
+        :type: (uu)
+        :flags: read-write, mutable
+
+        The macro repeat mode and count. Only meaningful when the button's
+        action type is *Macro*. The first element is the repeat mode, the
+        second element is the repeat count.
+
+        +-------+----------------------------------------------+
+        | Mode  | Description                                  |
+        +=======+==============================================+
+        |   0   | Play once (default)                          |
+        +-------+----------------------------------------------+
+        |   1   | Repeat a fixed number of times (use count)   |
+        +-------+----------------------------------------------+
+        |   2   | Repeat while the button is held              |
+        +-------+----------------------------------------------+
+        |   3   | Repeat until any other button is pressed     |
+        +-------+----------------------------------------------+
+
+        The count value is only used when the mode is 1 (repeat count).
+        For all other modes, the count should be set to 0.
+
+        Clients unaware of this property will get the default behavior
+        (play once) which preserves backwards compatibility.
+
 .. _led:
 
 org.freedesktop.ratbag1.Led

--- a/ratbagd/ratbagd-button.c
+++ b/ratbagd/ratbagd-button.c
@@ -306,6 +306,59 @@ static int ratbagd_button_set_macro(sd_bus *bus,
 	return 0;
 }
 
+static int ratbagd_button_get_dpi_lock(sd_bus *bus,
+				       const char *path,
+				       const char *interface,
+				       const char *property,
+				       sd_bus_message *reply,
+				       void *userdata,
+				       sd_bus_error *error)
+{
+	struct ratbagd_button *button = userdata;
+	int x, y;
+
+	x = ratbag_button_get_dpi_lock_x(button->lib_button);
+	y = ratbag_button_get_dpi_lock_y(button->lib_button);
+
+	verify_unsigned_int(x);
+	verify_unsigned_int(y);
+
+	CHECK_CALL(sd_bus_message_append(reply, "(uv)",
+					 RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK,
+					 "(uu)",
+					 (unsigned int)x,
+					 (unsigned int)y));
+
+	return 0;
+}
+
+static int ratbagd_button_set_dpi_lock(sd_bus *bus,
+				       const char *path,
+				       const char *interface,
+				       const char *property,
+				       sd_bus_message *m,
+				       void *userdata,
+				       sd_bus_error *error)
+{
+	struct ratbagd_button *button = userdata;
+	unsigned int x, y;
+	int r;
+
+	CHECK_CALL(sd_bus_message_read(m, "v", "(uu)", &x, &y));
+
+	r = ratbag_button_set_dpi_lock_xy(button->lib_button, x, y);
+
+	if (r == 0) {
+		sd_bus_emit_properties_changed(bus,
+					       button->path,
+					       RATBAGD_NAME_ROOT ".Button",
+					       "Mapping",
+					       NULL);
+	}
+
+	return 0;
+}
+
 static int ratbagd_button_get_none(sd_bus *bus,
 				   const char *path,
 				   const char *interface,
@@ -383,6 +436,9 @@ static int ratbagd_button_get_mapping(sd_bus *bus,
 	case RATBAG_BUTTON_ACTION_TYPE_MACRO:
 		return ratbagd_button_get_macro(bus, path, interface, property,
 						reply, userdata, error);
+	case RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK:
+		return ratbagd_button_get_dpi_lock(bus, path, interface, property,
+						    reply, userdata, error);
 	default:
 		return sd_bus_message_append(reply, "(uv)",
 					     RATBAG_BUTTON_ACTION_TYPE_UNKNOWN,
@@ -426,6 +482,10 @@ static int ratbagd_button_set_mapping(sd_bus *bus,
 		CHECK_CALL(ratbagd_button_set_macro(bus, path, interface, property,
 						    m, userdata, error));
 		break;
+	case RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK:
+		CHECK_CALL(ratbagd_button_set_dpi_lock(bus, path, interface, property,
+						       m, userdata, error));
+		break;
 	default:
 		/* FIXME */
 		return 1;
@@ -451,7 +511,8 @@ static int ratbagd_button_get_action_types(sd_bus *bus,
 		RATBAG_BUTTON_ACTION_TYPE_BUTTON,
 		RATBAG_BUTTON_ACTION_TYPE_SPECIAL,
 		RATBAG_BUTTON_ACTION_TYPE_KEY,
-		RATBAG_BUTTON_ACTION_TYPE_MACRO
+		RATBAG_BUTTON_ACTION_TYPE_MACRO,
+		RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK
 	};
 	enum ratbag_button_action_type *t;
 

--- a/ratbagd/ratbagd-button.c
+++ b/ratbagd/ratbagd-button.c
@@ -532,6 +532,64 @@ static int ratbagd_button_get_action_types(sd_bus *bus,
 	return 0;
 }
 
+static int ratbagd_button_get_macro_repeat(sd_bus *bus,
+					   const char *path,
+					   const char *interface,
+					   const char *property,
+					   sd_bus_message *reply,
+					   void *userdata,
+					   sd_bus_error *error)
+{
+	struct ratbagd_button *button = userdata;
+	_cleanup_(ratbag_button_macro_unrefp) struct ratbag_button_macro *macro = NULL;
+	unsigned int mode = 0, count = 0;
+
+	if (ratbag_button_get_action_type(button->lib_button) ==
+	    RATBAG_BUTTON_ACTION_TYPE_MACRO) {
+		macro = ratbag_button_get_macro(button->lib_button);
+		if (macro) {
+			mode = ratbag_button_macro_get_repeat_mode(macro);
+			count = ratbag_button_macro_get_repeat_count(macro);
+		}
+	}
+
+	return sd_bus_message_append(reply, "(uu)", mode, count);
+}
+
+static int ratbagd_button_set_macro_repeat(sd_bus *bus,
+					   const char *path,
+					   const char *interface,
+					   const char *property,
+					   sd_bus_message *m,
+					   void *userdata,
+					   sd_bus_error *error)
+{
+	struct ratbagd_button *button = userdata;
+	_cleanup_(ratbag_button_macro_unrefp) struct ratbag_button_macro *macro = NULL;
+	unsigned int mode, count;
+
+	CHECK_CALL(sd_bus_message_read(m, "(uu)", &mode, &count));
+
+	if (ratbag_button_get_action_type(button->lib_button) !=
+	    RATBAG_BUTTON_ACTION_TYPE_MACRO)
+		return 0;
+
+	macro = ratbag_button_get_macro(button->lib_button);
+	if (!macro)
+		return 0;
+
+	ratbag_button_macro_set_repeat(macro, mode, count);
+	ratbag_button_set_macro(button->lib_button, macro);
+
+	sd_bus_emit_properties_changed(bus,
+				       button->path,
+				       RATBAGD_NAME_ROOT ".Button",
+				       "MacroRepeat",
+				       NULL);
+
+	return 0;
+}
+
 const sd_bus_vtable ratbagd_button_vtable[] = {
 	SD_BUS_VTABLE_START(0),
 	SD_BUS_PROPERTY("Index", "u", NULL, offsetof(struct ratbagd_button, index), SD_BUS_VTABLE_PROPERTY_CONST),
@@ -540,6 +598,10 @@ const sd_bus_vtable ratbagd_button_vtable[] = {
 				 ratbagd_button_set_mapping,
 				 0, SD_BUS_VTABLE_UNPRIVILEGED | SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_PROPERTY("ActionTypes", "au", ratbagd_button_get_action_types, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+	SD_BUS_WRITABLE_PROPERTY("MacroRepeat", "(uu)",
+				 ratbagd_button_get_macro_repeat,
+				 ratbagd_button_set_macro_repeat,
+				 0, SD_BUS_VTABLE_UNPRIVILEGED | SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_VTABLE_END,
 };
 

--- a/ratbagd/ratbagd-device.c
+++ b/ratbagd/ratbagd-device.c
@@ -221,6 +221,35 @@ static int ratbagd_device_commit(sd_bus_message *m,
 	return 0;
 }
 
+static void ratbagd_device_reset_pending(void *data)
+{
+	struct ratbagd_device *device = data;
+	int r;
+
+	r = ratbag_device_reset(device->lib_device);
+	if (r)
+		log_error("error resetting device (%d)\n", r);
+
+	ratbagd_device_resync(device, device->ctx->bus);
+
+	ratbagd_device_unref(device);
+}
+
+static int ratbagd_device_do_reset(sd_bus_message *m,
+				   void *userdata,
+				   sd_bus_error *error)
+{
+	struct ratbagd_device *device = userdata;
+
+	ratbagd_schedule_task(device->ctx,
+			      ratbagd_device_reset_pending,
+			      ratbagd_device_ref(device));
+
+	CHECK_CALL(sd_bus_reply_method_return(m, "u", 0));
+
+	return 0;
+}
+
 static int
 ratbagd_device_get_model(sd_bus *bus,
 			 const char *path,
@@ -271,6 +300,7 @@ const sd_bus_vtable ratbagd_device_vtable[] = {
 	SD_BUS_PROPERTY("FirmwareVersion", "s", ratbagd_device_get_firmware_version, 0, SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_PROPERTY("Profiles", "ao", ratbagd_device_get_profiles, 0, SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_METHOD("Commit", "", "u", ratbagd_device_commit, SD_BUS_VTABLE_UNPRIVILEGED),
+	SD_BUS_METHOD("Reset", "", "u", ratbagd_device_do_reset, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_SIGNAL("Resync", "", 0),
 	SD_BUS_VTABLE_END,
 };

--- a/ratbagd/ratbagd-device.c
+++ b/ratbagd/ratbagd-device.c
@@ -27,17 +27,20 @@
 
 #include <assert.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <limits.h>
 #include <libratbag.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include <systemd/sd-bus.h>
 #include <systemd/sd-event.h>
 #include "ratbagd.h"
 #include "shared-macro.h"
 #include <rbtree/shared-rbtree.h>
 
+#include "libratbag-hidraw.h"
 #include "libratbag-util.h"
 
 struct ratbagd_device {
@@ -53,6 +56,8 @@ struct ratbagd_device {
 	sd_bus_slot *profile_enum_slot;
 	unsigned int n_profiles;
 	struct ratbagd_profile **profiles;
+
+	sd_event_source *hidraw_event_sources[MAX_HIDRAW];
 };
 
 #define ratbagd_device_from_node(_ptr) \
@@ -363,12 +368,96 @@ int ratbagd_device_new(struct ratbagd_device **out,
 	return 0;
 }
 
+static int ratbagd_device_hidraw_event(sd_event_source *source,
+				       int fd,
+				       uint32_t mask,
+				       void *userdata)
+{
+	struct ratbagd_device *device = userdata;
+	uint8_t buf[256];
+	int hidraw_index = -1;
+	int rc;
+	unsigned int events;
+
+	if (!(mask & EPOLLIN))
+		return 0;
+
+	for (int i = 0; i < MAX_HIDRAW; i++) {
+		if (ratbag_device_get_hidraw_fd(device->lib_device, i) == fd) {
+			hidraw_index = i;
+			break;
+		}
+	}
+	if (hidraw_index < 0)
+		return 0;
+
+	rc = read(fd, buf, sizeof(buf));
+	if (rc <= 0) {
+		if (rc < 0 && errno == EAGAIN)
+			return 0;
+		log_error("hidraw read error on %s\n", device->sysname);
+		return 0;
+	}
+
+	events = ratbag_device_dispatch_event(device->lib_device,
+					      buf, (size_t)rc,
+					      hidraw_index);
+
+	if (events != RATBAG_EVENT_NONE)
+		ratbagd_device_resync(device, device->ctx->bus);
+
+	return 0;
+}
+
+void ratbagd_device_stop_event_monitoring(struct ratbagd_device *device)
+{
+	for (int i = 0; i < MAX_HIDRAW; i++) {
+		if (device->hidraw_event_sources[i]) {
+			sd_event_source_set_enabled(device->hidraw_event_sources[i],
+						    SD_EVENT_OFF);
+			sd_event_source_unref(device->hidraw_event_sources[i]);
+			device->hidraw_event_sources[i] = NULL;
+		}
+	}
+}
+
+int ratbagd_device_start_event_monitoring(struct ratbagd_device *device)
+{
+	int fd, r;
+
+	if (!ratbag_device_has_event_support(device->lib_device))
+		return 0;
+
+	fd = ratbag_device_get_hidraw_fd(device->lib_device, 0);
+	if (fd < 0)
+		return 0;
+
+	/* Set non-blocking to avoid stalling the event loop */
+	fcntl(fd, F_SETFL, fcntl(fd, F_GETFL) | O_NONBLOCK);
+
+	r = sd_event_add_io(device->ctx->event,
+			    &device->hidraw_event_sources[0],
+			    fd,
+			    EPOLLIN,
+			    ratbagd_device_hidraw_event,
+			    device);
+	if (r < 0) {
+		log_error("%s: failed to add hidraw event source: %s\n",
+			  device->sysname, strerror(-r));
+		return r;
+	}
+
+	return 0;
+}
+
 static void ratbagd_device_free(struct ratbagd_device *device)
 {
 	unsigned int i;
 
 	if (!device)
 		return;
+
+	ratbagd_device_stop_event_monitoring(device);
 
 	assert(!ratbagd_device_linked(device));
 

--- a/ratbagd/ratbagd-json.c
+++ b/ratbagd/ratbagd-json.c
@@ -274,6 +274,7 @@ action_type_lookup(const char *string)
 		{ "special", RATBAG_BUTTON_ACTION_TYPE_SPECIAL},
 		{ "key", RATBAG_BUTTON_ACTION_TYPE_KEY},
 		{ "macro", RATBAG_BUTTON_ACTION_TYPE_MACRO},
+		{ "dpi-lock", RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK},
 		{ "unknown", RATBAG_BUTTON_ACTION_TYPE_UNKNOWN},
 	};
 
@@ -367,6 +368,14 @@ static void parse_button_member(JsonObject *obj, const gchar *name,
 			const gchar *v = json_array_get_string_element(a, s);
 			button->macro[s] = parse_macro(v);
 		}
+	} else if (streq(name, "dpi_lock")) {
+		JsonArray *a = json_object_get_array_member(obj, name);
+
+		assert(json_array_get_length(a) == 2);
+		button->dpi_lock.x = json_array_get_int_element(a, 0);
+		button->dpi_lock.y = json_array_get_int_element(a, 1);
+		log_verbose("json:    dpi_lock: %dx%d\n",
+			    button->dpi_lock.x, button->dpi_lock.y);
 	} else {
 		log_error("json: unknown button key '%s'\n", name);
 		parse_error = -EINVAL;

--- a/ratbagd/ratbagd-json.c
+++ b/ratbagd/ratbagd-json.c
@@ -368,6 +368,23 @@ static void parse_button_member(JsonObject *obj, const gchar *name,
 			const gchar *v = json_array_get_string_element(a, s);
 			button->macro[s] = parse_macro(v);
 		}
+	} else if (streq(name, "macro_repeat_mode")) {
+		const gchar *v = json_object_get_string_member(obj, name);
+		if (streq(v, "once"))
+			button->macro_repeat_mode = RATBAG_MACRO_REPEAT_ONCE;
+		else if (streq(v, "count"))
+			button->macro_repeat_mode = RATBAG_MACRO_REPEAT_COUNT;
+		else if (streq(v, "while-held"))
+			button->macro_repeat_mode = RATBAG_MACRO_REPEAT_WHILE_HELD;
+		else if (streq(v, "until-button-pressed"))
+			button->macro_repeat_mode = RATBAG_MACRO_REPEAT_UNTIL_BUTTON_PRESSED;
+		else
+			parser_error("macro_repeat_mode");
+		log_verbose("json:    macro_repeat_mode: %s\n", v);
+	} else if (streq(name, "macro_repeat_count")) {
+		gint v = json_object_get_int_member(obj, name);
+		button->macro_repeat_count = v;
+		log_verbose("json:    macro_repeat_count: %d\n", v);
 	} else if (streq(name, "dpi_lock")) {
 		JsonArray *a = json_object_get_array_member(obj, name);
 

--- a/ratbagd/ratbagd-profile.c
+++ b/ratbagd/ratbagd-profile.c
@@ -495,6 +495,23 @@ ratbagd_profile_get_angle_snapping(sd_bus *bus,
 }
 
 static int
+ratbagd_profile_get_motion_sync(sd_bus *bus,
+				const char *path,
+				const char *interface,
+				const char *property,
+				sd_bus_message *reply,
+				void *userdata,
+				sd_bus_error *error)
+{
+	struct ratbagd_profile *profile = userdata;
+	struct ratbag_profile *lib_profile = profile->lib_profile;
+	int value;
+
+	value = ratbag_profile_get_motion_sync(lib_profile);
+	return sd_bus_message_append(reply, "i", value);
+}
+
+static int
 ratbagd_profile_get_debounce(sd_bus *bus,
 			     const char *path,
 			     const char *interface,
@@ -701,6 +718,38 @@ ratbagd_profile_set_angle_snapping(sd_bus *bus,
 }
 
 static int
+ratbagd_profile_set_motion_sync(sd_bus *bus,
+				const char *path,
+				const char *interface,
+				const char *property,
+				sd_bus_message *m,
+				void *userdata,
+				sd_bus_error *error)
+{
+	struct ratbagd_profile *profile = userdata;
+	int value;
+	int r;
+
+	r = sd_bus_message_read(m, "i", &value);
+	if (r < 0)
+		return r;
+
+	r = ratbag_profile_set_motion_sync(profile->lib_profile, value);
+	if (r == 0) {
+		sd_bus *bus = sd_bus_message_get_bus(m);
+		sd_bus_emit_properties_changed(bus,
+					       profile->path,
+					       RATBAGD_NAME_ROOT ".Profile",
+					       "MotionSync",
+					       NULL);
+
+		ratbagd_profile_notify_dirty(bus, profile);
+	}
+
+	return 0;
+}
+
+static int
 ratbagd_profile_set_debounce(sd_bus *bus,
 			     const char *path,
 			     const char *interface,
@@ -787,6 +836,10 @@ const sd_bus_vtable ratbagd_profile_vtable[] = {
 	SD_BUS_WRITABLE_PROPERTY("AngleSnapping", "i",
 				 ratbagd_profile_get_angle_snapping,
 				 ratbagd_profile_set_angle_snapping, 0,
+				 SD_BUS_VTABLE_UNPRIVILEGED|SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
+	SD_BUS_WRITABLE_PROPERTY("MotionSync", "i",
+				 ratbagd_profile_get_motion_sync,
+				 ratbagd_profile_set_motion_sync, 0,
 				 SD_BUS_VTABLE_UNPRIVILEGED|SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_WRITABLE_PROPERTY("Debounce", "i",
 				 ratbagd_profile_get_debounce,

--- a/ratbagd/ratbagd-profile.c
+++ b/ratbagd/ratbagd-profile.c
@@ -62,6 +62,11 @@ struct ratbagd_profile {
 	struct ratbagd_led **leds;
 };
 
+static int ratbagd_profile_ensure_loaded(struct ratbagd_profile *profile)
+{
+	return ratbag_profile_load(profile->lib_profile);
+}
+
 static int ratbagd_profile_find_resolution(sd_bus *bus,
 					   const char *path,
 					   const char *interface,
@@ -379,6 +384,7 @@ ratbagd_profile_set_name(sd_bus *bus,
 	int r;
 
 	CHECK_CALL(sd_bus_message_read(m, "s", &name));
+	CHECK_CALL(ratbagd_profile_ensure_loaded(profile));
 
 	r = ratbag_profile_set_name(profile->lib_profile, name);
 
@@ -405,6 +411,8 @@ ratbagd_profile_get_name(sd_bus *bus,
 			 sd_bus_error *error)
 {
 	struct ratbagd_profile *profile = userdata;
+	CHECK_CALL(ratbagd_profile_ensure_loaded(profile));
+
 	const char *name = ratbag_profile_get_name(profile->lib_profile);
 	_cleanup_free_ char *utf8 = NULL;
 
@@ -472,6 +480,8 @@ ratbagd_profile_get_report_rate(sd_bus *bus,
 	struct ratbag_profile *lib_profile = profile->lib_profile;
 	int rate;
 
+	CHECK_CALL(ratbagd_profile_ensure_loaded(profile));
+
 	rate = ratbag_profile_get_report_rate(lib_profile);
 	verify_unsigned_int(rate);
 	return sd_bus_message_append(reply, "u", rate);
@@ -490,6 +500,8 @@ ratbagd_profile_get_angle_snapping(sd_bus *bus,
 	struct ratbag_profile *lib_profile = profile->lib_profile;
 	int value;
 
+	CHECK_CALL(ratbagd_profile_ensure_loaded(profile));
+
 	value = ratbag_profile_get_angle_snapping(lib_profile);
 	return sd_bus_message_append(reply, "i", value);
 }
@@ -506,6 +518,8 @@ ratbagd_profile_get_motion_sync(sd_bus *bus,
 	struct ratbagd_profile *profile = userdata;
 	struct ratbag_profile *lib_profile = profile->lib_profile;
 	int value;
+
+	CHECK_CALL(ratbagd_profile_ensure_loaded(profile));
 
 	value = ratbag_profile_get_motion_sync(lib_profile);
 	return sd_bus_message_append(reply, "i", value);
@@ -524,6 +538,8 @@ ratbagd_profile_get_ripple_control(sd_bus *bus,
 	struct ratbag_profile *lib_profile = profile->lib_profile;
 	int value;
 
+	CHECK_CALL(ratbagd_profile_ensure_loaded(profile));
+
 	value = ratbag_profile_get_ripple_control(lib_profile);
 	return sd_bus_message_append(reply, "i", value);
 }
@@ -541,6 +557,8 @@ ratbagd_profile_get_debounce(sd_bus *bus,
 	struct ratbag_profile *lib_profile = profile->lib_profile;
 	int value;
 
+	CHECK_CALL(ratbagd_profile_ensure_loaded(profile));
+
 	value = ratbag_profile_get_debounce(lib_profile);
 	return sd_bus_message_append(reply, "i", value);
 }
@@ -557,6 +575,8 @@ ratbagd_profile_get_lod(sd_bus *bus,
 	struct ratbagd_profile *profile = userdata;
 	struct ratbag_profile *lib_profile = profile->lib_profile;
 	double value;
+
+	CHECK_CALL(ratbagd_profile_ensure_loaded(profile));
 
 	value = ratbag_profile_get_lod(lib_profile);
 	return sd_bus_message_append(reply, "d", value);
@@ -580,6 +600,8 @@ ratbagd_profile_get_lods(sd_bus *bus,
 	r = sd_bus_message_open_container(reply, 'a', "d");
 	if (r < 0)
 		return r;
+
+	CHECK_CALL(ratbagd_profile_ensure_loaded(profile));
 
 	nlods = ratbag_profile_get_lod_list(lib_profile, &dummy, 1);
 	if (nlods > 0) {
@@ -612,6 +634,8 @@ ratbagd_profile_get_autosleep(sd_bus *bus,
 	struct ratbag_profile *lib_profile = profile->lib_profile;
 	int value;
 
+	CHECK_CALL(ratbagd_profile_ensure_loaded(profile));
+
 	value = ratbag_profile_get_autosleep(lib_profile);
 	return sd_bus_message_append(reply, "i", value);
 }
@@ -634,6 +658,8 @@ ratbagd_profile_get_autosleeps(sd_bus *bus,
 	r = sd_bus_message_open_container(reply, 'a', "u");
 	if (r < 0)
 		return r;
+
+	CHECK_CALL(ratbagd_profile_ensure_loaded(profile));
 
 	nautosleeps = ratbag_profile_get_autosleep_list(lib_profile, &dummy, 1);
 	if (nautosleeps > 0) {
@@ -672,6 +698,8 @@ ratbagd_profile_get_report_rates(sd_bus *bus,
 	if (r < 0)
 		return r;
 
+	CHECK_CALL(ratbagd_profile_ensure_loaded(profile));
+
 	nrates = ratbag_profile_get_report_rate_list(lib_profile,
 						     rates, nrates);
 	assert(nrates <= ARRAY_LENGTH(rates));
@@ -704,6 +732,8 @@ ratbagd_profile_get_debounces(sd_bus *bus,
 	r = sd_bus_message_open_container(reply, 'a', "u");
 	if (r < 0)
 		return r;
+
+	CHECK_CALL(ratbagd_profile_ensure_loaded(profile));
 
 	ndebounces = ratbag_profile_get_debounce_list(lib_profile, &dummy, 1);
 	if (ndebounces > 0) {
@@ -748,6 +778,8 @@ ratbagd_profile_set_report_rate(sd_bus *bus,
 		rate = 8000;
 	}
 
+	CHECK_CALL(ratbagd_profile_ensure_loaded(profile));
+
 	r = ratbag_profile_set_report_rate(profile->lib_profile, rate);
 	if (r == 0) {
 		sd_bus_emit_properties_changed(bus,
@@ -778,6 +810,8 @@ ratbagd_profile_set_angle_snapping(sd_bus *bus,
 	r = sd_bus_message_read(m, "i", &value);
 	if (r < 0)
 		return r;
+
+	CHECK_CALL(ratbagd_profile_ensure_loaded(profile));
 
 	r = ratbag_profile_set_angle_snapping(profile->lib_profile, value);
 	if (r == 0) {
@@ -811,6 +845,8 @@ ratbagd_profile_set_motion_sync(sd_bus *bus,
 	if (r < 0)
 		return r;
 
+	CHECK_CALL(ratbagd_profile_ensure_loaded(profile));
+
 	r = ratbag_profile_set_motion_sync(profile->lib_profile, value);
 	if (r == 0) {
 		sd_bus *bus = sd_bus_message_get_bus(m);
@@ -842,6 +878,8 @@ ratbagd_profile_set_ripple_control(sd_bus *bus,
 	r = sd_bus_message_read(m, "i", &value);
 	if (r < 0)
 		return r;
+
+	CHECK_CALL(ratbagd_profile_ensure_loaded(profile));
 
 	r = ratbag_profile_set_ripple_control(profile->lib_profile, value);
 	if (r == 0) {
@@ -875,6 +913,8 @@ ratbagd_profile_set_debounce(sd_bus *bus,
 	if (r < 0)
 		return r;
 
+	CHECK_CALL(ratbagd_profile_ensure_loaded(profile));
+
 	r = ratbag_profile_set_debounce(profile->lib_profile, value);
 	if (r == 0) {
 		sd_bus *bus = sd_bus_message_get_bus(m);
@@ -907,6 +947,8 @@ ratbagd_profile_set_lod(sd_bus *bus,
 	if (r < 0)
 		return r;
 
+	CHECK_CALL(ratbagd_profile_ensure_loaded(profile));
+
 	r = ratbag_profile_set_lod(profile->lib_profile, value);
 	if (r == 0) {
 		sd_bus *bus = sd_bus_message_get_bus(m);
@@ -937,6 +979,8 @@ ratbagd_profile_set_autosleep(sd_bus *bus,
 	r = sd_bus_message_read(m, "i", &value);
 	if (r < 0)
 		return r;
+
+	CHECK_CALL(ratbagd_profile_ensure_loaded(profile));
 
 	r = ratbag_profile_set_autosleep(profile->lib_profile, value);
 	if (r == 0) {

--- a/ratbagd/ratbagd-profile.c
+++ b/ratbagd/ratbagd-profile.c
@@ -600,6 +600,60 @@ ratbagd_profile_get_lods(sd_bus *bus,
 }
 
 static int
+ratbagd_profile_get_autosleep(sd_bus *bus,
+			      const char *path,
+			      const char *interface,
+			      const char *property,
+			      sd_bus_message *reply,
+			      void *userdata,
+			      sd_bus_error *error)
+{
+	struct ratbagd_profile *profile = userdata;
+	struct ratbag_profile *lib_profile = profile->lib_profile;
+	int value;
+
+	value = ratbag_profile_get_autosleep(lib_profile);
+	return sd_bus_message_append(reply, "i", value);
+}
+
+static int
+ratbagd_profile_get_autosleeps(sd_bus *bus,
+			       const char *path,
+			       const char *interface,
+			       const char *property,
+			       sd_bus_message *reply,
+			       void *userdata,
+			       sd_bus_error *error)
+{
+	struct ratbagd_profile *profile = userdata;
+	struct ratbag_profile *lib_profile = profile->lib_profile;
+	unsigned int dummy;
+	unsigned int nautosleeps;
+	int r;
+
+	r = sd_bus_message_open_container(reply, 'a', "u");
+	if (r < 0)
+		return r;
+
+	nautosleeps = ratbag_profile_get_autosleep_list(lib_profile, &dummy, 1);
+	if (nautosleeps > 0) {
+		unsigned int *autosleeps = zalloc(nautosleeps * sizeof(*autosleeps));
+		ratbag_profile_get_autosleep_list(lib_profile, autosleeps, nautosleeps);
+
+		for (unsigned int i = 0; i < nautosleeps; i++) {
+			r = sd_bus_message_append(reply, "u", autosleeps[i]);
+			if (r < 0) {
+				free(autosleeps);
+				return r;
+			}
+		}
+		free(autosleeps);
+	}
+
+	return sd_bus_message_close_container(reply);
+}
+
+static int
 ratbagd_profile_get_report_rates(sd_bus *bus,
 				 const char *path,
 				 const char *interface,
@@ -861,6 +915,37 @@ ratbagd_profile_set_lod(sd_bus *bus,
 	return 0;
 }
 
+static int
+ratbagd_profile_set_autosleep(sd_bus *bus,
+			      const char *path,
+			      const char *interface,
+			      const char *property,
+			      sd_bus_message *m,
+			      void *userdata,
+			      sd_bus_error *error)
+{
+	struct ratbagd_profile *profile = userdata;
+	int value;
+	int r;
+
+	r = sd_bus_message_read(m, "i", &value);
+	if (r < 0)
+		return r;
+
+	r = ratbag_profile_set_autosleep(profile->lib_profile, value);
+	if (r == 0) {
+		sd_bus *bus = sd_bus_message_get_bus(m);
+		sd_bus_emit_properties_changed(bus,
+					       profile->path,
+					       RATBAGD_NAME_ROOT ".Profile",
+					       "Autosleep", NULL);
+
+		ratbagd_profile_notify_dirty(bus, profile);
+	}
+
+	return 0;
+}
+
 const sd_bus_vtable ratbagd_profile_vtable[] = {
 	SD_BUS_VTABLE_START(0),
 	SD_BUS_WRITABLE_PROPERTY("Name", "s",
@@ -905,6 +990,11 @@ const sd_bus_vtable ratbagd_profile_vtable[] = {
 				 ratbagd_profile_set_lod, 0,
 				 SD_BUS_VTABLE_UNPRIVILEGED|SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_PROPERTY("Lods", "ad", ratbagd_profile_get_lods, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+	SD_BUS_WRITABLE_PROPERTY("Autosleep", "i",
+				 ratbagd_profile_get_autosleep,
+				 ratbagd_profile_set_autosleep, 0,
+				 SD_BUS_VTABLE_UNPRIVILEGED|SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
+	SD_BUS_PROPERTY("Autosleeps", "au", ratbagd_profile_get_autosleeps, 0, SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_METHOD("SetActive", "", "u", ratbagd_profile_set_active, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_VTABLE_END,
 };

--- a/ratbagd/ratbagd-profile.c
+++ b/ratbagd/ratbagd-profile.c
@@ -512,6 +512,60 @@ ratbagd_profile_get_debounce(sd_bus *bus,
 }
 
 static int
+ratbagd_profile_get_lod(sd_bus *bus,
+			const char *path,
+			const char *interface,
+			const char *property,
+			sd_bus_message *reply,
+			void *userdata,
+			sd_bus_error *error)
+{
+	struct ratbagd_profile *profile = userdata;
+	struct ratbag_profile *lib_profile = profile->lib_profile;
+	double value;
+
+	value = ratbag_profile_get_lod(lib_profile);
+	return sd_bus_message_append(reply, "d", value);
+}
+
+static int
+ratbagd_profile_get_lods(sd_bus *bus,
+			 const char *path,
+			 const char *interface,
+			 const char *property,
+			 sd_bus_message *reply,
+			 void *userdata,
+			 sd_bus_error *error)
+{
+	struct ratbagd_profile *profile = userdata;
+	struct ratbag_profile *lib_profile = profile->lib_profile;
+	double dummy;
+	unsigned int nlods;
+	int r;
+
+	r = sd_bus_message_open_container(reply, 'a', "d");
+	if (r < 0)
+		return r;
+
+	nlods = ratbag_profile_get_lod_list(lib_profile, &dummy, 1);
+	if (nlods > 0) {
+		double *lods = zalloc(nlods * sizeof(*lods));
+		ratbag_profile_get_lod_list(lib_profile, lods, nlods);
+
+		for (unsigned int i = 0; i < nlods; i++) {
+			r = sd_bus_message_append(reply, "d", lods[i]);
+			if (r < 0) {
+				free(lods);
+				return r;
+			}
+		}
+		free(lods);
+	}
+
+	return sd_bus_message_close_container(reply);
+}
+
+static int
 ratbagd_profile_get_report_rates(sd_bus *bus,
 				 const char *path,
 				 const char *interface,
@@ -678,6 +732,37 @@ ratbagd_profile_set_debounce(sd_bus *bus,
 	return 0;
 }
 
+static int
+ratbagd_profile_set_lod(sd_bus *bus,
+			const char *path,
+			const char *interface,
+			const char *property,
+			sd_bus_message *m,
+			void *userdata,
+			sd_bus_error *error)
+{
+	struct ratbagd_profile *profile = userdata;
+	double value;
+	int r;
+
+	r = sd_bus_message_read(m, "d", &value);
+	if (r < 0)
+		return r;
+
+	r = ratbag_profile_set_lod(profile->lib_profile, value);
+	if (r == 0) {
+		sd_bus *bus = sd_bus_message_get_bus(m);
+		sd_bus_emit_properties_changed(bus,
+					       profile->path,
+					       RATBAGD_NAME_ROOT ".Profile",
+					       "Lod", NULL);
+
+		ratbagd_profile_notify_dirty(bus, profile);
+	}
+
+	return 0;
+}
+
 const sd_bus_vtable ratbagd_profile_vtable[] = {
 	SD_BUS_VTABLE_START(0),
 	SD_BUS_WRITABLE_PROPERTY("Name", "s",
@@ -709,6 +794,11 @@ const sd_bus_vtable ratbagd_profile_vtable[] = {
 				 SD_BUS_VTABLE_UNPRIVILEGED|SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_PROPERTY("ReportRates", "au", ratbagd_profile_get_report_rates, 0, SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_PROPERTY("Debounces", "au", ratbagd_profile_get_debounces, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+	SD_BUS_WRITABLE_PROPERTY("Lod", "d",
+				 ratbagd_profile_get_lod,
+				 ratbagd_profile_set_lod, 0,
+				 SD_BUS_VTABLE_UNPRIVILEGED|SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
+	SD_BUS_PROPERTY("Lods", "ad", ratbagd_profile_get_lods, 0, SD_BUS_VTABLE_PROPERTY_CONST),
 	SD_BUS_METHOD("SetActive", "", "u", ratbagd_profile_set_active, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_VTABLE_END,
 };

--- a/ratbagd/ratbagd-profile.c
+++ b/ratbagd/ratbagd-profile.c
@@ -697,22 +697,28 @@ ratbagd_profile_get_debounces(sd_bus *bus,
 {
 	struct ratbagd_profile *profile = userdata;
 	struct ratbag_profile *lib_profile = profile->lib_profile;
-	unsigned int debounces[8];
-	unsigned int ndebounces = ARRAY_LENGTH(debounces);
+	unsigned int dummy;
+	unsigned int ndebounces;
 	int r;
 
 	r = sd_bus_message_open_container(reply, 'a', "u");
 	if (r < 0)
 		return r;
 
-	ndebounces = ratbag_profile_get_debounce_list(lib_profile, debounces, ndebounces);
-	assert(ndebounces <= ARRAY_LENGTH(debounces));
+	ndebounces = ratbag_profile_get_debounce_list(lib_profile, &dummy, 1);
+	if (ndebounces > 0) {
+		unsigned int *debounces = zalloc(ndebounces * sizeof(*debounces));
+		ratbag_profile_get_debounce_list(lib_profile, debounces, ndebounces);
 
-	for (unsigned int i = 0; i < ndebounces; i++) {
-		verify_unsigned_int(debounces[i]);
-		r = sd_bus_message_append(reply, "u", debounces[i]);
-		if (r < 0)
-			return r;
+		for (unsigned int i = 0; i < ndebounces; i++) {
+			verify_unsigned_int(debounces[i]);
+			r = sd_bus_message_append(reply, "u", debounces[i]);
+			if (r < 0) {
+				free(debounces);
+				return r;
+			}
+		}
+		free(debounces);
 	}
 
 	return sd_bus_message_close_container(reply);

--- a/ratbagd/ratbagd-profile.c
+++ b/ratbagd/ratbagd-profile.c
@@ -512,6 +512,23 @@ ratbagd_profile_get_motion_sync(sd_bus *bus,
 }
 
 static int
+ratbagd_profile_get_ripple_control(sd_bus *bus,
+				   const char *path,
+				   const char *interface,
+				   const char *property,
+				   sd_bus_message *reply,
+				   void *userdata,
+				   sd_bus_error *error)
+{
+	struct ratbagd_profile *profile = userdata;
+	struct ratbag_profile *lib_profile = profile->lib_profile;
+	int value;
+
+	value = ratbag_profile_get_ripple_control(lib_profile);
+	return sd_bus_message_append(reply, "i", value);
+}
+
+static int
 ratbagd_profile_get_debounce(sd_bus *bus,
 			     const char *path,
 			     const char *interface,
@@ -750,6 +767,38 @@ ratbagd_profile_set_motion_sync(sd_bus *bus,
 }
 
 static int
+ratbagd_profile_set_ripple_control(sd_bus *bus,
+				   const char *path,
+				   const char *interface,
+				   const char *property,
+				   sd_bus_message *m,
+				   void *userdata,
+				   sd_bus_error *error)
+{
+	struct ratbagd_profile *profile = userdata;
+	int value;
+	int r;
+
+	r = sd_bus_message_read(m, "i", &value);
+	if (r < 0)
+		return r;
+
+	r = ratbag_profile_set_ripple_control(profile->lib_profile, value);
+	if (r == 0) {
+		sd_bus *bus = sd_bus_message_get_bus(m);
+		sd_bus_emit_properties_changed(bus,
+					       profile->path,
+					       RATBAGD_NAME_ROOT ".Profile",
+					       "RippleControl",
+					       NULL);
+
+		ratbagd_profile_notify_dirty(bus, profile);
+	}
+
+	return 0;
+}
+
+static int
 ratbagd_profile_set_debounce(sd_bus *bus,
 			     const char *path,
 			     const char *interface,
@@ -840,6 +889,10 @@ const sd_bus_vtable ratbagd_profile_vtable[] = {
 	SD_BUS_WRITABLE_PROPERTY("MotionSync", "i",
 				 ratbagd_profile_get_motion_sync,
 				 ratbagd_profile_set_motion_sync, 0,
+				 SD_BUS_VTABLE_UNPRIVILEGED|SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
+	SD_BUS_WRITABLE_PROPERTY("RippleControl", "i",
+				 ratbagd_profile_get_ripple_control,
+				 ratbagd_profile_set_ripple_control, 0,
 				 SD_BUS_VTABLE_UNPRIVILEGED|SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_WRITABLE_PROPERTY("Debounce", "i",
 				 ratbagd_profile_get_debounce,

--- a/ratbagd/ratbagd-test.c
+++ b/ratbagd/ratbagd-test.c
@@ -67,6 +67,7 @@ static int load_test_device(sd_bus_message *m,
 	}
 
 	ratbagd_device_link(ratbagd_test_device);
+	ratbagd_device_start_event_monitoring(ratbagd_test_device);
 	if (m) {
 		sd_bus_reply_method_return(m, "u", r);
 		(void) sd_bus_emit_properties_changed(ctx->bus,

--- a/ratbagd/ratbagd.c
+++ b/ratbagd/ratbagd.c
@@ -233,6 +233,7 @@ static void ratbagd_process_device(struct ratbagd *ctx,
 		}
 
 		ratbagd_device_link(device);
+		ratbagd_device_start_event_monitoring(device);
 		(void) sd_bus_emit_properties_changed(ctx->bus,
 						      RATBAGD_OBJ_ROOT,
 						      RATBAGD_NAME_ROOT ".Manager",

--- a/ratbagd/ratbagd.h
+++ b/ratbagd/ratbagd.h
@@ -177,6 +177,8 @@ const char *ratbagd_device_get_path(struct ratbagd_device *device);
 unsigned int ratbagd_device_get_num_buttons(struct ratbagd_device *device);
 unsigned int ratbagd_device_get_num_leds(struct ratbagd_device *device);
 int ratbagd_device_resync(struct ratbagd_device *device, sd_bus *bus);
+int ratbagd_device_start_event_monitoring(struct ratbagd_device *device);
+void ratbagd_device_stop_event_monitoring(struct ratbagd_device *device);
 
 bool ratbagd_device_linked(struct ratbagd_device *device);
 void ratbagd_device_link(struct ratbagd_device *device);

--- a/src/driver-test.c
+++ b/src/driver-test.c
@@ -73,6 +73,8 @@ test_read_button(struct ratbag_button *button)
 				break;
 			ratbag_button_macro_set_event(m, idx++, e->type, e->value);
 		}
+		ratbag_button_macro_set_repeat(m, b->macro_repeat_mode,
+					       b->macro_repeat_count);
 		ratbag_button_copy_macro(button, m);
 		ratbag_button_macro_unref(m);
 		break;

--- a/src/driver-test.c
+++ b/src/driver-test.c
@@ -80,6 +80,11 @@ test_read_button(struct ratbag_button *button)
 		button->action.type = RATBAG_BUTTON_ACTION_TYPE_SPECIAL;
 		button->action.action.special = p->buttons[button->index].special;
 		break;
+	case RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK:
+		button->action.type = RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK;
+		button->action.action.dpi_lock.x = p->buttons[button->index].dpi_lock.x;
+		button->action.action.dpi_lock.y = p->buttons[button->index].dpi_lock.y;
+		break;
 	default:
 		button->action.type = RATBAG_BUTTON_ACTION_TYPE_UNKNOWN;
 	}
@@ -89,6 +94,7 @@ test_read_button(struct ratbag_button *button)
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_KEY);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_SPECIAL);
 	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_MACRO);
+	ratbag_button_enable_action_type(button, RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK);
 }
 
 static void

--- a/src/driver-test.c
+++ b/src/driver-test.c
@@ -216,6 +216,26 @@ test_read_profile(struct ratbag_profile *profile)
 		profile->name = strdup(p->name);
 	}
 
+	profile->angle_snapping = p->angle_snapping;
+	profile->motion_sync = p->motion_sync;
+	profile->ripple_control = p->ripple_control;
+	profile->debounce = p->debounce;
+	profile->lod = p->lod;
+	profile->autosleep = p->autosleep;
+
+	if (p->ndebounces > 0)
+		ratbag_profile_set_debounce_list(profile,
+						 p->debounces,
+						 p->ndebounces);
+	if (p->nlods > 0)
+		ratbag_profile_set_lod_list(profile,
+					    p->lods,
+					    p->nlods);
+	if (p->nautosleeps > 0)
+		ratbag_profile_set_autosleep_list(profile,
+						  p->autosleeps,
+						  p->nautosleeps);
+
 	for (i = 0; i < ARRAY_LENGTH(p->caps) && p->caps[i]; i++) {
 		ratbag_profile_set_cap(profile, p->caps[i]);
 	}

--- a/src/driver-test.c
+++ b/src/driver-test.c
@@ -285,6 +285,19 @@ test_commit(struct ratbag_device *device)
 	return 0;
 }
 
+static unsigned int
+test_handle_event(struct ratbag_device *device,
+		  const uint8_t *buf, size_t len,
+		  int hidraw_index)
+{
+	struct ratbag_test_device *d = ratbag_get_drv_data(device);
+
+	if (d->handle_event)
+		return d->handle_event(device, buf, len, hidraw_index);
+
+	return RATBAG_EVENT_NONE;
+}
+
 struct ratbag_driver test_driver = {
 	.name = "Test driver",
 	.id = "test_driver",
@@ -293,4 +306,5 @@ struct ratbag_driver test_driver = {
 	.remove = test_remove,
 	.commit = test_commit,
 	.set_active_profile = test_set_active_profile,
+	.handle_event = test_handle_event,
 };

--- a/src/libratbag-enums.h
+++ b/src/libratbag-enums.h
@@ -286,6 +286,22 @@ enum ratbag_macro_event_type {
 /**
  * @ingroup enums
  *
+ * Macro repeat modes describing how a macro is repeated.
+ */
+enum ratbag_macro_repeat_mode {
+	/** Play the macro once (default) */
+	RATBAG_MACRO_REPEAT_ONCE = 0,
+	/** Play the macro a fixed number of times */
+	RATBAG_MACRO_REPEAT_COUNT,
+	/** Repeat the macro while the button is held */
+	RATBAG_MACRO_REPEAT_WHILE_HELD,
+	/** Repeat the macro until any other button is pressed */
+	RATBAG_MACRO_REPEAT_UNTIL_BUTTON_PRESSED,
+};
+
+/**
+ * @ingroup enums
+ *
  * Device Types
  * Describes the types specified in the .device files
  */

--- a/src/libratbag-enums.h
+++ b/src/libratbag-enums.h
@@ -173,6 +173,10 @@ enum ratbag_button_action_type {
 	 */
 	RATBAG_BUTTON_ACTION_TYPE_MACRO,
 	/**
+	 * Button locks DPI to a specific value while held
+	 */
+	RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK,
+	/**
 	 * Button action is unknown
 	 */
 	RATBAG_BUTTON_ACTION_TYPE_UNKNOWN = 1000,

--- a/src/libratbag-enums.h
+++ b/src/libratbag-enums.h
@@ -304,3 +304,18 @@ enum ratbag_device_type {
 	 */
 	TYPE_KEYBOARD,
 };
+
+/**
+ * @ingroup enums
+ *
+ * Bitmask of device state that changed due to an unsolicited event.
+ * Returned by a driver's handle_event callback.
+ */
+enum ratbag_event_type {
+	RATBAG_EVENT_NONE               = 0,
+	RATBAG_EVENT_PROFILE_CHANGED    = (1 << 0),
+	RATBAG_EVENT_RESOLUTION_CHANGED = (1 << 1),
+	RATBAG_EVENT_BATTERY_CHANGED    = (1 << 2),
+	RATBAG_EVENT_LED_CHANGED        = (1 << 3),
+	RATBAG_EVENT_UNKNOWN            = (1 << 15),
+};

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -286,6 +286,11 @@ struct ratbag_profile {
 	double *lods;		/**< lift off distances available */
 	size_t nlods;		/**< number of entries in lods */
 
+	int autosleep;		/**< autosleep timeout in seconds */
+	bool autosleep_dirty;
+	unsigned int *autosleeps;	/**< autosleep timeouts available */
+	size_t nautosleeps;		/**< number of entries in autosleeps */
+
 	unsigned int num_resolutions;
 
 	bool is_active;		/**< profile is the currently active one */
@@ -586,6 +591,20 @@ ratbag_profile_set_lod_list(struct ratbag_profile *profile,
 	profile->lods = zalloc(nvalues * sizeof(*profile->lods));
 	memcpy(profile->lods, values, nvalues * sizeof(*values));
 	profile->nlods = nvalues;
+}
+
+static inline void
+ratbag_profile_set_autosleep_list(struct ratbag_profile *profile,
+				  const unsigned int *values,
+				  size_t nvalues)
+{
+	for (size_t i = 1; i < nvalues; i++)
+		assert(values[i] > values[i - 1]);
+
+	free(profile->autosleeps);
+	profile->autosleeps = zalloc(nvalues * sizeof(*profile->autosleeps));
+	memcpy(profile->autosleeps, values, nvalues * sizeof(*values));
+	profile->nautosleeps = nvalues;
 }
 
 static inline void

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -288,7 +288,7 @@ struct ratbag_profile {
 
 	int debounce;	/**< debounce time in ms */
 	bool debounce_dirty;
-	unsigned int debounces[8];	/**< debounce times available */
+	unsigned int *debounces;	/**< debounce times available */
 	size_t ndebounces;		/**< number of entries in debounces */
 
 	double lod;		/**< lift off distance in mm */
@@ -578,14 +578,12 @@ ratbag_profile_set_debounce_list(struct ratbag_profile *profile,
 				 const unsigned int *values,
 				 size_t nvalues)
 {
-	assert(nvalues <= ARRAY_LENGTH(profile->debounces));
-	_Static_assert(sizeof(*values) == sizeof(*profile->debounces), "Mismatching size");
+	for (size_t i = 1; i < nvalues; i++)
+		assert(values[i] > values[i - 1]);
 
-	for (size_t i = 0; i < nvalues; i++) {
-		profile->debounces[i] = values[i];
-		if (i > 0)
-			assert(values[i] > values[i - 1]);
-	}
+	free(profile->debounces);
+	profile->debounces = zalloc(nvalues * sizeof(*profile->debounces));
+	memcpy(profile->debounces, values, nvalues * sizeof(*values));
 	profile->ndebounces = nvalues;
 }
 

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -178,6 +178,43 @@ struct ratbag_driver {
 	int (*probe)(struct ratbag_device *device);
 
 	/**
+	 * Optional callback to lazily load a profile's current values
+	 * from the device. Called via ratbag_profile_load() the first
+	 * time a profile's data is accessed and the profile has not
+	 * been loaded yet (profile->loaded is false).
+	 *
+	 * Drivers that set this callback may skip populating non-active
+	 * profiles during probe() and instead defer the device reads
+	 * until the profile is actually requested. For profiles that
+	 * are fully populated during probe() (e.g. the active profile),
+	 * the driver must set profile->loaded to true so that
+	 * ratbag_profile_load() does not invoke read_profile again.
+	 *
+	 * Drivers that do not set this callback are unaffected.
+	 *
+	 * probe() must still set up all profiles with structural and
+	 * capability data that does not require reading from the
+	 * device in the profile's context:
+	 *  - resolution DPI ranges (ratbag_resolution_set_dpi_list_from_range)
+	 *  - resolution capabilities (RATBAG_RESOLUTION_CAP_*)
+	 *  - report rate lists (ratbag_profile_set_report_rate_list)
+	 *  - debounce lists
+	 *  - profile capabilities (RATBAG_PROFILE_CAP_*)
+	 *  - LED color depth and supported modes
+	 *  - is_active, is_enabled flags
+	 *
+	 * read_profile() then populates the current values:
+	 *  - active DPI / resolution values
+	 *  - current report rate, angle snapping, debounce
+	 *  - button mappings and macros
+	 *  - LED colors, brightness, effect duration, mode
+	 *  - profile name
+	 *
+	 * If NULL, all profile data must be populated during probe().
+	 */
+	int (*read_profile)(struct ratbag_profile *profile);
+
+	/**
 	 * Callback called right before the struct ratbag_device is
 	 * unref-ed.
 	 *
@@ -334,6 +371,7 @@ struct ratbag_profile {
 	bool is_active_dirty;
 
 	bool is_enabled;
+	bool loaded;      /**< profile data has been read from device */
 	bool dirty;       /**< profile changed since last commit */
 	unsigned long capabilities[NLONGS(MAX_CAP)];
 };

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -424,6 +424,8 @@ struct ratbag_macro {
 	char *name;
 	char *group;
 	struct ratbag_macro_event events[MAX_MACRO_EVENTS];
+	enum ratbag_macro_repeat_mode repeat_mode;
+	unsigned int repeat_count;
 };
 
 struct ratbag_button_macro {

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -275,6 +275,11 @@ struct ratbag_profile {
 	unsigned int debounces[8];	/**< debounce times available */
 	size_t ndebounces;		/**< number of entries in debounces */
 
+	double lod;		/**< lift off distance in mm */
+	bool lod_dirty;
+	double *lods;		/**< lift off distances available */
+	size_t nlods;		/**< number of entries in lods */
+
 	unsigned int num_resolutions;
 
 	bool is_active;		/**< profile is the currently active one */
@@ -561,6 +566,20 @@ ratbag_profile_set_debounce_list(struct ratbag_profile *profile,
 			assert(values[i] > values[i - 1]);
 	}
 	profile->ndebounces = nvalues;
+}
+
+static inline void
+ratbag_profile_set_lod_list(struct ratbag_profile *profile,
+			    const double *values,
+			    size_t nvalues)
+{
+	for (size_t i = 1; i < nvalues; i++)
+		assert(values[i] > values[i - 1]);
+
+	free(profile->lods);
+	profile->lods = zalloc(nvalues * sizeof(*profile->lods));
+	memcpy(profile->lods, values, nvalues * sizeof(*values));
+	profile->nlods = nvalues;
 }
 
 static inline void

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -404,6 +404,12 @@ struct ratbag_profile {
 #define BUTTON_ACTION_MACRO \
  { .type = RATBAG_BUTTON_ACTION_TYPE_MACRO, \
 	/* FIXME: add the macro keys */ }
+#define BUTTON_ACTION_DPI_LOCK(dpi_) \
+ { .type = RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK, \
+	.action.dpi_lock = { .x = (dpi_), .y = (dpi_) } }
+#define BUTTON_ACTION_DPI_LOCK_XY(x_, y_) \
+ { .type = RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK, \
+	.action.dpi_lock = { .x = (x_), .y = (y_) } }
 
 struct ratbag_macro_event {
 	enum ratbag_macro_event_type type;
@@ -440,6 +446,10 @@ struct ratbag_button_action {
 		unsigned int button; /* action_type == button */
 		enum ratbag_button_action_special special; /* action_type == special */
 		unsigned int key; /* action_type == key */
+		struct { /* action_type == dpi_lock */
+			unsigned int x;
+			unsigned int y;
+		} dpi_lock;
 	} action;
 	struct ratbag_macro *macro; /* dynamically allocated, so kept aside */
 };
@@ -541,6 +551,9 @@ ratbag_button_action_match(const struct ratbag_button_action *action,
 	case RATBAG_BUTTON_ACTION_TYPE_MACRO:
 		/* TODO: check if events match. */
 		return 1;
+	case RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK:
+		return match->action.dpi_lock.x == action->action.dpi_lock.x &&
+		       match->action.dpi_lock.y == action->action.dpi_lock.y;
 	default:
 		break;
 	}

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -270,6 +270,9 @@ struct ratbag_profile {
 	int angle_snapping;
 	bool angle_snapping_dirty;
 
+	int motion_sync;
+	bool motion_sync_dirty;
+
 	int debounce;	/**< debounce time in ms */
 	bool debounce_dirty;
 	unsigned int debounces[8];	/**< debounce times available */

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -209,6 +209,33 @@ struct ratbag_driver {
 	int (*reset)(struct ratbag_device *device);
 
 	/**
+	 * Handle an unsolicited HID input report from the device.
+	 *
+	 * Called when the hidraw fd becomes readable and raw data has been
+	 * read. The driver should parse the report and update internal
+	 * state (profiles, resolutions, etc.) accordingly.
+	 *
+	 * Drivers that do not support event monitoring should leave this
+	 * NULL. When NULL, no hidraw fds are monitored for this device.
+	 *
+	 * Note: Drivers that set this callback must not use
+	 * ratbag_hidraw_read_input_report() on the monitored hidraw fd,
+	 * as the event loop already reads from it. Using both would
+	 * cause one side to consume data intended for the other.
+	 *
+	 * @param device The ratbag device
+	 * @param buf The raw HID input report data
+	 * @param len The length of buf in bytes
+	 * @param hidraw_index Which hidraw fd the data came from (0 or 1)
+	 *
+	 * @return Bitmask of enum ratbag_event_type indicating what changed,
+	 *         or RATBAG_EVENT_NONE if the report was not relevant
+	 */
+	unsigned int (*handle_event)(struct ratbag_device *device,
+				     const uint8_t *buf, size_t len,
+				     int hidraw_index);
+
+	/**
 	 * Called to mark a previously written profile as active.
 	 *
 	 * There should be no need to write the profile here, a

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -199,6 +199,16 @@ struct ratbag_driver {
 	int (*commit)(struct ratbag_device *device);
 
 	/**
+	 * Callback called when the driver should instruct the hardware to
+	 * perform a factory reset, restoring all settings to their defaults.
+	 *
+	 * Drivers that do not support hardware reset should leave this NULL.
+	 * The library will return RATBAG_ERROR_CAPABILITY if this is called
+	 * on a device whose driver does not implement reset.
+	 */
+	int (*reset)(struct ratbag_device *device);
+
+	/**
 	 * Called to mark a previously written profile as active.
 	 *
 	 * There should be no need to write the profile here, a

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -273,6 +273,9 @@ struct ratbag_profile {
 	int motion_sync;
 	bool motion_sync_dirty;
 
+	int ripple_control;
+	bool ripple_control_dirty;
+
 	int debounce;	/**< debounce time in ms */
 	bool debounce_dirty;
 	unsigned int debounces[8];	/**< debounce times available */

--- a/src/libratbag-test.h
+++ b/src/libratbag-test.h
@@ -106,6 +106,9 @@ struct ratbag_test_device {
 	struct ratbag_test_profile profiles[RATBAG_TEST_MAX_PROFILES];
 	void (*destroyed)(struct ratbag_device *device, void *data);
 	void *destroyed_data;
+	unsigned int (*handle_event)(struct ratbag_device *device,
+				     const uint8_t *buf, size_t len,
+				     int hidraw_index);
 };
 
 struct ratbag_device* ratbag_device_new_test_device(struct ratbag *ratbag,

--- a/src/libratbag-test.h
+++ b/src/libratbag-test.h
@@ -50,6 +50,8 @@ struct ratbag_test_button {
 			unsigned int y;
 		} dpi_lock;
 	};
+	enum ratbag_macro_repeat_mode macro_repeat_mode;
+	unsigned int macro_repeat_count;
 };
 
 struct ratbag_test_resolution {

--- a/src/libratbag-test.h
+++ b/src/libratbag-test.h
@@ -45,6 +45,10 @@ struct ratbag_test_button {
 		int key;
 		enum ratbag_button_action_special special;
 		struct ratbag_test_macro_event macro[24];
+		struct {
+			unsigned int x;
+			unsigned int y;
+		} dpi_lock;
 	};
 };
 

--- a/src/libratbag-test.h
+++ b/src/libratbag-test.h
@@ -83,6 +83,19 @@ struct ratbag_test_profile {
 
 	int hz;
 	unsigned int report_rates[5];
+
+	int angle_snapping;
+	int motion_sync;
+	int ripple_control;
+	int debounce;
+	unsigned int debounces[8];
+	size_t ndebounces;
+	double lod;
+	double lods[8];
+	size_t nlods;
+	int autosleep;
+	unsigned int autosleeps[8];
+	size_t nautosleeps;
 };
 
 struct ratbag_test_device {

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -39,2086 +39,2361 @@
 #include "libratbag-util.h"
 #include "usb-ids.h"
 
-static enum ratbag_error_code error_code(enum ratbag_error_code code) {
-  switch (code) {
-  case RATBAG_SUCCESS:
-  case RATBAG_ERROR_DEVICE:
-  case RATBAG_ERROR_CAPABILITY:
-  case RATBAG_ERROR_VALUE:
-  case RATBAG_ERROR_SYSTEM:
-  case RATBAG_ERROR_IMPLEMENTATION:
-    break;
-  default:
-    assert(!"Invalid error code. This is a library bug.");
-  }
-  return code;
+static enum ratbag_error_code error_code(enum ratbag_error_code code)
+{
+	switch (code)
+	{
+	case RATBAG_SUCCESS:
+	case RATBAG_ERROR_DEVICE:
+	case RATBAG_ERROR_CAPABILITY:
+	case RATBAG_ERROR_VALUE:
+	case RATBAG_ERROR_SYSTEM:
+	case RATBAG_ERROR_IMPLEMENTATION:
+		break;
+	default:
+		assert(!"Invalid error code. This is a library bug.");
+	}
+	return code;
 }
 
-static void ratbag_profile_destroy(struct ratbag_profile *profile);
-static void ratbag_button_destroy(struct ratbag_button *button);
-static void ratbag_led_destroy(struct ratbag_led *led);
-static void ratbag_resolution_destroy(struct ratbag_resolution *resolution);
+static void ratbag_profile_destroy(struct ratbag_profile* profile);
+static void ratbag_button_destroy(struct ratbag_button* button);
+static void ratbag_led_destroy(struct ratbag_led* led);
+static void ratbag_resolution_destroy(struct ratbag_resolution* resolution);
 
-static void ratbag_default_log_func(struct ratbag *ratbag,
+static void ratbag_default_log_func(struct ratbag* ratbag,
                                     enum ratbag_log_priority priority,
-                                    const char *format, va_list args) {
-  const char *prefix;
-  FILE *out = stdout;
+                                    const char* format, va_list args)
+{
+	const char* prefix;
+	FILE* out = stdout;
 
-  switch (priority) {
-  case RATBAG_LOG_PRIORITY_RAW:
-    prefix = "raw";
-    break;
-  case RATBAG_LOG_PRIORITY_DEBUG:
-    prefix = "debug";
-    break;
-  case RATBAG_LOG_PRIORITY_INFO:
-    prefix = "info";
-    break;
-  case RATBAG_LOG_PRIORITY_ERROR:
-    prefix = "error";
-    out = stderr;
-    break;
-  default:
-    prefix = "<invalid priority>";
-    break;
-  }
+	switch (priority)
+	{
+	case RATBAG_LOG_PRIORITY_RAW:
+		prefix = "raw";
+		break;
+	case RATBAG_LOG_PRIORITY_DEBUG:
+		prefix = "debug";
+		break;
+	case RATBAG_LOG_PRIORITY_INFO:
+		prefix = "info";
+		break;
+	case RATBAG_LOG_PRIORITY_ERROR:
+		prefix = "error";
+		out = stderr;
+		break;
+	default:
+		prefix = "<invalid priority>";
+		break;
+	}
 
-  fprintf(out, "ratbag %s: ", prefix);
-  vfprintf(out, format, args);
+	fprintf(out, "ratbag %s: ", prefix);
+	vfprintf(out, format, args);
 }
 
-void log_msg_va(struct ratbag *ratbag, enum ratbag_log_priority priority,
-                const char *format, va_list args) {
-  if (ratbag->log_handler && ratbag->log_priority <= priority)
-    ratbag->log_handler(ratbag, priority, format, args);
+void log_msg_va(struct ratbag* ratbag, enum ratbag_log_priority priority,
+                const char* format, va_list args)
+{
+	if (ratbag->log_handler && ratbag->log_priority <= priority)
+		ratbag->log_handler(ratbag, priority, format, args);
 }
 
-void log_msg(struct ratbag *ratbag, enum ratbag_log_priority priority,
-             const char *format, ...) {
-  va_list args;
+void log_msg(struct ratbag* ratbag, enum ratbag_log_priority priority,
+             const char* format, ...)
+{
+	va_list args;
 
-  va_start(args, format);
-  log_msg_va(ratbag, priority, format, args);
-  va_end(args);
+	va_start(args, format);
+	log_msg_va(ratbag, priority, format, args);
+	va_end(args);
 }
 
-void log_buffer(struct ratbag *ratbag, enum ratbag_log_priority priority,
-                const char *header, const uint8_t *buf, size_t len) {
-  _cleanup_free_ char *output_buf = NULL;
-  char *sep = "";
-  unsigned int i, n;
-  unsigned int buf_len;
+void log_buffer(struct ratbag* ratbag, enum ratbag_log_priority priority,
+                const char* header, const uint8_t* buf, size_t len)
+{
+	_cleanup_free_ char* output_buf = NULL;
+	char* sep = "";
+	unsigned int i, n;
+	unsigned int buf_len;
 
-  if (ratbag->log_handler && ratbag->log_priority > priority)
-    return;
+	if (ratbag->log_handler && ratbag->log_priority > priority)
+		return;
 
-  buf_len = header ? strlen(header) : 0;
-  buf_len += len * 3;
-  buf_len += 1; /* terminating '\0' */
+	buf_len = header ? strlen(header) : 0;
+	buf_len += len * 3;
+	buf_len += 1; /* terminating '\0' */
 
-  output_buf = zalloc(buf_len);
-  n = 0;
-  if (header)
-    n += snprintf_safe(output_buf, buf_len - n, "%s", header);
+	output_buf = zalloc(buf_len);
+	n = 0;
+	if (header)
+		n += snprintf_safe(output_buf, buf_len - n, "%s", header);
 
-  for (i = 0; i < len; ++i) {
-    n += snprintf_safe(&output_buf[n], buf_len - n, "%s%02x", sep,
-                       buf[i] & 0xFF);
-    sep = " ";
-  }
+	for (i = 0; i < len; ++i)
+	{
+		n += snprintf_safe(&output_buf[n], buf_len - n, "%s%02x", sep,
+		                   buf[i] & 0xFF);
+		sep = " ";
+	}
 
-  log_msg(ratbag, priority, "%s\n", output_buf);
+	log_msg(ratbag, priority, "%s\n", output_buf);
 }
 
 LIBRATBAG_EXPORT void
-ratbag_log_set_priority(struct ratbag *ratbag,
-                        enum ratbag_log_priority priority) {
-  switch (priority) {
-  case RATBAG_LOG_PRIORITY_RAW:
-  case RATBAG_LOG_PRIORITY_DEBUG:
-  case RATBAG_LOG_PRIORITY_INFO:
-  case RATBAG_LOG_PRIORITY_ERROR:
-    break;
-  default:
-    log_bug_client(ratbag, "Invalid log priority %d. Using INFO instead\n",
-                   priority);
-    priority = RATBAG_LOG_PRIORITY_INFO;
-  }
-  ratbag->log_priority = priority;
+ratbag_log_set_priority(struct ratbag* ratbag,
+                        enum ratbag_log_priority priority)
+{
+	switch (priority)
+	{
+	case RATBAG_LOG_PRIORITY_RAW:
+	case RATBAG_LOG_PRIORITY_DEBUG:
+	case RATBAG_LOG_PRIORITY_INFO:
+	case RATBAG_LOG_PRIORITY_ERROR:
+		break;
+	default:
+		log_bug_client(
+			ratbag, "Invalid log priority %d. Using INFO instead\n",
+			priority);
+		priority = RATBAG_LOG_PRIORITY_INFO;
+	}
+	ratbag->log_priority = priority;
 }
 
 LIBRATBAG_EXPORT enum ratbag_log_priority
-ratbag_log_get_priority(const struct ratbag *ratbag) {
-  return ratbag->log_priority;
+ratbag_log_get_priority(const struct ratbag* ratbag)
+{
+	return ratbag->log_priority;
 }
 
-LIBRATBAG_EXPORT void ratbag_log_set_handler(struct ratbag *ratbag,
-                                             ratbag_log_handler log_handler) {
-  ratbag->log_handler = log_handler;
+LIBRATBAG_EXPORT void ratbag_log_set_handler(struct ratbag* ratbag,
+                                             ratbag_log_handler log_handler)
+{
+	ratbag->log_handler = log_handler;
 }
 
-struct ratbag_device *ratbag_device_new(struct ratbag *ratbag,
-                                        struct udev_device *udev_device,
-                                        const char *name,
-                                        const struct input_id *id) {
-  struct ratbag_device *device = NULL;
+struct ratbag_device* ratbag_device_new(struct ratbag* ratbag,
+                                        struct udev_device* udev_device,
+                                        const char* name,
+                                        const struct input_id* id)
+{
+	struct ratbag_device* device = NULL;
 
-  device = zalloc(sizeof(*device));
-  device->name = strdup_safe(name);
-  device->ratbag = ratbag_ref(ratbag);
-  device->refcount = 1;
-  device->udev_device = udev_device_ref(udev_device);
-  device->ids = *id;
-  device->data = ratbag_device_data_new_for_id(ratbag, id);
+	device = zalloc(sizeof(*device));
+	device->name = strdup_safe(name);
+	device->ratbag = ratbag_ref(ratbag);
+	device->refcount = 1;
+	device->udev_device = udev_device_ref(udev_device);
+	device->ids = *id;
+	device->data = ratbag_device_data_new_for_id(ratbag, id);
 
-  if (device->data != NULL)
-    device->devicetype = ratbag_device_data_get_device_type(device->data);
+	if (device->data != NULL)
+		device->devicetype = ratbag_device_data_get_device_type(
+			device->data);
 
-  list_init(&device->profiles);
+	list_init(&device->profiles);
 
-  list_insert(&ratbag->devices, &device->link);
+	list_insert(&ratbag->devices, &device->link);
 
-  return device;
+	return device;
 }
 
-void ratbag_device_destroy(struct ratbag_device *device) {
-  struct ratbag_profile *profile, *next;
+void ratbag_device_destroy(struct ratbag_device* device)
+{
+	struct ratbag_profile *profile, *next;
 
-  if (!device)
-    return;
+	if (!device)
+		return;
 
-  /* if we get to the point where the device is destroyed, profiles,
-   * buttons, etc. are at a refcount of 0, so we can destroy
-   * everything */
-  if (device->driver && device->driver->remove)
-    device->driver->remove(device);
+	/* if we get to the point where the device is destroyed, profiles,
+	 * buttons, etc. are at a refcount of 0, so we can destroy
+	 * everything */
+	if (device->driver && device->driver->remove)
+		device->driver->remove(device);
 
-  list_for_each_safe(profile, next, &device->profiles, link)
-      ratbag_profile_destroy(profile);
+	list_for_each_safe(profile, next, &device->profiles, link)
+		ratbag_profile_destroy(profile);
 
-  if (device->udev_device)
-    udev_device_unref(device->udev_device);
+	if (device->udev_device)
+		udev_device_unref(device->udev_device);
 
-  list_remove(&device->link);
+	list_remove(&device->link);
 
-  ratbag_unref(device->ratbag);
-  ratbag_device_data_unref(device->data);
-  free(device->name);
-  free(device->firmware_version);
-  free(device);
+	ratbag_unref(device->ratbag);
+	ratbag_device_data_unref(device->data);
+	free(device->name);
+	free(device->firmware_version);
+	free(device);
 }
 
 static bool
-ratbag_sanity_check_profile(struct ratbag_profile *profile)
+ratbag_sanity_check_profile(struct ratbag_profile* profile)
 {
-  struct ratbag_device *device = profile->device;
-  struct ratbag *ratbag = device->ratbag;
-  struct ratbag_resolution *resolution;
-  unsigned int vals[300];
-  unsigned int nvals = ARRAY_LENGTH(vals);
-  unsigned int nres;
+	struct ratbag_device* device = profile->device;
+	struct ratbag* ratbag = device->ratbag;
+	struct ratbag_resolution* resolution;
+	unsigned int vals[300];
+	unsigned int nvals = ARRAY_LENGTH(vals);
+	unsigned int nres;
 
-  nres = ratbag_profile_get_num_resolutions(profile);
-  if (nres > 16) {
-    log_bug_libratbag(ratbag, "%s: invalid number of resolutions (%d)\n",
-                      device->name, nres);
-    return false;
-  }
+	nres = ratbag_profile_get_num_resolutions(profile);
+	if (nres > 16)
+	{
+		log_bug_libratbag(
+			ratbag, "%s: invalid number of resolutions (%d)\n",
+			device->name, nres);
+		return false;
+	}
 
-  ratbag_profile_for_each_resolution(profile, resolution) {
-    nvals = ratbag_resolution_get_dpi_list(resolution, vals, nvals);
-    if (nvals == 0) {
-      log_bug_libratbag(ratbag, "%s: invalid dpi list\n", device->name);
-      return false;
-    }
-  }
+	ratbag_profile_for_each_resolution(profile, resolution)
+	{
+		nvals = ratbag_resolution_get_dpi_list(resolution, vals, nvals);
+		if (nvals == 0)
+		{
+			log_bug_libratbag(ratbag, "%s: invalid dpi list\n",
+			                  device->name);
+			return false;
+		}
+	}
 
-  nvals = ratbag_profile_get_report_rate_list(profile, vals, nvals);
-  if (nvals == 0) {
-    log_bug_libratbag(ratbag, "%s: invalid report rate list\n", device->name);
-    return false;
-  }
+	nvals = ratbag_profile_get_report_rate_list(profile, vals, nvals);
+	if (nvals == 0)
+	{
+		log_bug_libratbag(ratbag, "%s: invalid report rate list\n",
+		                  device->name);
+		return false;
+	}
 
-  return true;
+	return true;
 }
 
-static inline bool ratbag_sanity_check_device(struct ratbag_device *device) {
-  struct ratbag *ratbag = device->ratbag;
-  struct ratbag_profile *profile = NULL;
-  bool has_active = false;
-  bool rc = false;
+static inline bool ratbag_sanity_check_device(struct ratbag_device* device)
+{
+	struct ratbag* ratbag = device->ratbag;
+	struct ratbag_profile* profile = NULL;
+	bool has_active = false;
+	bool rc = false;
 
-  /* arbitrary number: max 16 profiles, does any mouse have more? but
-   * since we have num_profiles unsigned, it also checks for
-   * accidental negative */
-  if (device->num_profiles == 0 || device->num_profiles > 16) {
-    log_bug_libratbag(ratbag, "%s: invalid number of profiles (%d)\n",
-                      device->name, device->num_profiles);
-    goto out;
-  }
+	/* arbitrary number: max 16 profiles, does any mouse have more? but
+	 * since we have num_profiles unsigned, it also checks for
+	 * accidental negative */
+	if (device->num_profiles == 0 || device->num_profiles > 16)
+	{
+		log_bug_libratbag(
+			ratbag, "%s: invalid number of profiles (%d)\n",
+			device->name, device->num_profiles);
+		goto out;
+	}
 
-  ratbag_device_for_each_profile(device, profile) {
-    /* Allow max 1 active profile */
-    if (profile->is_active) {
-      if (has_active) {
-        log_bug_libratbag(ratbag, "%s: multiple active profiles\n",
-                          device->name);
-        goto out;
-      }
-      has_active = true;
-    }
+	ratbag_device_for_each_profile(device, profile)
+	{
+		/* Allow max 1 active profile */
+		if (profile->is_active)
+		{
+			if (has_active)
+			{
+				log_bug_libratbag(
+					ratbag,
+					"%s: multiple active profiles\n",
+					device->name);
+				goto out;
+			}
+			has_active = true;
+		}
 
-    /* Skip data validation for profiles not yet loaded by
-     * drivers that support lazy loading via read_profile. */
-    if (!profile->loaded && device->driver->read_profile)
-      continue;
+		/* Skip data validation for profiles not yet loaded by
+		 * drivers that support lazy loading via read_profile. */
+		if (!profile->loaded && device->driver->read_profile)
+			continue;
 
-    if (!ratbag_sanity_check_profile(profile))
-      goto out;
+		if (!ratbag_sanity_check_profile(profile))
+			goto out;
 
-    if (profile->dirty) {
-      log_bug_libratbag(ratbag, "%s: profile is dirty while probing\n",
-                        device->name);
-      /* Don't bail yet, as we may have some drivers that do this. */
-    }
-  }
+		if (profile->dirty)
+		{
+			log_bug_libratbag(
+				ratbag, "%s: profile is dirty while probing\n",
+				device->name);
+			/* Don't bail yet, as we may have some drivers that do this. */
+		}
+	}
 
-  /* Require 1 active profile */
-  if (!has_active) {
-    log_bug_libratbag(ratbag, "%s: no profile set as active profile\n",
-                      device->name);
-    goto out;
-  }
+	/* Require 1 active profile */
+	if (!has_active)
+	{
+		log_bug_libratbag(
+			ratbag, "%s: no profile set as active profile\n",
+			device->name);
+		goto out;
+	}
 
-  rc = true;
+	rc = true;
 
 out:
-  return rc;
+	return rc;
 }
 
 static inline bool
-ratbag_try_driver(struct ratbag_device *device, const struct input_id *dev_id,
-                  const char *driver_name,
-                  const struct ratbag_test_device *test_device) {
-  struct ratbag *ratbag = device->ratbag;
-  struct ratbag_driver *driver;
-  int rc;
+ratbag_try_driver(struct ratbag_device* device, const struct input_id* dev_id,
+                  const char* driver_name,
+                  const struct ratbag_test_device* test_device)
+{
+	struct ratbag* ratbag = device->ratbag;
+	struct ratbag_driver* driver;
+	int rc;
 
-  list_for_each(driver, &ratbag->drivers, link) {
-    if (streq(driver->id, driver_name)) {
-      device->driver = driver;
-      break;
-    }
-  }
+	list_for_each(driver, &ratbag->drivers, link)
+	{
+		if (streq(driver->id, driver_name))
+		{
+			device->driver = driver;
+			break;
+		}
+	}
 
-  if (!device->driver) {
-    log_error(ratbag, "%s: driver '%s' does not exist\n", device->name,
-              driver_name);
-    goto error;
-  }
+	if (!device->driver)
+	{
+		log_error(ratbag, "%s: driver '%s' does not exist\n",
+		          device->name,
+		          driver_name);
+		goto error;
+	}
 
-  if (test_device)
-    rc = device->driver->test_probe(device, test_device);
-  else
-    rc = device->driver->probe(device);
-  if (rc == 0) {
-    if (!ratbag_sanity_check_device(device)) {
-      goto error;
-    } else {
-      log_debug(ratbag, "driver match found: %s\n", device->driver->name);
-      return true;
-    }
-  }
+	if (test_device)
+		rc = device->driver->test_probe(device, test_device);
+	else
+		rc = device->driver->probe(device);
+	if (rc == 0)
+	{
+		if (!ratbag_sanity_check_device(device))
+		{
+			goto error;
+		}
+		else
+		{
+			log_debug(ratbag, "driver match found: %s\n",
+			          device->driver->name);
+			return true;
+		}
+	}
 
-  if (rc != -ENODEV)
-    log_error(ratbag, "%s: error opening hidraw node (%s)\n", device->name,
-              strerror(-rc));
+	if (rc != -ENODEV)
+		log_error(ratbag, "%s: error opening hidraw node (%s)\n", device->name,
+	          strerror(-rc));
 
-  device->driver = NULL;
+	device->driver = NULL;
 error:
-  return false;
+	return false;
 }
 
-bool ratbag_assign_driver(struct ratbag_device *device,
-                          const struct input_id *dev_id,
-                          const struct ratbag_test_device *test_device) {
-  const char *driver_name;
+bool ratbag_assign_driver(struct ratbag_device* device,
+                          const struct input_id* dev_id,
+                          const struct ratbag_test_device* test_device)
+{
+	const char* driver_name;
 
-  if (!test_device) {
-    driver_name = ratbag_device_data_get_driver(device->data);
-  } else {
-    log_debug(device->ratbag, "This is a test device\n");
-    driver_name = "test_driver";
-  }
+	if (!test_device)
+	{
+		driver_name = ratbag_device_data_get_driver(device->data);
+	}
+	else
+	{
+		log_debug(device->ratbag, "This is a test device\n");
+		driver_name = "test_driver";
+	}
 
-  log_debug(device->ratbag, "device assigned driver %s\n", driver_name);
-  return ratbag_try_driver(device, dev_id, driver_name, test_device);
+	log_debug(device->ratbag, "device assigned driver %s\n", driver_name);
+	return ratbag_try_driver(device, dev_id, driver_name, test_device);
 }
 
-static char *get_device_name(struct udev_device *device) {
-  const char *prop;
+static char* get_device_name(struct udev_device* device)
+{
+	const char* prop;
 
-  prop = udev_prop_value(device, "HID_NAME");
+	prop = udev_prop_value(device, "HID_NAME");
 
-  return strdup_safe(prop);
+	return strdup_safe(prop);
 }
 
-static inline int get_product_id(struct udev_device *device,
-                                 struct input_id *id) {
-  const char *product;
-  struct input_id ids = {0};
-  int rc;
+static inline int get_product_id(struct udev_device* device,
+                                 struct input_id* id)
+{
+	const char* product;
+	struct input_id ids = {0};
+	int rc;
 
-  product = udev_prop_value(device, "HID_ID");
-  if (!product)
-    return -1;
+	product = udev_prop_value(device, "HID_ID");
+	if (!product)
+		return -1;
 
-  rc = sscanf(product, "%hx:%hx:%hx", &ids.bustype, &ids.vendor, &ids.product);
-  if (rc != 3)
-    return -1;
+	rc = sscanf(product, "%hx:%hx:%hx", &ids.bustype, &ids.vendor,
+	            &ids.product);
+	if (rc != 3)
+		return -1;
 
-  *id = ids;
-  return 0;
+	*id = ids;
+	return 0;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_device_new_from_udev_device(struct ratbag *ratbag,
-                                   struct udev_device *udev_device,
-                                   struct ratbag_device **device_out) {
-  struct ratbag_device *device = NULL;
-  enum ratbag_error_code error = RATBAG_ERROR_DEVICE;
-  _cleanup_free_ char *name = NULL;
-  struct input_id id;
+ratbag_device_new_from_udev_device(struct ratbag* ratbag,
+                                   struct udev_device* udev_device,
+                                   struct ratbag_device** device_out)
+{
+	struct ratbag_device* device = NULL;
+	enum ratbag_error_code error = RATBAG_ERROR_DEVICE;
+	_cleanup_free_ char* name = NULL;
+	struct input_id id;
 
-  assert(ratbag != NULL);
-  assert(udev_device != NULL);
-  assert(device_out != NULL);
+	assert(ratbag != NULL);
+	assert(udev_device != NULL);
+	assert(device_out != NULL);
 
-  if (get_product_id(udev_device, &id) != 0)
-    goto out_err;
+	if (get_product_id(udev_device, &id) != 0)
+		goto out_err;
 
-  if ((name = get_device_name(udev_device)) == 0)
-    goto out_err;
+	if ((name = get_device_name(udev_device)) == 0)
+		goto out_err;
 
-  log_debug(ratbag, "New device: %s\n", name);
+	log_debug(ratbag, "New device: %s\n", name);
 
-  device = ratbag_device_new(ratbag, udev_device, name, &id);
-  if (!device || !device->data)
-    goto out_err;
+	device = ratbag_device_new(ratbag, udev_device, name, &id);
+	if (!device || !device->data)
+		goto out_err;
 
-  if (!ratbag_assign_driver(device, &device->ids, NULL))
-    goto out_err;
+	if (!ratbag_assign_driver(device, &device->ids, NULL))
+		goto out_err;
 
-  error = RATBAG_SUCCESS;
+	error = RATBAG_SUCCESS;
 
 out_err:
 
-  if (error != RATBAG_SUCCESS)
-    ratbag_device_destroy(device);
-  else
-    *device_out = device;
+	if (error != RATBAG_SUCCESS)
+		ratbag_device_destroy(device);
+	else
+		*device_out = device;
 
-  return error_code(error);
+	return error_code(error);
 }
 
-LIBRATBAG_EXPORT struct ratbag_device *
-ratbag_device_ref(struct ratbag_device *device) {
-  assert(device->refcount < INT_MAX);
+LIBRATBAG_EXPORT struct ratbag_device*
+ratbag_device_ref(struct ratbag_device* device)
+{
+	assert(device->refcount < INT_MAX);
 
-  device->refcount++;
-  return device;
+	device->refcount++;
+	return device;
 }
 
-LIBRATBAG_EXPORT struct ratbag_device *
-ratbag_device_unref(struct ratbag_device *device) {
-  if (device == NULL)
-    return NULL;
+LIBRATBAG_EXPORT struct ratbag_device*
+ratbag_device_unref(struct ratbag_device* device)
+{
+	if (device == NULL)
+		return NULL;
 
-  assert(device->refcount > 0);
-  device->refcount--;
-  if (device->refcount == 0)
-    ratbag_device_destroy(device);
+	assert(device->refcount > 0);
+	device->refcount--;
+	if (device->refcount == 0)
+		ratbag_device_destroy(device);
 
-  return NULL;
+	return NULL;
 }
 
-LIBRATBAG_EXPORT const char *
-ratbag_device_get_name(const struct ratbag_device *device) {
-  return device->name;
+LIBRATBAG_EXPORT const char*
+ratbag_device_get_name(const struct ratbag_device* device)
+{
+	return device->name;
 }
 
 LIBRATBAG_EXPORT enum ratbag_device_type
-ratbag_device_get_device_type(const struct ratbag_device *device) {
-  return device->devicetype;
+ratbag_device_get_device_type(const struct ratbag_device* device)
+{
+	return device->devicetype;
 }
 
-LIBRATBAG_EXPORT const char *
-ratbag_device_get_bustype(const struct ratbag_device *device) {
-  switch (device->ids.bustype) {
-  case BUS_USB:
-    return "usb";
-  case BUS_BLUETOOTH:
-    return "bluetooth";
-  default:
-    return NULL;
-  }
-}
-
-LIBRATBAG_EXPORT uint32_t
-ratbag_device_get_vendor_id(const struct ratbag_device *device) {
-  return device->ids.vendor;
-}
-
-LIBRATBAG_EXPORT uint32_t
-ratbag_device_get_product_id(const struct ratbag_device *device) {
-  return device->ids.product;
+LIBRATBAG_EXPORT const char*
+ratbag_device_get_bustype(const struct ratbag_device* device)
+{
+	switch (device->ids.bustype)
+	{
+	case BUS_USB:
+		return "usb";
+	case BUS_BLUETOOTH:
+		return "bluetooth";
+	default:
+		return NULL;
+	}
 }
 
 LIBRATBAG_EXPORT uint32_t
-ratbag_device_get_product_version(const struct ratbag_device *device) {
-  /* change this when we have a need for it, i.e. when we start supporting
-   * devices where the USB ID gets reused */
-  return 0;
+ratbag_device_get_vendor_id(const struct ratbag_device* device)
+{
+	return device->ids.vendor;
 }
 
-void ratbag_register_driver(struct ratbag *ratbag,
-                            struct ratbag_driver *driver) {
-  if (!driver->name) {
-    log_bug_libratbag(ratbag, "Driver is missing name\n");
-    return;
-  }
-
-  if (!driver->probe || !driver->remove) {
-    log_bug_libratbag(ratbag, "Driver %s is incomplete.\n", driver->name);
-    return;
-  }
-  list_insert(&ratbag->drivers, &driver->link);
+LIBRATBAG_EXPORT uint32_t
+ratbag_device_get_product_id(const struct ratbag_device* device)
+{
+	return device->ids.product;
 }
 
-LIBRATBAG_EXPORT struct ratbag *
-ratbag_create_context(const struct ratbag_interface *interface,
-                      void *userdata) {
-  struct ratbag *ratbag;
-
-  assert(interface != NULL);
-  assert(interface->open_restricted != NULL);
-  assert(interface->close_restricted != NULL);
-
-  ratbag = zalloc(sizeof(*ratbag));
-  ratbag->refcount = 1;
-  ratbag->interface = interface;
-  ratbag->userdata = userdata;
-
-  list_init(&ratbag->drivers);
-  list_init(&ratbag->devices);
-  ratbag->udev = udev_new();
-  if (!ratbag->udev) {
-    free(ratbag);
-    return NULL;
-  }
-
-  ratbag->log_handler = ratbag_default_log_func;
-  ratbag->log_priority = RATBAG_LOG_PRIORITY_INFO;
-
-  ratbag_register_driver(ratbag, &etekcity_driver);
-  ratbag_register_driver(ratbag, &hidpp20_driver);
-  ratbag_register_driver(ratbag, &hidpp10_driver);
-  ratbag_register_driver(ratbag, &logitech_g300_driver);
-  ratbag_register_driver(ratbag, &logitech_g600_driver);
-  ratbag_register_driver(ratbag, &marsgaming_driver);
-  ratbag_register_driver(ratbag, &roccat_driver);
-  ratbag_register_driver(ratbag, &roccat_kone_pure_driver);
-  ratbag_register_driver(ratbag, &roccat_emp_driver);
-  ratbag_register_driver(ratbag, &gskill_driver);
-  ratbag_register_driver(ratbag, &steelseries_driver);
-  ratbag_register_driver(ratbag, &asus_driver);
-  ratbag_register_driver(ratbag, &sinowealth_driver);
-  ratbag_register_driver(ratbag, &sinowealth_nubwo_driver);
-  ratbag_register_driver(ratbag, &openinput_driver);
-
-  return ratbag;
+LIBRATBAG_EXPORT uint32_t
+ratbag_device_get_product_version(const struct ratbag_device* device)
+{
+	/* change this when we have a need for it, i.e. when we start supporting
+	 * devices where the USB ID gets reused */
+	return 0;
 }
 
-LIBRATBAG_EXPORT struct ratbag *ratbag_ref(struct ratbag *ratbag) {
-  ratbag->refcount++;
-  return ratbag;
+void ratbag_register_driver(struct ratbag* ratbag,
+                            struct ratbag_driver* driver)
+{
+	if (!driver->name)
+	{
+		log_bug_libratbag(ratbag, "Driver is missing name\n");
+		return;
+	}
+
+	if (!driver->probe || !driver->remove)
+	{
+		log_bug_libratbag(ratbag, "Driver %s is incomplete.\n",
+		                  driver->name);
+		return;
+	}
+	list_insert(&ratbag->drivers, &driver->link);
 }
 
-LIBRATBAG_EXPORT struct ratbag *ratbag_unref(struct ratbag *ratbag) {
-  if (ratbag == NULL)
-    return NULL;
+LIBRATBAG_EXPORT struct ratbag*
+ratbag_create_context(const struct ratbag_interface* interface,
+                      void* userdata)
+{
+	struct ratbag* ratbag;
 
-  assert(ratbag->refcount > 0);
-  ratbag->refcount--;
-  if (ratbag->refcount == 0) {
-    ratbag->udev = udev_unref(ratbag->udev);
-    free(ratbag);
-  }
+	assert(interface != NULL);
+	assert(interface->open_restricted != NULL);
+	assert(interface->close_restricted != NULL);
 
-  return NULL;
+	ratbag = zalloc(sizeof(*ratbag));
+	ratbag->refcount = 1;
+	ratbag->interface = interface;
+	ratbag->userdata = userdata;
+
+	list_init(&ratbag->drivers);
+	list_init(&ratbag->devices);
+	ratbag->udev = udev_new();
+	if (!ratbag->udev)
+	{
+		free(ratbag);
+		return NULL;
+	}
+
+	ratbag->log_handler = ratbag_default_log_func;
+	ratbag->log_priority = RATBAG_LOG_PRIORITY_INFO;
+
+	ratbag_register_driver(ratbag, &etekcity_driver);
+	ratbag_register_driver(ratbag, &hidpp20_driver);
+	ratbag_register_driver(ratbag, &hidpp10_driver);
+	ratbag_register_driver(ratbag, &logitech_g300_driver);
+	ratbag_register_driver(ratbag, &logitech_g600_driver);
+	ratbag_register_driver(ratbag, &marsgaming_driver);
+	ratbag_register_driver(ratbag, &roccat_driver);
+	ratbag_register_driver(ratbag, &roccat_kone_pure_driver);
+	ratbag_register_driver(ratbag, &roccat_emp_driver);
+	ratbag_register_driver(ratbag, &gskill_driver);
+	ratbag_register_driver(ratbag, &steelseries_driver);
+	ratbag_register_driver(ratbag, &asus_driver);
+	ratbag_register_driver(ratbag, &sinowealth_driver);
+	ratbag_register_driver(ratbag, &sinowealth_nubwo_driver);
+	ratbag_register_driver(ratbag, &openinput_driver);
+
+	return ratbag;
 }
 
-static struct ratbag_button *
-ratbag_create_button(struct ratbag_profile *profile, unsigned int index) {
-  struct ratbag_button *button;
-
-  button = zalloc(sizeof(*button));
-  button->refcount = 0;
-  button->profile = profile;
-  button->index = index;
-
-  list_append(&profile->buttons, &button->link);
-
-  return button;
+LIBRATBAG_EXPORT struct ratbag* ratbag_ref(struct ratbag* ratbag)
+{
+	ratbag->refcount++;
+	return ratbag;
 }
 
-static struct ratbag_led *ratbag_create_led(struct ratbag_profile *profile,
-                                            unsigned int index) {
-  struct ratbag_led *led;
+LIBRATBAG_EXPORT struct ratbag* ratbag_unref(struct ratbag* ratbag)
+{
+	if (ratbag == NULL)
+		return NULL;
 
-  led = zalloc(sizeof(*led));
-  led->refcount = 0;
-  led->profile = profile;
-  led->index = index;
-  led->colordepth = RATBAG_LED_COLORDEPTH_RGB_888;
+	assert(ratbag->refcount > 0);
+	ratbag->refcount--;
+	if (ratbag->refcount == 0)
+	{
+		ratbag->udev = udev_unref(ratbag->udev);
+		free(ratbag);
+	}
 
-  list_append(&profile->leds, &led->link);
+	return NULL;
+}
 
-  return led;
+static struct ratbag_button*
+ratbag_create_button(struct ratbag_profile* profile, unsigned int index)
+{
+	struct ratbag_button* button;
+
+	button = zalloc(sizeof(*button));
+	button->refcount = 0;
+	button->profile = profile;
+	button->index = index;
+
+	list_append(&profile->buttons, &button->link);
+
+	return button;
+}
+
+static struct ratbag_led* ratbag_create_led(struct ratbag_profile* profile,
+                                            unsigned int index)
+{
+	struct ratbag_led* led;
+
+	led = zalloc(sizeof(*led));
+	led->refcount = 0;
+	led->profile = profile;
+	led->index = index;
+	led->colordepth = RATBAG_LED_COLORDEPTH_RGB_888;
+
+	list_append(&profile->leds, &led->link);
+
+	return led;
 }
 
 LIBRATBAG_EXPORT bool
-ratbag_profile_has_capability(const struct ratbag_profile *profile,
-                              enum ratbag_profile_capability cap) {
-  if (cap == RATBAG_PROFILE_CAP_NONE || cap >= MAX_CAP)
-    abort();
+ratbag_profile_has_capability(const struct ratbag_profile* profile,
+                              enum ratbag_profile_capability cap)
+{
+	if (cap == RATBAG_PROFILE_CAP_NONE || cap >= MAX_CAP)
+		abort();
 
-  return long_bit_is_set(profile->capabilities, cap);
+	return long_bit_is_set(profile->capabilities, cap);
 }
 
-static inline void ratbag_create_resolution(struct ratbag_profile *profile,
-                                            int index) {
-  struct ratbag_resolution *res;
+static inline void ratbag_create_resolution(struct ratbag_profile* profile,
+                                            int index)
+{
+	struct ratbag_resolution* res;
 
-  res = zalloc(sizeof(*res));
-  res->refcount = 0;
-  res->profile = profile;
-  res->index = index;
+	res = zalloc(sizeof(*res));
+	res->refcount = 0;
+	res->profile = profile;
+	res->index = index;
 
-  list_append(&profile->resolutions, &res->link);
+	list_append(&profile->resolutions, &res->link);
 
-  profile->num_resolutions++;
+	profile->num_resolutions++;
 }
 
-static struct ratbag_profile *
-ratbag_create_profile(struct ratbag_device *device, unsigned int index,
+static struct ratbag_profile*
+ratbag_create_profile(struct ratbag_device* device, unsigned int index,
                       unsigned int num_resolutions, unsigned int num_buttons,
-                      unsigned int num_leds) {
-  struct ratbag_profile *profile;
-  unsigned i;
+                      unsigned int num_leds)
+{
+	struct ratbag_profile* profile;
+	unsigned i;
 
-  profile = zalloc(sizeof(*profile));
-  profile->refcount = 0;
-  profile->device = device;
-  profile->index = index;
-  profile->num_resolutions = 0;
-  profile->is_enabled = true;
-  profile->name = NULL;
-  profile->angle_snapping = -1;
-  profile->motion_sync = -1;
-  profile->ripple_control = -1;
-  profile->debounce = -1;
-  profile->lod = -1;
-  profile->autosleep = -1;
+	profile = zalloc(sizeof(*profile));
+	profile->refcount = 0;
+	profile->device = device;
+	profile->index = index;
+	profile->num_resolutions = 0;
+	profile->is_enabled = true;
+	profile->name = NULL;
+	profile->angle_snapping = -1;
+	profile->motion_sync = -1;
+	profile->ripple_control = -1;
+	profile->debounce = -1;
+	profile->lod = -1;
+	profile->autosleep = -1;
 
-  list_append(&device->profiles, &profile->link);
-  list_init(&profile->buttons);
-  list_init(&profile->leds);
-  list_init(&profile->resolutions);
+	list_append(&device->profiles, &profile->link);
+	list_init(&profile->buttons);
+	list_init(&profile->leds);
+	list_init(&profile->resolutions);
 
-  profile->device->num_buttons = num_buttons;
-  profile->device->num_leds = num_leds;
+	profile->device->num_buttons = num_buttons;
+	profile->device->num_leds = num_leds;
 
-  for (i = 0; i < num_resolutions; i++)
-    ratbag_create_resolution(profile, i);
+	for (i = 0; i < num_resolutions; i++)
+		ratbag_create_resolution(profile, i);
 
-  for (i = 0; i < num_buttons; i++)
-    ratbag_create_button(profile, i);
+	for (i = 0; i < num_buttons; i++)
+		ratbag_create_button(profile, i);
 
-  for (i = 0; i < num_leds; i++)
-    ratbag_create_led(profile, i);
+	for (i = 0; i < num_leds; i++)
+		ratbag_create_led(profile, i);
 
-  return profile;
+	return profile;
 }
 
-int ratbag_device_init_profiles(struct ratbag_device *device,
+int ratbag_device_init_profiles(struct ratbag_device* device,
                                 unsigned int num_profiles,
                                 unsigned int num_resolutions,
                                 unsigned int num_buttons,
-                                unsigned int num_leds) {
-  unsigned int i;
-
-  for (i = 0; i < num_profiles; i++) {
-    ratbag_create_profile(device, i, num_resolutions, num_buttons, num_leds);
-  }
-
-  device->num_profiles = num_profiles;
-
-  return 0;
-}
-
-LIBRATBAG_EXPORT struct ratbag_profile *
-ratbag_profile_ref(struct ratbag_profile *profile) {
-  assert(profile->refcount < INT_MAX);
-
-  ratbag_device_ref(profile->device);
-  profile->refcount++;
-  return profile;
-}
-
-static void ratbag_profile_destroy(struct ratbag_profile *profile) {
-  struct ratbag_button *button, *b_next;
-  struct ratbag_led *led, *l_next;
-  struct ratbag_resolution *res, *r_next;
-
-  /* if we get to the point where the profile is destroyed, buttons,
-   * resolutions , etc. are at a refcount of 0, so we can destroy
-   * everything */
-  list_for_each_safe(button, b_next, &profile->buttons, link)
-      ratbag_button_destroy(button);
-
-  list_for_each_safe(led, l_next, &profile->leds, link) ratbag_led_destroy(led);
-
-  list_for_each_safe(res, r_next, &profile->resolutions, link)
-      ratbag_resolution_destroy(res);
-
-  free(profile->name);
-  free(profile->debounces);
-  free(profile->lods);
-  free(profile->autosleeps);
-
-  list_remove(&profile->link);
-  free(profile);
-}
-
-LIBRATBAG_EXPORT struct ratbag_profile *
-ratbag_profile_unref(struct ratbag_profile *profile) {
-  if (profile == NULL)
-    return NULL;
-
-  assert(profile->refcount > 0);
-  profile->refcount--;
-
-  ratbag_device_unref(profile->device);
-
-  return NULL;
-}
-
-LIBRATBAG_EXPORT struct ratbag_profile *
-ratbag_device_get_profile(struct ratbag_device *device, unsigned int index) {
-  struct ratbag_profile *profile;
-
-  if (index >= ratbag_device_get_num_profiles(device)) {
-    log_bug_client(device->ratbag, "Requested invalid profile %d\n", index);
-    return NULL;
-  }
-
-  list_for_each(profile, &device->profiles, link) {
-    if (profile->index == index)
-      return ratbag_profile_ref(profile);
-  }
-
-  log_bug_libratbag(device->ratbag, "Profile %d not found\n", index);
-
-  return NULL;
-}
-
-LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_profile_set_enabled(struct ratbag_profile *profile, bool enabled) {
-  if (!ratbag_profile_has_capability(profile, RATBAG_PROFILE_CAP_DISABLE))
-    return RATBAG_ERROR_CAPABILITY;
-
-  if (profile->is_active && !enabled)
-    return RATBAG_ERROR_VALUE;
-
-  profile->is_enabled = enabled;
-  profile->dirty = true;
-
-  return RATBAG_SUCCESS;
-}
-
-LIBRATBAG_EXPORT int
-ratbag_profile_load(struct ratbag_profile *profile)
+                                unsigned int num_leds)
 {
-  struct ratbag_device *device = profile->device;
+	unsigned int i;
 
-  if (profile->loaded)
-    return 0;
+	for (i = 0; i < num_profiles; i++)
+	{
+		ratbag_create_profile(device, i, num_resolutions, num_buttons,
+		                      num_leds);
+	}
 
-  if (!device->driver->read_profile) {
-    profile->loaded = true;
-    return 0;
-  }
+	device->num_profiles = num_profiles;
 
-  int rc = device->driver->read_profile(profile);
-  if (rc) {
-    log_error(device->ratbag,
-              "Failed to load profile %d: %d\n",
-              profile->index, rc);
-    return rc;
-  }
-
-  if (!ratbag_sanity_check_profile(profile)) {
-    log_error(device->ratbag,
-              "Profile %d failed sanity check after loading\n",
-              profile->index);
-    return -EINVAL;
-  }
-
-  profile->loaded = true;
-  return 0;
+	return 0;
 }
 
-LIBRATBAG_EXPORT bool
-ratbag_profile_is_active(const struct ratbag_profile *profile) {
-  return !!profile->is_active;
+LIBRATBAG_EXPORT struct ratbag_profile*
+ratbag_profile_ref(struct ratbag_profile* profile)
+{
+	assert(profile->refcount < INT_MAX);
+
+	ratbag_device_ref(profile->device);
+	profile->refcount++;
+	return profile;
 }
 
-LIBRATBAG_EXPORT bool
-ratbag_profile_is_dirty(const struct ratbag_profile *profile) {
-  return !!profile->dirty;
+static void ratbag_profile_destroy(struct ratbag_profile* profile)
+{
+	struct ratbag_button *button, *b_next;
+	struct ratbag_led *led, *l_next;
+	struct ratbag_resolution *res, *r_next;
+
+	/* if we get to the point where the profile is destroyed, buttons,
+	 * resolutions , etc. are at a refcount of 0, so we can destroy
+	 * everything */
+	list_for_each_safe(button, b_next, &profile->buttons, link)
+		ratbag_button_destroy(button);
+
+	list_for_each_safe(led, l_next, &profile->leds, link)
+		ratbag_led_destroy(led);
+
+	list_for_each_safe(res, r_next, &profile->resolutions, link)
+		ratbag_resolution_destroy(res);
+
+	free(profile->name);
+	free(profile->debounces);
+	free(profile->lods);
+	free(profile->autosleeps);
+
+	list_remove(&profile->link);
+	free(profile);
 }
 
-LIBRATBAG_EXPORT bool
-ratbag_profile_is_enabled(const struct ratbag_profile *profile) {
-  return !!profile->is_enabled;
+LIBRATBAG_EXPORT struct ratbag_profile*
+ratbag_profile_unref(struct ratbag_profile* profile)
+{
+	if (profile == NULL)
+		return NULL;
+
+	assert(profile->refcount > 0);
+	profile->refcount--;
+
+	ratbag_device_unref(profile->device);
+
+	return NULL;
 }
 
-LIBRATBAG_EXPORT unsigned int
-ratbag_device_get_num_profiles(const struct ratbag_device *device) {
-  return device->num_profiles;
-}
+LIBRATBAG_EXPORT struct ratbag_profile*
+ratbag_device_get_profile(struct ratbag_device* device, unsigned int index)
+{
+	struct ratbag_profile* profile;
 
-LIBRATBAG_EXPORT unsigned int
-ratbag_device_get_num_buttons(const struct ratbag_device *device) {
-  return device->num_buttons;
-}
+	if (index >= ratbag_device_get_num_profiles(device))
+	{
+		log_bug_client(device->ratbag, "Requested invalid profile %d\n",
+		               index);
+		return NULL;
+	}
 
-LIBRATBAG_EXPORT unsigned int
-ratbag_device_get_num_leds(const struct ratbag_device *device) {
-  return device->num_leds;
-}
+	list_for_each(profile, &device->profiles, link)
+	{
+		if (profile->index == index)
+			return ratbag_profile_ref(profile);
+	}
 
-LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_device_commit(struct ratbag_device *device) {
-  struct ratbag_profile *profile;
-  struct ratbag_button *button;
-  struct ratbag_led *led;
-  struct ratbag_resolution *resolution;
-  int rc;
+	log_bug_libratbag(device->ratbag, "Profile %d not found\n", index);
 
-  if (device->driver->commit == NULL) {
-    log_error(
-        device->ratbag,
-        "Trying to commit with a driver that doesn't support committing\n");
-    return RATBAG_ERROR_CAPABILITY;
-  }
-
-  rc = device->driver->commit(device);
-  if (rc)
-    return RATBAG_ERROR_DEVICE;
-
-  list_for_each(profile, &device->profiles, link) {
-    profile->dirty = false;
-
-    profile->angle_snapping_dirty = false;
-    profile->debounce_dirty = false;
-    profile->lod_dirty = false;
-    profile->autosleep_dirty = false;
-    profile->rate_dirty = false;
-
-    list_for_each(button, &profile->buttons, link) button->dirty = false;
-
-    list_for_each(led, &profile->leds, link) led->dirty = false;
-
-    list_for_each(resolution, &profile->resolutions, link) resolution->dirty =
-        false;
-
-    /* TODO: think if this should be moved into `driver-commit`. */
-    if (profile->is_active_dirty && profile->is_active) {
-      if (device->driver->set_active_profile == NULL)
-        return RATBAG_ERROR_IMPLEMENTATION;
-
-      rc = device->driver->set_active_profile(device, profile->index);
-      if (rc)
-        return RATBAG_ERROR_DEVICE;
-    }
-    profile->is_active_dirty = false;
-  }
-
-  return RATBAG_SUCCESS;
+	return NULL;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_device_reset(struct ratbag_device *device) {
-  int rc;
+ratbag_profile_set_enabled(struct ratbag_profile* profile, bool enabled)
+{
+	if (!ratbag_profile_has_capability(profile, RATBAG_PROFILE_CAP_DISABLE))
+		return RATBAG_ERROR_CAPABILITY;
 
-  if (device->driver->reset == NULL) {
-    log_error(device->ratbag,
-              "Trying to reset a device whose driver doesn't support reset\n");
-    return RATBAG_ERROR_CAPABILITY;
-  }
+	if (profile->is_active && !enabled)
+		return RATBAG_ERROR_VALUE;
 
-  rc = device->driver->reset(device);
-  if (rc)
-    return RATBAG_ERROR_DEVICE;
+	profile->is_enabled = enabled;
+	profile->dirty = true;
 
-  return RATBAG_SUCCESS;
-}
-
-LIBRATBAG_EXPORT bool
-ratbag_device_has_event_support(struct ratbag_device *device) {
-  return device->driver && device->driver->handle_event != NULL;
+	return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT int
-ratbag_device_get_hidraw_fd(struct ratbag_device *device, unsigned int index) {
-  if (index >= MAX_HIDRAW)
-    return -1;
-  return device->hidraw[index].fd;
-}
+ratbag_profile_load(struct ratbag_profile* profile)
+{
+	struct ratbag_device* device = profile->device;
 
-LIBRATBAG_EXPORT unsigned int
-ratbag_device_dispatch_event(struct ratbag_device *device,
-                             const uint8_t *buf, size_t len,
-                             int hidraw_index) {
-  if (!device->driver || !device->driver->handle_event)
-    return RATBAG_EVENT_NONE;
-  return device->driver->handle_event(device, buf, len, hidraw_index);
-}
+	if (profile->loaded)
+		return 0;
 
-LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_profile_set_active(struct ratbag_profile *profile) {
-  struct ratbag_device *device = profile->device;
-  struct ratbag_profile *p;
+	if (!device->driver->read_profile)
+	{
+		profile->loaded = true;
+		return 0;
+	}
 
-  if (!profile->is_enabled)
-    return RATBAG_ERROR_VALUE;
+	int rc = device->driver->read_profile(profile);
+	if (rc)
+	{
+		log_error(device->ratbag,
+		          "Failed to load profile %d: %d\n",
+		          profile->index, rc);
+		return rc;
+	}
 
-  if (device->num_profiles == 1)
-    return RATBAG_SUCCESS;
+	if (!ratbag_sanity_check_profile(profile))
+	{
+		log_error(device->ratbag,
+		          "Profile %d failed sanity check after loading\n",
+		          profile->index);
+		return -EINVAL;
+	}
 
-  list_for_each(p, &device->profiles, link) {
-    if (p->is_active) {
-      p->is_active = false;
-      p->is_active_dirty = true;
-      p->dirty = true;
-    }
-  }
-
-  profile->is_active = true;
-  profile->is_active_dirty = true;
-  profile->dirty = true;
-  return RATBAG_SUCCESS;
-}
-
-LIBRATBAG_EXPORT unsigned int
-ratbag_profile_get_num_resolutions(const struct ratbag_profile *profile) {
-  return profile->num_resolutions;
-}
-
-LIBRATBAG_EXPORT struct ratbag_resolution *
-ratbag_profile_get_resolution(struct ratbag_profile *profile,
-                              unsigned int idx) {
-  struct ratbag_device *device = profile->device;
-  struct ratbag_resolution *res;
-  unsigned max = ratbag_profile_get_num_resolutions(profile);
-
-  if (idx >= max) {
-    log_bug_client(profile->device->ratbag, "Requested invalid resolution %d\n",
-                   idx);
-    return NULL;
-  }
-
-  ratbag_profile_for_each_resolution(profile, res) {
-    if (res->index == idx)
-      return ratbag_resolution_ref(res);
-  }
-
-  log_bug_libratbag(device->ratbag, "Resolution %d, profile %d not found\n",
-                    idx, profile->index);
-
-  return NULL;
-}
-
-LIBRATBAG_EXPORT struct ratbag_resolution *
-ratbag_resolution_ref(struct ratbag_resolution *resolution) {
-  assert(resolution->refcount < INT_MAX);
-
-  ratbag_profile_ref(resolution->profile);
-  resolution->refcount++;
-  return resolution;
-}
-
-LIBRATBAG_EXPORT struct ratbag_resolution *
-ratbag_resolution_unref(struct ratbag_resolution *resolution) {
-  if (resolution == NULL)
-    return NULL;
-
-  assert(resolution->refcount > 0);
-  resolution->refcount--;
-
-  ratbag_profile_unref(resolution->profile);
-
-  return NULL;
+	profile->loaded = true;
+	return 0;
 }
 
 LIBRATBAG_EXPORT bool
-ratbag_resolution_has_capability(const struct ratbag_resolution *resolution,
-                                 enum ratbag_resolution_capability cap) {
-  assert(cap <= RATBAG_RESOLUTION_CAP_DISABLE);
+ratbag_profile_is_active(const struct ratbag_profile* profile)
+{
+	return !!profile->is_active;
+}
 
-  return !!(resolution->capabilities & (1 << cap));
+LIBRATBAG_EXPORT bool
+ratbag_profile_is_dirty(const struct ratbag_profile* profile)
+{
+	return !!profile->dirty;
+}
+
+LIBRATBAG_EXPORT bool
+ratbag_profile_is_enabled(const struct ratbag_profile* profile)
+{
+	return !!profile->is_enabled;
+}
+
+LIBRATBAG_EXPORT unsigned int
+ratbag_device_get_num_profiles(const struct ratbag_device* device)
+{
+	return device->num_profiles;
+}
+
+LIBRATBAG_EXPORT unsigned int
+ratbag_device_get_num_buttons(const struct ratbag_device* device)
+{
+	return device->num_buttons;
+}
+
+LIBRATBAG_EXPORT unsigned int
+ratbag_device_get_num_leds(const struct ratbag_device* device)
+{
+	return device->num_leds;
+}
+
+LIBRATBAG_EXPORT enum ratbag_error_code
+ratbag_device_commit(struct ratbag_device* device)
+{
+	struct ratbag_profile* profile;
+	struct ratbag_button* button;
+	struct ratbag_led* led;
+	struct ratbag_resolution* resolution;
+	int rc;
+
+	if (device->driver->commit == NULL)
+	{
+		log_error(
+			device->ratbag,
+			"Trying to commit with a driver that doesn't support committing\n");
+		return RATBAG_ERROR_CAPABILITY;
+	}
+
+	rc = device->driver->commit(device);
+	if (rc)
+		return RATBAG_ERROR_DEVICE;
+
+	list_for_each(profile, &device->profiles, link)
+	{
+		profile->dirty = false;
+
+		profile->angle_snapping_dirty = false;
+		profile->debounce_dirty = false;
+		profile->lod_dirty = false;
+		profile->autosleep_dirty = false;
+		profile->rate_dirty = false;
+
+		list_for_each(button, &profile->buttons, link) button->dirty =
+			false;
+
+		list_for_each(led, &profile->leds, link) led->dirty = false;
+
+		list_for_each(resolution, &profile->resolutions, link)
+			resolution->dirty =
+				false;
+
+		/* TODO: think if this should be moved into `driver-commit`. */
+		if (profile->is_active_dirty && profile->is_active)
+		{
+			if (device->driver->set_active_profile == NULL)
+				return RATBAG_ERROR_IMPLEMENTATION;
+
+			rc = device->driver->set_active_profile(
+				device, profile->index);
+			if (rc)
+				return RATBAG_ERROR_DEVICE;
+		}
+		profile->is_active_dirty = false;
+	}
+
+	return RATBAG_SUCCESS;
+}
+
+LIBRATBAG_EXPORT enum ratbag_error_code
+ratbag_device_reset(struct ratbag_device* device)
+{
+	int rc;
+
+	if (device->driver->reset == NULL)
+	{
+		log_error(device->ratbag,
+		          "Trying to reset a device whose driver doesn't support reset\n");
+		return RATBAG_ERROR_CAPABILITY;
+	}
+
+	rc = device->driver->reset(device);
+	if (rc)
+		return RATBAG_ERROR_DEVICE;
+
+	return RATBAG_SUCCESS;
+}
+
+LIBRATBAG_EXPORT bool
+ratbag_device_has_event_support(struct ratbag_device* device)
+{
+	return device->driver && device->driver->handle_event != NULL;
+}
+
+LIBRATBAG_EXPORT int
+ratbag_device_get_hidraw_fd(struct ratbag_device* device, unsigned int index)
+{
+	if (index >= MAX_HIDRAW)
+		return -1;
+	return device->hidraw[index].fd;
+}
+
+LIBRATBAG_EXPORT unsigned int
+ratbag_device_dispatch_event(struct ratbag_device* device,
+                             const uint8_t* buf, size_t len,
+                             int hidraw_index)
+{
+	if (!device->driver || !device->driver->handle_event)
+		return RATBAG_EVENT_NONE;
+	return device->driver->handle_event(device, buf, len, hidraw_index);
+}
+
+LIBRATBAG_EXPORT enum ratbag_error_code
+ratbag_profile_set_active(struct ratbag_profile* profile)
+{
+	struct ratbag_device* device = profile->device;
+	struct ratbag_profile* p;
+
+	if (!profile->is_enabled)
+		return RATBAG_ERROR_VALUE;
+
+	if (device->num_profiles == 1)
+		return RATBAG_SUCCESS;
+
+	list_for_each(p, &device->profiles, link)
+	{
+		if (p->is_active)
+		{
+			p->is_active = false;
+			p->is_active_dirty = true;
+			p->dirty = true;
+		}
+	}
+
+	profile->is_active = true;
+	profile->is_active_dirty = true;
+	profile->dirty = true;
+	return RATBAG_SUCCESS;
+}
+
+LIBRATBAG_EXPORT unsigned int
+ratbag_profile_get_num_resolutions(const struct ratbag_profile* profile)
+{
+	return profile->num_resolutions;
+}
+
+LIBRATBAG_EXPORT struct ratbag_resolution*
+ratbag_profile_get_resolution(struct ratbag_profile* profile,
+                              unsigned int idx)
+{
+	struct ratbag_device* device = profile->device;
+	struct ratbag_resolution* res;
+	unsigned max = ratbag_profile_get_num_resolutions(profile);
+
+	if (idx >= max)
+	{
+		log_bug_client(profile->device->ratbag,
+		               "Requested invalid resolution %d\n",
+		               idx);
+		return NULL;
+	}
+
+	ratbag_profile_for_each_resolution(profile, res)
+	{
+		if (res->index == idx)
+			return ratbag_resolution_ref(res);
+	}
+
+	log_bug_libratbag(device->ratbag,
+	                  "Resolution %d, profile %d not found\n",
+	                  idx, profile->index);
+
+	return NULL;
+}
+
+LIBRATBAG_EXPORT struct ratbag_resolution*
+ratbag_resolution_ref(struct ratbag_resolution* resolution)
+{
+	assert(resolution->refcount < INT_MAX);
+
+	ratbag_profile_ref(resolution->profile);
+	resolution->refcount++;
+	return resolution;
+}
+
+LIBRATBAG_EXPORT struct ratbag_resolution*
+ratbag_resolution_unref(struct ratbag_resolution* resolution)
+{
+	if (resolution == NULL)
+		return NULL;
+
+	assert(resolution->refcount > 0);
+	resolution->refcount--;
+
+	ratbag_profile_unref(resolution->profile);
+
+	return NULL;
+}
+
+LIBRATBAG_EXPORT bool
+ratbag_resolution_has_capability(const struct ratbag_resolution* resolution,
+                                 enum ratbag_resolution_capability cap)
+{
+	assert(cap <= RATBAG_RESOLUTION_CAP_DISABLE);
+
+	return !!(resolution->capabilities & (1 << cap));
 }
 
 static inline bool
-resolution_has_dpi(const struct ratbag_resolution *resolution,
-                   unsigned int dpi) {
-  for (size_t i = 0; i < resolution->ndpis; i++) {
-    if (dpi == resolution->dpis[i])
-      return true;
-  }
+resolution_has_dpi(const struct ratbag_resolution* resolution,
+                   unsigned int dpi)
+{
+	for (size_t i = 0; i < resolution->ndpis; i++)
+	{
+		if (dpi == resolution->dpis[i])
+			return true;
+	}
 
-  return false;
+	return false;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_resolution_set_dpi(struct ratbag_resolution *resolution,
-                          unsigned int dpi) {
-  struct ratbag_profile *profile = resolution->profile;
+ratbag_resolution_set_dpi(struct ratbag_resolution* resolution,
+                          unsigned int dpi)
+{
+	struct ratbag_profile* profile = resolution->profile;
 
-  if (!resolution_has_dpi(resolution, dpi))
-    return RATBAG_ERROR_VALUE;
+	if (!resolution_has_dpi(resolution, dpi))
+		return RATBAG_ERROR_VALUE;
 
-  if (resolution->dpi_x != dpi || resolution->dpi_y != dpi) {
-    resolution->dpi_x = dpi;
-    resolution->dpi_y = dpi;
-    resolution->dirty = true;
-    profile->dirty = true;
-  }
+	if (resolution->dpi_x != dpi || resolution->dpi_y != dpi)
+	{
+		resolution->dpi_x = dpi;
+		resolution->dpi_y = dpi;
+		resolution->dirty = true;
+		profile->dirty = true;
+	}
 
-  return RATBAG_SUCCESS;
+	return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_resolution_set_dpi_xy(struct ratbag_resolution *resolution,
-                             unsigned int x, unsigned int y) {
-  struct ratbag_profile *profile = resolution->profile;
+ratbag_resolution_set_dpi_xy(struct ratbag_resolution* resolution,
+                             unsigned int x, unsigned int y)
+{
+	struct ratbag_profile* profile = resolution->profile;
 
-  if (!ratbag_resolution_has_capability(
-          resolution, RATBAG_RESOLUTION_CAP_SEPARATE_XY_RESOLUTION))
-    return RATBAG_ERROR_CAPABILITY;
+	if (!ratbag_resolution_has_capability(
+		resolution, RATBAG_RESOLUTION_CAP_SEPARATE_XY_RESOLUTION))
+		return RATBAG_ERROR_CAPABILITY;
 
-  if ((x == 0 && y != 0) || (x != 0 && y == 0))
-    return RATBAG_ERROR_VALUE;
+	if ((x == 0 && y != 0) || (x != 0 && y == 0))
+		return RATBAG_ERROR_VALUE;
 
-  if (!resolution_has_dpi(resolution, x) || !resolution_has_dpi(resolution, y))
-    return RATBAG_ERROR_VALUE;
+	if (!resolution_has_dpi(resolution, x) || !resolution_has_dpi(
+		resolution, y))
+		return RATBAG_ERROR_VALUE;
 
-  if (resolution->dpi_x != x || resolution->dpi_y != y) {
-    resolution->dpi_x = x;
-    resolution->dpi_y = y;
-    resolution->dirty = true;
-    profile->dirty = true;
-  }
+	if (resolution->dpi_x != x || resolution->dpi_y != y)
+	{
+		resolution->dpi_x = x;
+		resolution->dpi_y = y;
+		resolution->dirty = true;
+		profile->dirty = true;
+	}
 
-  return RATBAG_SUCCESS;
+	return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_profile_set_report_rate(struct ratbag_profile *profile,
-                               unsigned int hz) {
-  if (profile->hz != hz) {
-    profile->hz = hz;
-    profile->dirty = true;
-    profile->rate_dirty = true;
-  }
+ratbag_profile_set_report_rate(struct ratbag_profile* profile,
+                               unsigned int hz)
+{
+	if (profile->hz != hz)
+	{
+		profile->hz = hz;
+		profile->dirty = true;
+		profile->rate_dirty = true;
+	}
 
-  return RATBAG_SUCCESS;
+	return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_profile_set_angle_snapping(struct ratbag_profile *profile, int value) {
-  if (profile->angle_snapping != value) {
-    profile->angle_snapping = value;
-    profile->dirty = true;
-    profile->angle_snapping_dirty = true;
-  }
+ratbag_profile_set_angle_snapping(struct ratbag_profile* profile, int value)
+{
+	if (profile->angle_snapping != value)
+	{
+		profile->angle_snapping = value;
+		profile->dirty = true;
+		profile->angle_snapping_dirty = true;
+	}
 
-  return RATBAG_SUCCESS;
+	return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_profile_set_motion_sync(struct ratbag_profile *profile, int value) {
-  if (profile->motion_sync != value) {
-    profile->motion_sync = value;
-    profile->dirty = true;
-    profile->motion_sync_dirty = true;
-  }
+ratbag_profile_set_motion_sync(struct ratbag_profile* profile, int value)
+{
+	if (profile->motion_sync != value)
+	{
+		profile->motion_sync = value;
+		profile->dirty = true;
+		profile->motion_sync_dirty = true;
+	}
 
-  return RATBAG_SUCCESS;
+	return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_profile_set_ripple_control(struct ratbag_profile *profile, int value) {
-  if (profile->ripple_control != value) {
-    profile->ripple_control = value;
-    profile->dirty = true;
-    profile->ripple_control_dirty = true;
-  }
+ratbag_profile_set_ripple_control(struct ratbag_profile* profile, int value)
+{
+	if (profile->ripple_control != value)
+	{
+		profile->ripple_control = value;
+		profile->dirty = true;
+		profile->ripple_control_dirty = true;
+	}
 
-  return RATBAG_SUCCESS;
+	return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_profile_set_debounce(struct ratbag_profile *profile, int value) {
-  if (profile->debounce != value) {
-    profile->debounce = value;
-    profile->dirty = true;
-    profile->debounce_dirty = true;
-  }
+ratbag_profile_set_debounce(struct ratbag_profile* profile, int value)
+{
+	if (profile->debounce != value)
+	{
+		profile->debounce = value;
+		profile->dirty = true;
+		profile->debounce_dirty = true;
+	}
 
-  return RATBAG_SUCCESS;
+	return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT int
-ratbag_resolution_get_dpi(const struct ratbag_resolution *resolution) {
-  return resolution->dpi_x;
+ratbag_resolution_get_dpi(const struct ratbag_resolution* resolution)
+{
+	return resolution->dpi_x;
 }
 
 LIBRATBAG_EXPORT size_t
-ratbag_resolution_get_dpi_list(const struct ratbag_resolution *resolution,
-                               unsigned int *resolutions, size_t nres) {
-  _Static_assert(sizeof(*resolutions) == sizeof(*resolution->dpis),
-                 "type mismatch");
+ratbag_resolution_get_dpi_list(const struct ratbag_resolution* resolution,
+                               unsigned int* resolutions, size_t nres)
+{
+	_Static_assert(sizeof(*resolutions) == sizeof(*resolution->dpis),
+	               "type mismatch");
 
-  assert(nres > 0);
+	assert(nres > 0);
 
-  if (resolution->ndpis == 0)
-    return 0;
+	if (resolution->ndpis == 0)
+		return 0;
 
-  memcpy(resolutions, resolution->dpis,
-         sizeof(unsigned int) * min(nres, resolution->ndpis));
+	memcpy(resolutions, resolution->dpis,
+	       sizeof(unsigned int) * min(nres, resolution->ndpis));
 
-  return resolution->ndpis;
+	return resolution->ndpis;
 }
 
 LIBRATBAG_EXPORT int
-ratbag_resolution_get_dpi_x(const struct ratbag_resolution *resolution) {
-  return resolution->dpi_x;
+ratbag_resolution_get_dpi_x(const struct ratbag_resolution* resolution)
+{
+	return resolution->dpi_x;
 }
 
 LIBRATBAG_EXPORT int
-ratbag_resolution_get_dpi_y(const struct ratbag_resolution *resolution) {
-  return resolution->dpi_y;
+ratbag_resolution_get_dpi_y(const struct ratbag_resolution* resolution)
+{
+	return resolution->dpi_y;
 }
 
 LIBRATBAG_EXPORT int
-ratbag_profile_get_report_rate(const struct ratbag_profile *profile) {
-  return profile->hz;
+ratbag_profile_get_report_rate(const struct ratbag_profile* profile)
+{
+	return profile->hz;
 }
 
 LIBRATBAG_EXPORT int
-ratbag_profile_get_angle_snapping(const struct ratbag_profile *profile) {
-  return profile->angle_snapping;
+ratbag_profile_get_angle_snapping(const struct ratbag_profile* profile)
+{
+	return profile->angle_snapping;
 }
 
 LIBRATBAG_EXPORT int
-ratbag_profile_get_motion_sync(const struct ratbag_profile *profile) {
-  return profile->motion_sync;
+ratbag_profile_get_motion_sync(const struct ratbag_profile* profile)
+{
+	return profile->motion_sync;
 }
 
 LIBRATBAG_EXPORT int
-ratbag_profile_get_ripple_control(const struct ratbag_profile *profile) {
-  return profile->ripple_control;
+ratbag_profile_get_ripple_control(const struct ratbag_profile* profile)
+{
+	return profile->ripple_control;
 }
 
 LIBRATBAG_EXPORT int
-ratbag_profile_get_debounce(const struct ratbag_profile *profile) {
-  return profile->debounce;
+ratbag_profile_get_debounce(const struct ratbag_profile* profile)
+{
+	return profile->debounce;
 }
 
 LIBRATBAG_EXPORT size_t
-ratbag_profile_get_debounce_list(const struct ratbag_profile *profile,
-                                 unsigned int *debounces, size_t ndebounces) {
-  _Static_assert(sizeof(*debounces) == sizeof(*profile->debounces),
-                 "type mismatch");
+ratbag_profile_get_debounce_list(const struct ratbag_profile* profile,
+                                 unsigned int* debounces, size_t ndebounces)
+{
+	_Static_assert(sizeof(*debounces) == sizeof(*profile->debounces),
+	               "type mismatch");
 
-  assert(ndebounces > 0);
+	assert(ndebounces > 0);
 
-  if (profile->ndebounces == 0)
-    return 0;
+	if (profile->ndebounces == 0)
+		return 0;
 
-  memcpy(debounces, profile->debounces,
-         sizeof(unsigned int) * min(ndebounces, profile->ndebounces));
+	memcpy(debounces, profile->debounces,
+	       sizeof(unsigned int) * min(ndebounces, profile->ndebounces));
 
-  return profile->ndebounces;
+	return profile->ndebounces;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_profile_set_lod(struct ratbag_profile *profile, double value) {
-  if (profile->lod != value) {
-    profile->lod = value;
-    profile->dirty = true;
-    profile->lod_dirty = true;
-  }
+ratbag_profile_set_lod(struct ratbag_profile* profile, double value)
+{
+	if (profile->lod != value)
+	{
+		profile->lod = value;
+		profile->dirty = true;
+		profile->lod_dirty = true;
+	}
 
-  return RATBAG_SUCCESS;
+	return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT double
-ratbag_profile_get_lod(const struct ratbag_profile *profile) {
-  return profile->lod;
+ratbag_profile_get_lod(const struct ratbag_profile* profile)
+{
+	return profile->lod;
 }
 
 LIBRATBAG_EXPORT size_t ratbag_profile_get_lod_list(
-    const struct ratbag_profile *profile, double *lods, size_t nlods) {
-  _Static_assert(sizeof(*lods) == sizeof(*profile->lods), "type mismatch");
+	const struct ratbag_profile* profile, double* lods, size_t nlods)
+{
+	_Static_assert(sizeof(*lods) == sizeof(*profile->lods),
+	               "type mismatch");
 
-  assert(nlods > 0);
+	assert(nlods > 0);
 
-  if (profile->nlods == 0)
-    return 0;
+	if (profile->nlods == 0)
+		return 0;
 
-  memcpy(lods, profile->lods, sizeof(double) * min(nlods, profile->nlods));
+	memcpy(lods, profile->lods,
+	       sizeof(double) * min(nlods, profile->nlods));
 
-  return profile->nlods;
+	return profile->nlods;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_profile_set_autosleep(struct ratbag_profile *profile, int value) {
-  if (profile->autosleep != value) {
-    profile->autosleep = value;
-    profile->dirty = true;
-    profile->autosleep_dirty = true;
-  }
+ratbag_profile_set_autosleep(struct ratbag_profile* profile, int value)
+{
+	if (profile->autosleep != value)
+	{
+		profile->autosleep = value;
+		profile->dirty = true;
+		profile->autosleep_dirty = true;
+	}
 
-  return RATBAG_SUCCESS;
+	return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT int
-ratbag_profile_get_autosleep(const struct ratbag_profile *profile) {
-  return profile->autosleep;
+ratbag_profile_get_autosleep(const struct ratbag_profile* profile)
+{
+	return profile->autosleep;
 }
 
 LIBRATBAG_EXPORT size_t ratbag_profile_get_autosleep_list(
-    const struct ratbag_profile *profile, unsigned int *autosleeps,
-    size_t nautosleeps) {
-  _Static_assert(sizeof(*autosleeps) == sizeof(*profile->autosleeps),
-                 "type mismatch");
+	const struct ratbag_profile* profile, unsigned int* autosleeps,
+	size_t nautosleeps)
+{
+	_Static_assert(sizeof(*autosleeps) == sizeof(*profile->autosleeps),
+	               "type mismatch");
 
-  assert(nautosleeps > 0);
+	assert(nautosleeps > 0);
 
-  if (profile->nautosleeps == 0)
-    return 0;
+	if (profile->nautosleeps == 0)
+		return 0;
 
-  memcpy(autosleeps, profile->autosleeps,
-         sizeof(unsigned int) * min(nautosleeps, profile->nautosleeps));
+	memcpy(autosleeps, profile->autosleeps,
+	       sizeof(unsigned int) * min(nautosleeps, profile->nautosleeps));
 
-  return profile->nautosleeps;
+	return profile->nautosleeps;
 }
 
 LIBRATBAG_EXPORT size_t ratbag_profile_get_report_rate_list(
-    const struct ratbag_profile *profile, unsigned int *rates, size_t nrates) {
-  _Static_assert(sizeof(*rates) == sizeof(*profile->rates), "type mismatch");
+	const struct ratbag_profile* profile, unsigned int* rates,
+	size_t nrates)
+{
+	_Static_assert(sizeof(*rates) == sizeof(*profile->rates),
+	               "type mismatch");
 
-  assert(nrates > 0);
+	assert(nrates > 0);
 
-  if (profile->nrates == 0)
-    return 0;
+	if (profile->nrates == 0)
+		return 0;
 
-  memcpy(rates, profile->rates,
-         sizeof(unsigned int) * min(nrates, profile->nrates));
+	memcpy(rates, profile->rates,
+	       sizeof(unsigned int) * min(nrates, profile->nrates));
 
-  return profile->nrates;
+	return profile->nrates;
 }
 
 LIBRATBAG_EXPORT bool
-ratbag_resolution_is_active(const struct ratbag_resolution *resolution) {
-  return !!resolution->is_active;
+ratbag_resolution_is_active(const struct ratbag_resolution* resolution)
+{
+	return !!resolution->is_active;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_resolution_set_active(struct ratbag_resolution *resolution) {
-  struct ratbag_profile *profile = resolution->profile;
-  struct ratbag_resolution *res;
+ratbag_resolution_set_active(struct ratbag_resolution* resolution)
+{
+	struct ratbag_profile* profile = resolution->profile;
+	struct ratbag_resolution* res;
 
-  if (resolution->is_disabled) {
-    log_error(profile->device->ratbag,
-              "%s: setting the active resolution to a disabled resolution is "
-              "not allowed\n",
-              profile->device->name);
-    return RATBAG_ERROR_VALUE;
-  }
+	if (resolution->is_disabled)
+	{
+		log_error(profile->device->ratbag,
+		          "%s: setting the active resolution to a disabled resolution is "
+		          "not allowed\n",
+		          profile->device->name);
+		return RATBAG_ERROR_VALUE;
+	}
 
-  ratbag_profile_for_each_resolution(profile, res) res->is_active = false;
+	ratbag_profile_for_each_resolution(profile, res) res->is_active = false;
 
-  resolution->is_active = true;
-  resolution->dirty = true;
-  profile->dirty = true;
-  return RATBAG_SUCCESS;
+	resolution->is_active = true;
+	resolution->dirty = true;
+	profile->dirty = true;
+	return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT bool
-ratbag_resolution_is_default(const struct ratbag_resolution *resolution) {
-  return !!resolution->is_default;
+ratbag_resolution_is_default(const struct ratbag_resolution* resolution)
+{
+	return !!resolution->is_default;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_resolution_set_default(struct ratbag_resolution *resolution) {
-  struct ratbag_profile *profile = resolution->profile;
-  struct ratbag_resolution *other;
+ratbag_resolution_set_default(struct ratbag_resolution* resolution)
+{
+	struct ratbag_profile* profile = resolution->profile;
+	struct ratbag_resolution* other;
 
-  if (resolution->is_disabled) {
-    log_error(profile->device->ratbag,
-              "%s: setting the default resolution to a disabled resolution is "
-              "not allowed\n",
-              profile->device->name);
-    return RATBAG_ERROR_VALUE;
-  }
+	if (resolution->is_disabled)
+	{
+		log_error(profile->device->ratbag,
+		          "%s: setting the default resolution to a disabled resolution is "
+		          "not allowed\n",
+		          profile->device->name);
+		return RATBAG_ERROR_VALUE;
+	}
 
-  /* Unset the default on the other resolutions */
-  ratbag_profile_for_each_resolution(profile, other) {
-    if (other == resolution || !other->is_default)
-      continue;
+	/* Unset the default on the other resolutions */
+	ratbag_profile_for_each_resolution(profile, other)
+	{
+		if (other == resolution || !other->is_default)
+			continue;
 
-    other->is_default = false;
-    resolution->dirty = true;
-    profile->dirty = true;
-  }
+		other->is_default = false;
+		resolution->dirty = true;
+		profile->dirty = true;
+	}
 
-  if (!resolution->is_default) {
-    resolution->is_default = true;
-    resolution->dirty = true;
-    profile->dirty = true;
-  }
+	if (!resolution->is_default)
+	{
+		resolution->is_default = true;
+		resolution->dirty = true;
+		profile->dirty = true;
+	}
 
-  return RATBAG_SUCCESS;
+	return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT bool
-ratbag_resolution_is_disabled(const struct ratbag_resolution *resolution) {
-  return !!resolution->is_disabled;
+ratbag_resolution_is_disabled(const struct ratbag_resolution* resolution)
+{
+	return !!resolution->is_disabled;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_resolution_set_disabled(struct ratbag_resolution *resolution,
-                               bool disable) {
-  struct ratbag_profile *profile = resolution->profile;
+ratbag_resolution_set_disabled(struct ratbag_resolution* resolution,
+                               bool disable)
+{
+	struct ratbag_profile* profile = resolution->profile;
 
-  if (!ratbag_resolution_has_capability(resolution,
-                                        RATBAG_RESOLUTION_CAP_DISABLE))
-    return RATBAG_ERROR_CAPABILITY;
+	if (!ratbag_resolution_has_capability(resolution,
+	                                      RATBAG_RESOLUTION_CAP_DISABLE))
+		return RATBAG_ERROR_CAPABILITY;
 
-  if (disable) {
-    if (resolution->is_active) {
-      log_error(profile->device->ratbag,
-                "%s: disabling the active resolution is not allowed\n",
-                profile->device->name);
-      return RATBAG_ERROR_VALUE;
-    }
-    if (resolution->is_default) {
-      log_error(profile->device->ratbag,
-                "%s: disabling the default resolution is not allowed\n",
-                profile->device->name);
-      return RATBAG_ERROR_VALUE;
-    }
-  }
+	if (disable)
+	{
+		if (resolution->is_active)
+		{
+			log_error(profile->device->ratbag,
+			          "%s: disabling the active resolution is not allowed\n",
+			          profile->device->name);
+			return RATBAG_ERROR_VALUE;
+		}
+		if (resolution->is_default)
+		{
+			log_error(profile->device->ratbag,
+			          "%s: disabling the default resolution is not allowed\n",
+			          profile->device->name);
+			return RATBAG_ERROR_VALUE;
+		}
+	}
 
-  resolution->is_disabled = disable;
-  resolution->dirty = true;
-  profile->dirty = true;
+	resolution->is_disabled = disable;
+	resolution->dirty = true;
+	profile->dirty = true;
 
-  return RATBAG_SUCCESS;
+	return RATBAG_SUCCESS;
 }
 
-LIBRATBAG_EXPORT struct ratbag_button *
-ratbag_profile_get_button(struct ratbag_profile *profile, unsigned int index) {
-  struct ratbag_device *device = profile->device;
-  struct ratbag_button *button;
+LIBRATBAG_EXPORT struct ratbag_button*
+ratbag_profile_get_button(struct ratbag_profile* profile, unsigned int index)
+{
+	struct ratbag_device* device = profile->device;
+	struct ratbag_button* button;
 
-  if (index >= ratbag_device_get_num_buttons(device)) {
-    log_bug_client(device->ratbag, "Requested invalid button %d\n", index);
-    return NULL;
-  }
+	if (index >= ratbag_device_get_num_buttons(device))
+	{
+		log_bug_client(device->ratbag, "Requested invalid button %d\n",
+		               index);
+		return NULL;
+	}
 
-  list_for_each(button, &profile->buttons, link) {
-    if (button->index == index)
-      return ratbag_button_ref(button);
-  }
+	list_for_each(button, &profile->buttons, link)
+	{
+		if (button->index == index)
+			return ratbag_button_ref(button);
+	}
 
-  log_bug_libratbag(device->ratbag, "Button %d, profile %d not found\n", index,
-                    profile->index);
+	log_bug_libratbag(device->ratbag, "Button %d, profile %d not found\n",
+	                  index,
+	                  profile->index);
 
-  return NULL;
+	return NULL;
 }
 
 LIBRATBAG_EXPORT enum ratbag_button_action_type
-ratbag_button_get_action_type(const struct ratbag_button *button) {
-  return button->action.type;
+ratbag_button_get_action_type(const struct ratbag_button* button)
+{
+	return button->action.type;
 }
 
 LIBRATBAG_EXPORT bool
-ratbag_button_has_action_type(const struct ratbag_button *button,
-                              enum ratbag_button_action_type action_type) {
-  switch (action_type) {
-  case RATBAG_BUTTON_ACTION_TYPE_NONE:
-  case RATBAG_BUTTON_ACTION_TYPE_BUTTON:
-  case RATBAG_BUTTON_ACTION_TYPE_SPECIAL:
-  case RATBAG_BUTTON_ACTION_TYPE_KEY:
-  case RATBAG_BUTTON_ACTION_TYPE_MACRO:
-  case RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK:
-    break;
-  default:
-    return 0;
-  }
+ratbag_button_has_action_type(const struct ratbag_button* button,
+                              enum ratbag_button_action_type action_type)
+{
+	switch (action_type)
+	{
+	case RATBAG_BUTTON_ACTION_TYPE_NONE:
+	case RATBAG_BUTTON_ACTION_TYPE_BUTTON:
+	case RATBAG_BUTTON_ACTION_TYPE_SPECIAL:
+	case RATBAG_BUTTON_ACTION_TYPE_KEY:
+	case RATBAG_BUTTON_ACTION_TYPE_MACRO:
+	case RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK:
+		break;
+	default:
+		return 0;
+	}
 
-  return !!(button->action_caps & (1 << action_type));
+	return !!(button->action_caps & (1 << action_type));
 }
 
 LIBRATBAG_EXPORT unsigned int
-ratbag_button_get_button(const struct ratbag_button *button) {
-  if (button->action.type != RATBAG_BUTTON_ACTION_TYPE_BUTTON)
-    return 0;
+ratbag_button_get_button(const struct ratbag_button* button)
+{
+	if (button->action.type != RATBAG_BUTTON_ACTION_TYPE_BUTTON)
+		return 0;
 
-  return button->action.action.button;
+	return button->action.action.button;
 }
 
-void ratbag_button_set_action(struct ratbag_button *button,
-                              const struct ratbag_button_action *action) {
-  struct ratbag_macro *macro = button->action.macro;
+void ratbag_button_set_action(struct ratbag_button* button,
+                              const struct ratbag_button_action* action)
+{
+	struct ratbag_macro* macro = button->action.macro;
 
-  button->action = *action;
-  if (action->type != RATBAG_BUTTON_ACTION_TYPE_MACRO)
-    button->action.macro = macro;
+	button->action = *action;
+	if (action->type != RATBAG_BUTTON_ACTION_TYPE_MACRO)
+		button->action.macro = macro;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_button_set_button(struct ratbag_button *button, unsigned int btn) {
-  struct ratbag_button_action action = {0};
+ratbag_button_set_button(struct ratbag_button* button, unsigned int btn)
+{
+	struct ratbag_button_action action = {0};
 
-  if (!ratbag_button_has_action_type(button, RATBAG_BUTTON_ACTION_TYPE_BUTTON))
-    return RATBAG_ERROR_CAPABILITY;
+	if (!ratbag_button_has_action_type(
+		button, RATBAG_BUTTON_ACTION_TYPE_BUTTON))
+		return RATBAG_ERROR_CAPABILITY;
 
-  action.type = RATBAG_BUTTON_ACTION_TYPE_BUTTON;
-  action.action.button = btn;
+	action.type = RATBAG_BUTTON_ACTION_TYPE_BUTTON;
+	action.action.button = btn;
 
-  ratbag_button_set_action(button, &action);
-  button->dirty = true;
-  button->profile->dirty = true;
+	ratbag_button_set_action(button, &action);
+	button->dirty = true;
+	button->profile->dirty = true;
 
-  return RATBAG_SUCCESS;
+	return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT enum ratbag_button_action_special
-ratbag_button_get_special(const struct ratbag_button *button) {
-  if (button->action.type != RATBAG_BUTTON_ACTION_TYPE_SPECIAL)
-    return RATBAG_BUTTON_ACTION_SPECIAL_INVALID;
+ratbag_button_get_special(const struct ratbag_button* button)
+{
+	if (button->action.type != RATBAG_BUTTON_ACTION_TYPE_SPECIAL)
+		return RATBAG_BUTTON_ACTION_SPECIAL_INVALID;
 
-  return button->action.action.special;
+	return button->action.action.special;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_button_set_special(struct ratbag_button *button,
-                          enum ratbag_button_action_special act) {
-  struct ratbag_button_action action = {0};
+ratbag_button_set_special(struct ratbag_button* button,
+                          enum ratbag_button_action_special act)
+{
+	struct ratbag_button_action action = {0};
 
-  /* FIXME: range checks */
+	/* FIXME: range checks */
 
-  if (!ratbag_button_has_action_type(button, RATBAG_BUTTON_ACTION_TYPE_SPECIAL))
-    return RATBAG_ERROR_CAPABILITY;
+	if (!ratbag_button_has_action_type(
+		button, RATBAG_BUTTON_ACTION_TYPE_SPECIAL))
+		return RATBAG_ERROR_CAPABILITY;
 
-  action.type = RATBAG_BUTTON_ACTION_TYPE_SPECIAL;
-  action.action.special = act;
+	action.type = RATBAG_BUTTON_ACTION_TYPE_SPECIAL;
+	action.action.special = act;
 
-  ratbag_button_set_action(button, &action);
-  button->dirty = true;
-  button->profile->dirty = true;
+	ratbag_button_set_action(button, &action);
+	button->dirty = true;
+	button->profile->dirty = true;
 
-  return RATBAG_SUCCESS;
+	return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT unsigned int
-ratbag_button_get_key(const struct ratbag_button *button) {
-  if (button->action.type != RATBAG_BUTTON_ACTION_TYPE_KEY)
-    return 0;
+ratbag_button_get_key(const struct ratbag_button* button)
+{
+	if (button->action.type != RATBAG_BUTTON_ACTION_TYPE_KEY)
+		return 0;
 
-  return button->action.action.key;
+	return button->action.action.key;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_button_set_key(struct ratbag_button *button, unsigned int key) {
-  struct ratbag_button_action action = {0};
+ratbag_button_set_key(struct ratbag_button* button, unsigned int key)
+{
+	struct ratbag_button_action action = {0};
 
-  /* FIXME: range checks */
+	/* FIXME: range checks */
 
-  if (!ratbag_button_has_action_type(button, RATBAG_BUTTON_ACTION_TYPE_KEY))
-    return RATBAG_ERROR_CAPABILITY;
+	if (!ratbag_button_has_action_type(
+		button, RATBAG_BUTTON_ACTION_TYPE_KEY))
+		return RATBAG_ERROR_CAPABILITY;
 
-  action.type = RATBAG_BUTTON_ACTION_TYPE_KEY;
-  action.action.key = key;
+	action.type = RATBAG_BUTTON_ACTION_TYPE_KEY;
+	action.action.key = key;
 
-  ratbag_button_set_action(button, &action);
-  button->dirty = true;
-  button->profile->dirty = true;
+	ratbag_button_set_action(button, &action);
+	button->dirty = true;
+	button->profile->dirty = true;
 
-  return RATBAG_SUCCESS;
+	return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT int
-ratbag_button_get_dpi_lock(const struct ratbag_button *button) {
-  return ratbag_button_get_dpi_lock_x(button);
+ratbag_button_get_dpi_lock(const struct ratbag_button* button)
+{
+	return ratbag_button_get_dpi_lock_x(button);
 }
 
 LIBRATBAG_EXPORT int
-ratbag_button_get_dpi_lock_x(const struct ratbag_button *button) {
-  if (button->action.type != RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK)
-    return -1;
+ratbag_button_get_dpi_lock_x(const struct ratbag_button* button)
+{
+	if (button->action.type != RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK)
+		return -1;
 
-  return (int)button->action.action.dpi_lock.x;
+	return (int)button->action.action.dpi_lock.x;
 }
 
 LIBRATBAG_EXPORT int
-ratbag_button_get_dpi_lock_y(const struct ratbag_button *button) {
-  if (button->action.type != RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK)
-    return -1;
+ratbag_button_get_dpi_lock_y(const struct ratbag_button* button)
+{
+	if (button->action.type != RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK)
+		return -1;
 
-  return (int)button->action.action.dpi_lock.y;
+	return (int)button->action.action.dpi_lock.y;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_button_set_dpi_lock(struct ratbag_button *button, unsigned int dpi) {
-  return ratbag_button_set_dpi_lock_xy(button, dpi, dpi);
+ratbag_button_set_dpi_lock(struct ratbag_button* button, unsigned int dpi)
+{
+	return ratbag_button_set_dpi_lock_xy(button, dpi, dpi);
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_button_set_dpi_lock_xy(struct ratbag_button *button,
-                              unsigned int x, unsigned int y) {
-  struct ratbag_button_action action = {0};
+ratbag_button_set_dpi_lock_xy(struct ratbag_button* button,
+                              unsigned int x, unsigned int y)
+{
+	struct ratbag_button_action action = {0};
 
-  if (!ratbag_button_has_action_type(button, RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK))
-    return RATBAG_ERROR_CAPABILITY;
+	if (!ratbag_button_has_action_type(
+		button, RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK))
+		return RATBAG_ERROR_CAPABILITY;
 
-  action.type = RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK;
-  action.action.dpi_lock.x = x;
-  action.action.dpi_lock.y = y;
+	action.type = RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK;
+	action.action.dpi_lock.x = x;
+	action.action.dpi_lock.y = y;
 
-  ratbag_button_set_action(button, &action);
-  button->dirty = true;
-  button->profile->dirty = true;
+	ratbag_button_set_action(button, &action);
+	button->dirty = true;
+	button->profile->dirty = true;
 
-  return RATBAG_SUCCESS;
+	return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_button_disable(struct ratbag_button *button) {
-  if (!ratbag_button_has_action_type(button, RATBAG_BUTTON_ACTION_TYPE_NONE))
-    return RATBAG_ERROR_CAPABILITY;
+ratbag_button_disable(struct ratbag_button* button)
+{
+	if (!ratbag_button_has_action_type(
+		button, RATBAG_BUTTON_ACTION_TYPE_NONE))
+		return RATBAG_ERROR_CAPABILITY;
 
-  struct ratbag_button_action action = {0};
+	struct ratbag_button_action action = {0};
 
-  action.type = RATBAG_BUTTON_ACTION_TYPE_NONE;
+	action.type = RATBAG_BUTTON_ACTION_TYPE_NONE;
 
-  ratbag_button_set_action(button, &action);
-  button->dirty = true;
-  button->profile->dirty = true;
+	ratbag_button_set_action(button, &action);
+	button->dirty = true;
+	button->profile->dirty = true;
 
-  return RATBAG_SUCCESS;
+	return RATBAG_SUCCESS;
 }
 
-LIBRATBAG_EXPORT struct ratbag_button *
-ratbag_button_ref(struct ratbag_button *button) {
-  assert(button->refcount < INT_MAX);
+LIBRATBAG_EXPORT struct ratbag_button*
+ratbag_button_ref(struct ratbag_button* button)
+{
+	assert(button->refcount < INT_MAX);
 
-  ratbag_profile_ref(button->profile);
-  button->refcount++;
-  return button;
+	ratbag_profile_ref(button->profile);
+	button->refcount++;
+	return button;
 }
 
-LIBRATBAG_EXPORT struct ratbag_led *ratbag_led_ref(struct ratbag_led *led) {
-  assert(led->refcount < INT_MAX);
+LIBRATBAG_EXPORT struct ratbag_led* ratbag_led_ref(struct ratbag_led* led)
+{
+	assert(led->refcount < INT_MAX);
 
-  ratbag_profile_ref(led->profile);
-  led->refcount++;
-  return led;
+	ratbag_profile_ref(led->profile);
+	led->refcount++;
+	return led;
 }
 
-static void ratbag_button_destroy(struct ratbag_button *button) {
-  list_remove(&button->link);
-  if (button->action.macro) {
-    free(button->action.macro->name);
-    free(button->action.macro->group);
-    free(button->action.macro);
-  }
-  free(button);
+static void ratbag_button_destroy(struct ratbag_button* button)
+{
+	list_remove(&button->link);
+	if (button->action.macro)
+	{
+		free(button->action.macro->name);
+		free(button->action.macro->group);
+		free(button->action.macro);
+	}
+	free(button);
 }
 
-static void ratbag_led_destroy(struct ratbag_led *led) {
-  list_remove(&led->link);
-  free(led);
+static void ratbag_led_destroy(struct ratbag_led* led)
+{
+	list_remove(&led->link);
+	free(led);
 }
 
-static void ratbag_resolution_destroy(struct ratbag_resolution *res) {
-  list_remove(&res->link);
-  free(res);
+static void ratbag_resolution_destroy(struct ratbag_resolution* res)
+{
+	list_remove(&res->link);
+	free(res);
 }
 
-LIBRATBAG_EXPORT struct ratbag_button *
-ratbag_button_unref(struct ratbag_button *button) {
-  if (button == NULL)
-    return NULL;
+LIBRATBAG_EXPORT struct ratbag_button*
+ratbag_button_unref(struct ratbag_button* button)
+{
+	if (button == NULL)
+		return NULL;
 
-  assert(button->refcount > 0);
-  button->refcount--;
+	assert(button->refcount > 0);
+	button->refcount--;
 
-  ratbag_profile_unref(button->profile);
+	ratbag_profile_unref(button->profile);
 
-  return NULL;
+	return NULL;
 }
 
-LIBRATBAG_EXPORT struct ratbag_led *ratbag_led_unref(struct ratbag_led *led) {
-  if (led == NULL)
-    return NULL;
+LIBRATBAG_EXPORT struct ratbag_led* ratbag_led_unref(struct ratbag_led* led)
+{
+	if (led == NULL)
+		return NULL;
 
-  assert(led->refcount > 0);
-  led->refcount--;
+	assert(led->refcount > 0);
+	led->refcount--;
 
-  ratbag_profile_unref(led->profile);
+	ratbag_profile_unref(led->profile);
 
-  return NULL;
+	return NULL;
 }
 
 LIBRATBAG_EXPORT enum ratbag_led_mode
-ratbag_led_get_mode(const struct ratbag_led *led) {
-  return led->mode;
+ratbag_led_get_mode(const struct ratbag_led* led)
+{
+	return led->mode;
 }
 
-LIBRATBAG_EXPORT bool ratbag_led_has_mode(const struct ratbag_led *led,
-                                          enum ratbag_led_mode mode) {
-  assert(mode <= RATBAG_LED_BREATHING);
+LIBRATBAG_EXPORT bool ratbag_led_has_mode(const struct ratbag_led* led,
+                                          enum ratbag_led_mode mode)
+{
+	assert(mode <= RATBAG_LED_BREATHING);
 
-  if (mode == RATBAG_LED_OFF)
-    return 1;
+	if (mode == RATBAG_LED_OFF)
+		return 1;
 
-  return !!(led->modes & (1 << mode));
+	return !!(led->modes & (1 << mode));
 }
 
 LIBRATBAG_EXPORT struct ratbag_color
-ratbag_led_get_color(const struct ratbag_led *led) {
-  return led->color;
+ratbag_led_get_color(const struct ratbag_led* led)
+{
+	return led->color;
 }
 
 LIBRATBAG_EXPORT int
-ratbag_led_get_effect_duration(const struct ratbag_led *led) {
-  return led->ms;
+ratbag_led_get_effect_duration(const struct ratbag_led* led)
+{
+	return led->ms;
 }
 
 LIBRATBAG_EXPORT unsigned int
-ratbag_led_get_brightness(const struct ratbag_led *led) {
-  return led->brightness;
+ratbag_led_get_brightness(const struct ratbag_led* led)
+{
+	return led->brightness;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_led_set_mode(struct ratbag_led *led, enum ratbag_led_mode mode) {
-  led->mode = mode;
-  led->dirty = true;
-  led->profile->dirty = true;
-  return RATBAG_SUCCESS;
+ratbag_led_set_mode(struct ratbag_led* led, enum ratbag_led_mode mode)
+{
+	led->mode = mode;
+	led->dirty = true;
+	led->profile->dirty = true;
+	return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_led_set_color(struct ratbag_led *led, struct ratbag_color color) {
-  led->color = color;
-  led->dirty = true;
-  led->profile->dirty = true;
-  return RATBAG_SUCCESS;
+ratbag_led_set_color(struct ratbag_led* led, struct ratbag_color color)
+{
+	led->color = color;
+	led->dirty = true;
+	led->profile->dirty = true;
+	return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT enum ratbag_led_colordepth
-ratbag_led_get_colordepth(const struct ratbag_led *led) {
-  return led->colordepth;
+ratbag_led_get_colordepth(const struct ratbag_led* led)
+{
+	return led->colordepth;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_led_set_effect_duration(struct ratbag_led *led, unsigned int ms) {
-  led->ms = ms;
-  led->dirty = true;
-  led->profile->dirty = true;
-  return RATBAG_SUCCESS;
+ratbag_led_set_effect_duration(struct ratbag_led* led, unsigned int ms)
+{
+	led->ms = ms;
+	led->dirty = true;
+	led->profile->dirty = true;
+	return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_led_set_brightness(struct ratbag_led *led, unsigned int brightness) {
-  led->brightness = brightness;
-  led->dirty = true;
-  led->profile->dirty = true;
-  return RATBAG_SUCCESS;
+ratbag_led_set_brightness(struct ratbag_led* led, unsigned int brightness)
+{
+	led->brightness = brightness;
+	led->dirty = true;
+	led->profile->dirty = true;
+	return RATBAG_SUCCESS;
 }
 
-LIBRATBAG_EXPORT struct ratbag_led *
-ratbag_profile_get_led(struct ratbag_profile *profile, unsigned int index) {
-  struct ratbag_device *device = profile->device;
-  struct ratbag_led *led;
+LIBRATBAG_EXPORT struct ratbag_led*
+ratbag_profile_get_led(struct ratbag_profile* profile, unsigned int index)
+{
+	struct ratbag_device* device = profile->device;
+	struct ratbag_led* led;
 
-  if (index >= ratbag_device_get_num_leds(device)) {
-    log_bug_client(device->ratbag, "Requested invalid led %d\n", index);
-    return NULL;
-  }
+	if (index >= ratbag_device_get_num_leds(device))
+	{
+		log_bug_client(device->ratbag, "Requested invalid led %d\n",
+		               index);
+		return NULL;
+	}
 
-  list_for_each(led, &profile->leds, link) {
-    if (led->index == index)
-      return ratbag_led_ref(led);
-  }
+	list_for_each(led, &profile->leds, link)
+	{
+		if (led->index == index)
+			return ratbag_led_ref(led);
+	}
 
-  log_bug_libratbag(device->ratbag, "Led %d, profile %d not found\n", index,
-                    profile->index);
+	log_bug_libratbag(device->ratbag, "Led %d, profile %d not found\n",
+	                  index,
+	                  profile->index);
 
-  return NULL;
+	return NULL;
 }
 
-LIBRATBAG_EXPORT const char *
-ratbag_profile_get_name(const struct ratbag_profile *profile) {
-  return profile->name;
+LIBRATBAG_EXPORT const char*
+ratbag_profile_get_name(const struct ratbag_profile* profile)
+{
+	return profile->name;
 }
 
-LIBRATBAG_EXPORT int ratbag_profile_set_name(struct ratbag_profile *profile,
-                                             const char *name) {
-  char *name_copy;
+LIBRATBAG_EXPORT int ratbag_profile_set_name(struct ratbag_profile* profile,
+                                             const char* name)
+{
+	char* name_copy;
 
-  if (!profile->name)
-    return RATBAG_ERROR_CAPABILITY;
+	if (!profile->name)
+		return RATBAG_ERROR_CAPABILITY;
 
-  name_copy = strdup_safe(name);
-  if (profile->name)
-    free(profile->name);
+	name_copy = strdup_safe(name);
+	if (profile->name)
+		free(profile->name);
 
-  profile->name = name_copy;
-  profile->dirty = true;
+	profile->name = name_copy;
+	profile->dirty = true;
 
-  return 0;
+	return 0;
 }
 
-LIBRATBAG_EXPORT void ratbag_set_user_data(struct ratbag *ratbag,
-                                           void *userdata) {
-  ratbag->userdata = userdata;
-}
-
-LIBRATBAG_EXPORT void
-ratbag_device_set_user_data(struct ratbag_device *ratbag_device,
-                            void *userdata) {
-  ratbag_device->userdata = userdata;
-}
-
-LIBRATBAG_EXPORT void
-ratbag_profile_set_user_data(struct ratbag_profile *ratbag_profile,
-                             void *userdata) {
-  ratbag_profile->userdata = userdata;
+LIBRATBAG_EXPORT void ratbag_set_user_data(struct ratbag* ratbag,
+                                           void* userdata)
+{
+	ratbag->userdata = userdata;
 }
 
 LIBRATBAG_EXPORT void
-ratbag_button_set_user_data(struct ratbag_button *ratbag_button,
-                            void *userdata) {
-  ratbag_button->userdata = userdata;
+ratbag_device_set_user_data(struct ratbag_device* ratbag_device,
+                            void* userdata)
+{
+	ratbag_device->userdata = userdata;
 }
 
 LIBRATBAG_EXPORT void
-ratbag_resolution_set_user_data(struct ratbag_resolution *ratbag_resolution,
-                                void *userdata) {
-  ratbag_resolution->userdata = userdata;
-}
-
-LIBRATBAG_EXPORT void *ratbag_get_user_data(const struct ratbag *ratbag) {
-  return ratbag->userdata;
-}
-
-LIBRATBAG_EXPORT void *
-ratbag_device_get_user_data(const struct ratbag_device *ratbag_device) {
-  return ratbag_device->userdata;
-}
-
-LIBRATBAG_EXPORT const char *
-ratbag_device_get_firmware_version(const struct ratbag_device *ratbag_device) {
-  return ratbag_device->firmware_version;
+ratbag_profile_set_user_data(struct ratbag_profile* ratbag_profile,
+                             void* userdata)
+{
+	ratbag_profile->userdata = userdata;
 }
 
 LIBRATBAG_EXPORT void
-ratbag_device_set_firmware_version(struct ratbag_device *device,
-                                   const char *fw) {
-  free(device->firmware_version);
-  device->firmware_version = strdup_safe(fw);
+ratbag_button_set_user_data(struct ratbag_button* ratbag_button,
+                            void* userdata)
+{
+	ratbag_button->userdata = userdata;
 }
 
-LIBRATBAG_EXPORT void *
-ratbag_profile_get_user_data(const struct ratbag_profile *ratbag_profile) {
-  return ratbag_profile->userdata;
+LIBRATBAG_EXPORT void
+ratbag_resolution_set_user_data(struct ratbag_resolution* ratbag_resolution,
+                                void* userdata)
+{
+	ratbag_resolution->userdata = userdata;
 }
 
-LIBRATBAG_EXPORT void *
-ratbag_button_get_user_data(const struct ratbag_button *ratbag_button) {
-  return ratbag_button->userdata;
+LIBRATBAG_EXPORT void* ratbag_get_user_data(const struct ratbag* ratbag)
+{
+	return ratbag->userdata;
 }
 
-LIBRATBAG_EXPORT void *ratbag_resolution_get_user_data(
-    const struct ratbag_resolution *ratbag_resolution) {
-  return ratbag_resolution->userdata;
+LIBRATBAG_EXPORT void*
+ratbag_device_get_user_data(const struct ratbag_device* ratbag_device)
+{
+	return ratbag_device->userdata;
 }
 
-LIBRATBAG_EXPORT struct ratbag_button_macro *
-ratbag_button_get_macro(struct ratbag_button *button) {
-  struct ratbag_button_macro *macro;
-
-  if (button->action.type != RATBAG_BUTTON_ACTION_TYPE_MACRO)
-    return NULL;
-
-  macro = ratbag_button_macro_new(button->action.macro->name);
-  memcpy(macro->macro.events, button->action.macro->events,
-         sizeof(macro->macro.events));
-  macro->macro.repeat_mode = button->action.macro->repeat_mode;
-  macro->macro.repeat_count = button->action.macro->repeat_count;
-
-  return macro;
+LIBRATBAG_EXPORT const char*
+ratbag_device_get_firmware_version(const struct ratbag_device* ratbag_device)
+{
+	return ratbag_device->firmware_version;
 }
 
-void ratbag_button_copy_macro(struct ratbag_button *button,
-                              const struct ratbag_button_macro *macro) {
-  if (!button->action.macro)
-    button->action.macro = zalloc(sizeof(struct ratbag_macro));
-  else {
-    free(button->action.macro->name);
-    free(button->action.macro->group);
-    memset(button->action.macro, 0, sizeof(struct ratbag_macro));
-  }
+LIBRATBAG_EXPORT void
+ratbag_device_set_firmware_version(struct ratbag_device* device,
+                                   const char* fw)
+{
+	free(device->firmware_version);
+	device->firmware_version = strdup_safe(fw);
+}
 
-  button->action.type = RATBAG_BUTTON_ACTION_TYPE_MACRO;
-  memcpy(button->action.macro->events, macro->macro.events,
-         sizeof(macro->macro.events));
-  button->action.macro->name = strdup_safe(macro->macro.name);
-  button->action.macro->group = strdup_safe(macro->macro.group);
-  button->action.macro->repeat_mode = macro->macro.repeat_mode;
-  button->action.macro->repeat_count = macro->macro.repeat_count;
+LIBRATBAG_EXPORT void*
+ratbag_profile_get_user_data(const struct ratbag_profile* ratbag_profile)
+{
+	return ratbag_profile->userdata;
+}
+
+LIBRATBAG_EXPORT void*
+ratbag_button_get_user_data(const struct ratbag_button* ratbag_button)
+{
+	return ratbag_button->userdata;
+}
+
+LIBRATBAG_EXPORT void* ratbag_resolution_get_user_data(
+	const struct ratbag_resolution* ratbag_resolution)
+{
+	return ratbag_resolution->userdata;
+}
+
+LIBRATBAG_EXPORT struct ratbag_button_macro*
+ratbag_button_get_macro(struct ratbag_button* button)
+{
+	struct ratbag_button_macro* macro;
+
+	if (button->action.type != RATBAG_BUTTON_ACTION_TYPE_MACRO)
+		return NULL;
+
+	macro = ratbag_button_macro_new(button->action.macro->name);
+	memcpy(macro->macro.events, button->action.macro->events,
+	       sizeof(macro->macro.events));
+	macro->macro.repeat_mode = button->action.macro->repeat_mode;
+	macro->macro.repeat_count = button->action.macro->repeat_count;
+
+	return macro;
+}
+
+void ratbag_button_copy_macro(struct ratbag_button* button,
+                              const struct ratbag_button_macro* macro)
+{
+	if (!button->action.macro)
+		button->action.macro = zalloc(sizeof(struct ratbag_macro));
+	else
+	{
+		free(button->action.macro->name);
+		free(button->action.macro->group);
+		memset(button->action.macro, 0, sizeof(struct ratbag_macro));
+	}
+
+	button->action.type = RATBAG_BUTTON_ACTION_TYPE_MACRO;
+	memcpy(button->action.macro->events, macro->macro.events,
+	       sizeof(macro->macro.events));
+	button->action.macro->name = strdup_safe(macro->macro.name);
+	button->action.macro->group = strdup_safe(macro->macro.group);
+	button->action.macro->repeat_mode = macro->macro.repeat_mode;
+	button->action.macro->repeat_count = macro->macro.repeat_count;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_button_set_macro(struct ratbag_button *button,
-                        const struct ratbag_button_macro *macro) {
-  if (!ratbag_button_has_action_type(button, RATBAG_BUTTON_ACTION_TYPE_MACRO))
-    return RATBAG_ERROR_CAPABILITY;
+ratbag_button_set_macro(struct ratbag_button* button,
+                        const struct ratbag_button_macro* macro)
+{
+	if (!ratbag_button_has_action_type(
+		button, RATBAG_BUTTON_ACTION_TYPE_MACRO))
+		return RATBAG_ERROR_CAPABILITY;
 
-  ratbag_button_copy_macro(button, macro);
-  button->dirty = true;
-  button->profile->dirty = true;
+	ratbag_button_copy_macro(button, macro);
+	button->dirty = true;
+	button->profile->dirty = true;
 
-  return RATBAG_SUCCESS;
+	return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_button_macro_set_event(struct ratbag_button_macro *m, unsigned int index,
+ratbag_button_macro_set_event(struct ratbag_button_macro* m, unsigned int index,
                               enum ratbag_macro_event_type type,
-                              unsigned int data) {
-  struct ratbag_macro *macro = &m->macro;
+                              unsigned int data)
+{
+	struct ratbag_macro* macro = &m->macro;
 
-  if (index >= MAX_MACRO_EVENTS)
-    return RATBAG_ERROR_VALUE;
+	if (index >= MAX_MACRO_EVENTS)
+		return RATBAG_ERROR_VALUE;
 
-  switch (type) {
-  case RATBAG_MACRO_EVENT_KEY_PRESSED:
-  case RATBAG_MACRO_EVENT_KEY_RELEASED:
-    macro->events[index].type = type;
-    macro->events[index].event.key = data;
-    break;
-  case RATBAG_MACRO_EVENT_WAIT:
-    macro->events[index].type = type;
-    macro->events[index].event.timeout = data;
-    break;
-  case RATBAG_MACRO_EVENT_NONE:
-    macro->events[index].type = type;
-    break;
-  default:
-    return RATBAG_ERROR_VALUE;
-  }
+	switch (type)
+	{
+	case RATBAG_MACRO_EVENT_KEY_PRESSED:
+	case RATBAG_MACRO_EVENT_KEY_RELEASED:
+		macro->events[index].type = type;
+		macro->events[index].event.key = data;
+		break;
+	case RATBAG_MACRO_EVENT_WAIT:
+		macro->events[index].type = type;
+		macro->events[index].event.timeout = data;
+		break;
+	case RATBAG_MACRO_EVENT_NONE:
+		macro->events[index].type = type;
+		break;
+	default:
+		return RATBAG_ERROR_VALUE;
+	}
 
-  return 0;
+	return 0;
 }
 
 LIBRATBAG_EXPORT enum ratbag_macro_event_type
-ratbag_button_macro_get_event_type(const struct ratbag_button_macro *macro,
-                                   unsigned int index) {
-  if (index >= MAX_MACRO_EVENTS)
-    return RATBAG_MACRO_EVENT_INVALID;
+ratbag_button_macro_get_event_type(const struct ratbag_button_macro* macro,
+                                   unsigned int index)
+{
+	if (index >= MAX_MACRO_EVENTS)
+		return RATBAG_MACRO_EVENT_INVALID;
 
-  return macro->macro.events[index].type;
+	return macro->macro.events[index].type;
 }
 
 LIBRATBAG_EXPORT int
-ratbag_button_macro_get_event_key(const struct ratbag_button_macro *m,
-                                  unsigned int index) {
-  const struct ratbag_macro *macro = &m->macro;
+ratbag_button_macro_get_event_key(const struct ratbag_button_macro* m,
+                                  unsigned int index)
+{
+	const struct ratbag_macro* macro = &m->macro;
 
-  if (index >= MAX_MACRO_EVENTS)
-    return 0;
+	if (index >= MAX_MACRO_EVENTS)
+		return 0;
 
-  if (macro->events[index].type != RATBAG_MACRO_EVENT_KEY_PRESSED &&
-      macro->events[index].type != RATBAG_MACRO_EVENT_KEY_RELEASED)
-    return -EINVAL;
+	if (macro->events[index].type != RATBAG_MACRO_EVENT_KEY_PRESSED &&
+		macro->events[index].type != RATBAG_MACRO_EVENT_KEY_RELEASED)
+		return -EINVAL;
 
-  return macro->events[index].event.key;
+	return macro->events[index].event.key;
 }
 
 LIBRATBAG_EXPORT int
-ratbag_button_macro_get_event_timeout(const struct ratbag_button_macro *m,
-                                      unsigned int index) {
-  const struct ratbag_macro *macro = &m->macro;
+ratbag_button_macro_get_event_timeout(const struct ratbag_button_macro* m,
+                                      unsigned int index)
+{
+	const struct ratbag_macro* macro = &m->macro;
 
-  if (index >= MAX_MACRO_EVENTS)
-    return 0;
+	if (index >= MAX_MACRO_EVENTS)
+		return 0;
 
-  if (macro->events[index].type != RATBAG_MACRO_EVENT_WAIT)
-    return 0;
+	if (macro->events[index].type != RATBAG_MACRO_EVENT_WAIT)
+		return 0;
 
-  return macro->events[index].event.timeout;
+	return macro->events[index].event.timeout;
 }
 
 LIBRATBAG_EXPORT unsigned int
-ratbag_button_macro_get_num_events(const struct ratbag_button_macro *macro) {
-  return MAX_MACRO_EVENTS;
+ratbag_button_macro_get_num_events(const struct ratbag_button_macro* macro)
+{
+	return MAX_MACRO_EVENTS;
 }
 
-LIBRATBAG_EXPORT const char *
-ratbag_button_macro_get_name(const struct ratbag_button_macro *macro) {
-  return macro->macro.name;
+LIBRATBAG_EXPORT const char*
+ratbag_button_macro_get_name(const struct ratbag_button_macro* macro)
+{
+	return macro->macro.name;
 }
 
 LIBRATBAG_EXPORT enum ratbag_macro_repeat_mode
-ratbag_button_macro_get_repeat_mode(const struct ratbag_button_macro *macro) {
-  return macro->macro.repeat_mode;
+ratbag_button_macro_get_repeat_mode(const struct ratbag_button_macro* macro)
+{
+	return macro->macro.repeat_mode;
 }
 
 LIBRATBAG_EXPORT unsigned int
-ratbag_button_macro_get_repeat_count(const struct ratbag_button_macro *macro) {
-  return macro->macro.repeat_count;
+ratbag_button_macro_get_repeat_count(const struct ratbag_button_macro* macro)
+{
+	return macro->macro.repeat_count;
 }
 
 LIBRATBAG_EXPORT void
-ratbag_button_macro_set_repeat(struct ratbag_button_macro *macro,
+ratbag_button_macro_set_repeat(struct ratbag_button_macro* macro,
                                enum ratbag_macro_repeat_mode mode,
-                               unsigned int count) {
-  macro->macro.repeat_mode = mode;
-  macro->macro.repeat_count = count;
+                               unsigned int count)
+{
+	macro->macro.repeat_mode = mode;
+	macro->macro.repeat_count = count;
 }
 
-static void ratbag_button_macro_destroy(struct ratbag_button_macro *macro) {
-  assert(macro->refcount == 0);
-  free(macro->macro.name);
-  free(macro->macro.group);
-  free(macro);
+static void ratbag_button_macro_destroy(struct ratbag_button_macro* macro)
+{
+	assert(macro->refcount == 0);
+	free(macro->macro.name);
+	free(macro->macro.group);
+	free(macro);
 }
 
-LIBRATBAG_EXPORT struct ratbag_button_macro *
-ratbag_button_macro_ref(struct ratbag_button_macro *macro) {
-  assert(macro->refcount < INT_MAX);
+LIBRATBAG_EXPORT struct ratbag_button_macro*
+ratbag_button_macro_ref(struct ratbag_button_macro* macro)
+{
+	assert(macro->refcount < INT_MAX);
 
-  macro->refcount++;
-  return macro;
+	macro->refcount++;
+	return macro;
 }
 
-LIBRATBAG_EXPORT struct ratbag_button_macro *
-ratbag_button_macro_unref(struct ratbag_button_macro *macro) {
-  if (macro == NULL)
-    return NULL;
+LIBRATBAG_EXPORT struct ratbag_button_macro*
+ratbag_button_macro_unref(struct ratbag_button_macro* macro)
+{
+	if (macro == NULL)
+		return NULL;
 
-  assert(macro->refcount > 0);
-  macro->refcount--;
-  if (macro->refcount == 0)
-    ratbag_button_macro_destroy(macro);
+	assert(macro->refcount > 0);
+	macro->refcount--;
+	if (macro->refcount == 0)
+		ratbag_button_macro_destroy(macro);
 
-  return NULL;
+	return NULL;
 }
 
-LIBRATBAG_EXPORT struct ratbag_button_macro *
-ratbag_button_macro_new(const char *name) {
-  struct ratbag_button_macro *macro;
+LIBRATBAG_EXPORT struct ratbag_button_macro*
+ratbag_button_macro_new(const char* name)
+{
+	struct ratbag_button_macro* macro;
 
-  macro = zalloc(sizeof *macro);
-  macro->refcount = 1;
-  macro->macro.name = strdup_safe(name);
+	macro = zalloc(sizeof *macro);
+	macro->refcount = 1;
+	macro->macro.name = strdup_safe(name);
 
-  return macro;
+	return macro;
 }
 
-struct ratbag_modifier_mapping {
-  unsigned int modifier_mask;
-  unsigned int key;
+struct ratbag_modifier_mapping
+{
+	unsigned int modifier_mask;
+	unsigned int key;
 };
 
 struct ratbag_modifier_mapping ratbag_modifier_mapping[] = {
-    {MODIFIER_LEFTCTRL, KEY_LEFTCTRL},   {MODIFIER_LEFTSHIFT, KEY_LEFTSHIFT},
-    {MODIFIER_LEFTALT, KEY_LEFTALT},     {MODIFIER_LEFTMETA, KEY_LEFTMETA},
-    {MODIFIER_RIGHTCTRL, KEY_RIGHTCTRL}, {MODIFIER_RIGHTSHIFT, KEY_RIGHTSHIFT},
-    {MODIFIER_RIGHTALT, KEY_RIGHTALT},   {MODIFIER_RIGHTMETA, KEY_RIGHTMETA},
+	{MODIFIER_LEFTCTRL, KEY_LEFTCTRL}, {MODIFIER_LEFTSHIFT, KEY_LEFTSHIFT},
+	{MODIFIER_LEFTALT, KEY_LEFTALT}, {MODIFIER_LEFTMETA, KEY_LEFTMETA},
+	{MODIFIER_RIGHTCTRL, KEY_RIGHTCTRL},
+	{MODIFIER_RIGHTSHIFT, KEY_RIGHTSHIFT},
+	{MODIFIER_RIGHTALT, KEY_RIGHTALT}, {MODIFIER_RIGHTMETA, KEY_RIGHTMETA},
 };
 
-int ratbag_button_macro_new_from_keycode(struct ratbag_button *button,
+int ratbag_button_macro_new_from_keycode(struct ratbag_button* button,
                                          unsigned int key,
-                                         unsigned int modifiers) {
-  struct ratbag_button_macro *macro;
-  struct ratbag_modifier_mapping *mapping;
-  int i;
+                                         unsigned int modifiers)
+{
+	struct ratbag_button_macro* macro;
+	struct ratbag_modifier_mapping* mapping;
+	int i;
 
-  macro = ratbag_button_macro_new("key");
-  i = 0;
+	macro = ratbag_button_macro_new("key");
+	i = 0;
 
-  ARRAY_FOR_EACH(ratbag_modifier_mapping, mapping) {
-    if (modifiers & mapping->modifier_mask)
-      ratbag_button_macro_set_event(macro, i++, RATBAG_MACRO_EVENT_KEY_PRESSED,
-                                    mapping->key);
-  }
+	ARRAY_FOR_EACH(ratbag_modifier_mapping, mapping)
+	{
+		if (modifiers & mapping->modifier_mask)
+			ratbag_button_macro_set_event(
+				macro, i++, RATBAG_MACRO_EVENT_KEY_PRESSED,
+				mapping->key);
+	}
 
-  ratbag_button_macro_set_event(macro, i++, RATBAG_MACRO_EVENT_KEY_PRESSED,
-                                key);
-  ratbag_button_macro_set_event(macro, i++, RATBAG_MACRO_EVENT_KEY_RELEASED,
-                                key);
+	ratbag_button_macro_set_event(macro, i++,
+	                              RATBAG_MACRO_EVENT_KEY_PRESSED,
+	                              key);
+	ratbag_button_macro_set_event(macro, i++,
+	                              RATBAG_MACRO_EVENT_KEY_RELEASED,
+	                              key);
 
-  ARRAY_FOR_EACH(ratbag_modifier_mapping, mapping) {
-    if (modifiers & mapping->modifier_mask)
-      ratbag_button_macro_set_event(macro, i++, RATBAG_MACRO_EVENT_KEY_RELEASED,
-                                    mapping->key);
-  }
+	ARRAY_FOR_EACH(ratbag_modifier_mapping, mapping)
+	{
+		if (modifiers & mapping->modifier_mask)
+			ratbag_button_macro_set_event(
+				macro, i++, RATBAG_MACRO_EVENT_KEY_RELEASED,
+				mapping->key);
+	}
 
-  ratbag_button_copy_macro(button, macro);
-  ratbag_button_macro_unref(macro);
+	ratbag_button_copy_macro(button, macro);
+	ratbag_button_macro_unref(macro);
 
-  return 0;
+	return 0;
 }
 
-int ratbag_action_macro_num_keys(const struct ratbag_button_action *action) {
-  const struct ratbag_macro *macro = action->macro;
-  int count = 0;
-  for (int i = 0; i < MAX_MACRO_EVENTS; i++) {
-    struct ratbag_macro_event event = macro->events[i];
-    if (event.type == RATBAG_MACRO_EVENT_NONE ||
-        event.type == RATBAG_MACRO_EVENT_INVALID) {
-      break;
-    }
-    if (ratbag_key_is_modifier(event.event.key)) {
-      continue;
-    }
-    if (event.type == RATBAG_MACRO_EVENT_KEY_PRESSED) {
-      count += 1;
-    }
-  }
-  return count;
+int ratbag_action_macro_num_keys(const struct ratbag_button_action* action)
+{
+	const struct ratbag_macro* macro = action->macro;
+	int count = 0;
+	for (int i = 0; i < MAX_MACRO_EVENTS; i++)
+	{
+		struct ratbag_macro_event event = macro->events[i];
+		if (event.type == RATBAG_MACRO_EVENT_NONE ||
+			event.type == RATBAG_MACRO_EVENT_INVALID)
+		{
+			break;
+		}
+		if (ratbag_key_is_modifier(event.event.key))
+		{
+			continue;
+		}
+		if (event.type == RATBAG_MACRO_EVENT_KEY_PRESSED)
+		{
+			count += 1;
+		}
+	}
+	return count;
 }
 
-int ratbag_action_keycode_from_macro(const struct ratbag_button_action *action,
-                                     unsigned int *key_out,
-                                     unsigned int *modifiers_out) {
-  const struct ratbag_macro *macro = action->macro;
-  unsigned int key = KEY_RESERVED;
-  unsigned int modifiers = 0;
-  unsigned int i;
+int ratbag_action_keycode_from_macro(const struct ratbag_button_action* action,
+                                     unsigned int* key_out,
+                                     unsigned int* modifiers_out)
+{
+	const struct ratbag_macro* macro = action->macro;
+	unsigned int key = KEY_RESERVED;
+	unsigned int modifiers = 0;
+	unsigned int i;
 
-  if (!macro || action->type != RATBAG_BUTTON_ACTION_TYPE_MACRO)
-    return -EINVAL;
+	if (!macro || action->type != RATBAG_BUTTON_ACTION_TYPE_MACRO)
+		return -EINVAL;
 
-  if (macro->events[0].type == RATBAG_MACRO_EVENT_NONE)
-    return -EINVAL;
+	if (macro->events[0].type == RATBAG_MACRO_EVENT_NONE)
+		return -EINVAL;
 
-  if (ratbag_action_macro_num_keys(action) != 1)
-    return -EINVAL;
+	if (ratbag_action_macro_num_keys(action) != 1)
+		return -EINVAL;
 
-  for (i = 0; i < MAX_MACRO_EVENTS; i++) {
-    struct ratbag_macro_event event;
+	for (i = 0; i < MAX_MACRO_EVENTS; i++)
+	{
+		struct ratbag_macro_event event;
 
-    event = macro->events[i];
-    switch (event.type) {
-    case RATBAG_MACRO_EVENT_INVALID:
-      return -EINVAL;
-    case RATBAG_MACRO_EVENT_NONE:
-      return 0;
-    case RATBAG_MACRO_EVENT_KEY_PRESSED:
-      switch (event.event.key) {
-      case KEY_LEFTCTRL:
-        modifiers |= MODIFIER_LEFTCTRL;
-        break;
-      case KEY_LEFTSHIFT:
-        modifiers |= MODIFIER_LEFTSHIFT;
-        break;
-      case KEY_LEFTALT:
-        modifiers |= MODIFIER_LEFTALT;
-        break;
-      case KEY_LEFTMETA:
-        modifiers |= MODIFIER_LEFTMETA;
-        break;
-      case KEY_RIGHTCTRL:
-        modifiers |= MODIFIER_RIGHTCTRL;
-        break;
-      case KEY_RIGHTSHIFT:
-        modifiers |= MODIFIER_RIGHTSHIFT;
-        break;
-      case KEY_RIGHTALT:
-        modifiers |= MODIFIER_RIGHTALT;
-        break;
-      case KEY_RIGHTMETA:
-        modifiers |= MODIFIER_RIGHTMETA;
-        break;
-      default:
-        if (key != KEY_RESERVED)
-          return -EINVAL;
+		event = macro->events[i];
+		switch (event.type)
+		{
+		case RATBAG_MACRO_EVENT_INVALID:
+			return -EINVAL;
+		case RATBAG_MACRO_EVENT_NONE:
+			return 0;
+		case RATBAG_MACRO_EVENT_KEY_PRESSED:
+			switch (event.event.key)
+			{
+			case KEY_LEFTCTRL:
+				modifiers |= MODIFIER_LEFTCTRL;
+				break;
+			case KEY_LEFTSHIFT:
+				modifiers |= MODIFIER_LEFTSHIFT;
+				break;
+			case KEY_LEFTALT:
+				modifiers |= MODIFIER_LEFTALT;
+				break;
+			case KEY_LEFTMETA:
+				modifiers |= MODIFIER_LEFTMETA;
+				break;
+			case KEY_RIGHTCTRL:
+				modifiers |= MODIFIER_RIGHTCTRL;
+				break;
+			case KEY_RIGHTSHIFT:
+				modifiers |= MODIFIER_RIGHTSHIFT;
+				break;
+			case KEY_RIGHTALT:
+				modifiers |= MODIFIER_RIGHTALT;
+				break;
+			case KEY_RIGHTMETA:
+				modifiers |= MODIFIER_RIGHTMETA;
+				break;
+			default:
+				if (key != KEY_RESERVED)
+					return -EINVAL;
 
-        key = event.event.key;
-      }
-      break;
-    case RATBAG_MACRO_EVENT_KEY_RELEASED:
-      switch (event.event.key) {
-      case KEY_LEFTCTRL:
-        modifiers &= ~MODIFIER_LEFTCTRL;
-        break;
-      case KEY_LEFTSHIFT:
-        modifiers &= ~MODIFIER_LEFTSHIFT;
-        break;
-      case KEY_LEFTALT:
-        modifiers &= ~MODIFIER_LEFTALT;
-        break;
-      case KEY_LEFTMETA:
-        modifiers &= ~MODIFIER_LEFTMETA;
-        break;
-      case KEY_RIGHTCTRL:
-        modifiers &= ~MODIFIER_RIGHTCTRL;
-        break;
-      case KEY_RIGHTSHIFT:
-        modifiers &= ~MODIFIER_RIGHTSHIFT;
-        break;
-      case KEY_RIGHTALT:
-        modifiers &= ~MODIFIER_RIGHTALT;
-        break;
-      case KEY_RIGHTMETA:
-        modifiers &= ~MODIFIER_RIGHTMETA;
-        break;
-      default:
-        if (event.event.key != key)
-          return -EINVAL;
+				key = event.event.key;
+			}
+			break;
+		case RATBAG_MACRO_EVENT_KEY_RELEASED:
+			switch (event.event.key)
+			{
+			case KEY_LEFTCTRL:
+				modifiers &= ~MODIFIER_LEFTCTRL;
+				break;
+			case KEY_LEFTSHIFT:
+				modifiers &= ~MODIFIER_LEFTSHIFT;
+				break;
+			case KEY_LEFTALT:
+				modifiers &= ~MODIFIER_LEFTALT;
+				break;
+			case KEY_LEFTMETA:
+				modifiers &= ~MODIFIER_LEFTMETA;
+				break;
+			case KEY_RIGHTCTRL:
+				modifiers &= ~MODIFIER_RIGHTCTRL;
+				break;
+			case KEY_RIGHTSHIFT:
+				modifiers &= ~MODIFIER_RIGHTSHIFT;
+				break;
+			case KEY_RIGHTALT:
+				modifiers &= ~MODIFIER_RIGHTALT;
+				break;
+			case KEY_RIGHTMETA:
+				modifiers &= ~MODIFIER_RIGHTMETA;
+				break;
+			default:
+				if (event.event.key != key)
+					return -EINVAL;
 
-        *key_out = key;
-        *modifiers_out = modifiers;
-        return 1;
-      }
-    case RATBAG_MACRO_EVENT_WAIT:
-      break;
-    default:
-      return -EINVAL;
-    }
-  }
+				*key_out = key;
+				*modifiers_out = modifiers;
+				return 1;
+			}
+		case RATBAG_MACRO_EVENT_WAIT:
+			break;
+		default:
+			return -EINVAL;
+		}
+	}
 
-  return -EINVAL;
+	return -EINVAL;
 }

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -684,6 +684,7 @@ ratbag_create_profile(struct ratbag_device *device,
 	profile->name = NULL;
 	profile->angle_snapping = -1;
 	profile->debounce = -1;
+	profile->lod = -1;
 
 	list_append(&device->profiles, &profile->link);
 	list_init(&profile->buttons);
@@ -753,6 +754,7 @@ ratbag_profile_destroy(struct ratbag_profile *profile)
 		ratbag_resolution_destroy(res);
 
 	free(profile->name);
+	free(profile->lods);
 
 	list_remove(&profile->link);
 	free(profile);
@@ -867,6 +869,7 @@ ratbag_device_commit(struct ratbag_device *device)
 
 		profile->angle_snapping_dirty = false;
 		profile->debounce_dirty = false;
+		profile->lod_dirty = false;
 		profile->rate_dirty = false;
 
 		list_for_each(button, &profile->buttons, link)
@@ -1148,6 +1151,43 @@ ratbag_profile_get_debounce_list(const struct ratbag_profile *profile,
 	       sizeof(unsigned int) * min(ndebounces, profile->ndebounces));
 
 	return profile->ndebounces;
+}
+
+LIBRATBAG_EXPORT enum ratbag_error_code
+ratbag_profile_set_lod(struct ratbag_profile *profile,
+		       double value)
+{
+	if (profile->lod != value) {
+		profile->lod = value;
+		profile->dirty = true;
+		profile->lod_dirty = true;
+	}
+
+	return RATBAG_SUCCESS;
+}
+
+LIBRATBAG_EXPORT double
+ratbag_profile_get_lod(const struct ratbag_profile *profile)
+{
+	return profile->lod;
+}
+
+LIBRATBAG_EXPORT size_t
+ratbag_profile_get_lod_list(const struct ratbag_profile *profile,
+			    double *lods,
+			    size_t nlods)
+{
+	_Static_assert(sizeof(*lods) == sizeof(*profile->lods), "type mismatch");
+
+	assert(nlods > 0);
+
+	if (profile->nlods == 0)
+		return 0;
+
+	memcpy(lods, profile->lods,
+	       sizeof(double) * min(nlods, profile->nlods));
+
+	return profile->nlods;
 }
 
 LIBRATBAG_EXPORT size_t

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -1784,6 +1784,8 @@ ratbag_button_get_macro(struct ratbag_button *button) {
   macro = ratbag_button_macro_new(button->action.macro->name);
   memcpy(macro->macro.events, button->action.macro->events,
          sizeof(macro->macro.events));
+  macro->macro.repeat_mode = button->action.macro->repeat_mode;
+  macro->macro.repeat_count = button->action.macro->repeat_count;
 
   return macro;
 }
@@ -1803,6 +1805,8 @@ void ratbag_button_copy_macro(struct ratbag_button *button,
          sizeof(macro->macro.events));
   button->action.macro->name = strdup_safe(macro->macro.name);
   button->action.macro->group = strdup_safe(macro->macro.group);
+  button->action.macro->repeat_mode = macro->macro.repeat_mode;
+  button->action.macro->repeat_count = macro->macro.repeat_count;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
@@ -1893,6 +1897,24 @@ ratbag_button_macro_get_num_events(const struct ratbag_button_macro *macro) {
 LIBRATBAG_EXPORT const char *
 ratbag_button_macro_get_name(const struct ratbag_button_macro *macro) {
   return macro->macro.name;
+}
+
+LIBRATBAG_EXPORT enum ratbag_macro_repeat_mode
+ratbag_button_macro_get_repeat_mode(const struct ratbag_button_macro *macro) {
+  return macro->macro.repeat_mode;
+}
+
+LIBRATBAG_EXPORT unsigned int
+ratbag_button_macro_get_repeat_count(const struct ratbag_button_macro *macro) {
+  return macro->macro.repeat_count;
+}
+
+LIBRATBAG_EXPORT void
+ratbag_button_macro_set_repeat(struct ratbag_button_macro *macro,
+                               enum ratbag_macro_repeat_mode mode,
+                               unsigned int count) {
+  macro->macro.repeat_mode = mode;
+  macro->macro.repeat_count = count;
 }
 
 static void ratbag_button_macro_destroy(struct ratbag_button_macro *macro) {

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -683,6 +683,7 @@ ratbag_create_profile(struct ratbag_device *device,
 	profile->is_enabled = true;
 	profile->name = NULL;
 	profile->angle_snapping = -1;
+	profile->motion_sync = -1;
 	profile->debounce = -1;
 	profile->lod = -1;
 
@@ -1069,6 +1070,19 @@ ratbag_profile_set_angle_snapping(struct ratbag_profile *profile,
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
+ratbag_profile_set_motion_sync(struct ratbag_profile *profile,
+			       int value)
+{
+	if (profile->motion_sync != value) {
+		profile->motion_sync = value;
+		profile->dirty = true;
+		profile->motion_sync_dirty = true;
+	}
+
+	return RATBAG_SUCCESS;
+}
+
+LIBRATBAG_EXPORT enum ratbag_error_code
 ratbag_profile_set_debounce(struct ratbag_profile *profile,
 			    int value)
 {
@@ -1127,6 +1141,12 @@ LIBRATBAG_EXPORT int
 ratbag_profile_get_angle_snapping(const struct ratbag_profile *profile)
 {
 	return profile->angle_snapping;
+}
+
+LIBRATBAG_EXPORT int
+ratbag_profile_get_motion_sync(const struct ratbag_profile *profile)
+{
+	return profile->motion_sync;
 }
 
 LIBRATBAG_EXPORT int

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -902,6 +902,24 @@ ratbag_device_commit(struct ratbag_device *device)
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
+ratbag_device_reset(struct ratbag_device *device)
+{
+	int rc;
+
+	if (device->driver->reset == NULL) {
+		log_error(device->ratbag,
+			  "Trying to reset a device whose driver doesn't support reset\n");
+		return RATBAG_ERROR_CAPABILITY;
+	}
+
+	rc = device->driver->reset(device);
+	if (rc)
+		return RATBAG_ERROR_DEVICE;
+
+	return RATBAG_SUCCESS;
+}
+
+LIBRATBAG_EXPORT enum ratbag_error_code
 ratbag_profile_set_active(struct ratbag_profile *profile)
 {
 	struct ratbag_device *device = profile->device;

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -684,6 +684,7 @@ ratbag_create_profile(struct ratbag_device *device,
 	profile->name = NULL;
 	profile->angle_snapping = -1;
 	profile->motion_sync = -1;
+	profile->ripple_control = -1;
 	profile->debounce = -1;
 	profile->lod = -1;
 
@@ -1083,6 +1084,19 @@ ratbag_profile_set_motion_sync(struct ratbag_profile *profile,
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
+ratbag_profile_set_ripple_control(struct ratbag_profile *profile,
+				  int value)
+{
+	if (profile->ripple_control != value) {
+		profile->ripple_control = value;
+		profile->dirty = true;
+		profile->ripple_control_dirty = true;
+	}
+
+	return RATBAG_SUCCESS;
+}
+
+LIBRATBAG_EXPORT enum ratbag_error_code
 ratbag_profile_set_debounce(struct ratbag_profile *profile,
 			    int value)
 {
@@ -1147,6 +1161,12 @@ LIBRATBAG_EXPORT int
 ratbag_profile_get_motion_sync(const struct ratbag_profile *profile)
 {
 	return profile->motion_sync;
+}
+
+LIBRATBAG_EXPORT int
+ratbag_profile_get_ripple_control(const struct ratbag_profile *profile)
+{
+	return profile->ripple_control;
 }
 
 LIBRATBAG_EXPORT int

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -25,6 +25,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <libudev.h>
+#include <limits.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -32,2140 +33,1955 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <limits.h>
 
-#include "usb-ids.h"
+#include "libratbag-data.h"
 #include "libratbag-private.h"
 #include "libratbag-util.h"
-#include "libratbag-data.h"
+#include "usb-ids.h"
 
-static enum ratbag_error_code
-error_code(enum ratbag_error_code code)
-{
-	switch(code) {
-	case RATBAG_SUCCESS:
-	case RATBAG_ERROR_DEVICE:
-	case RATBAG_ERROR_CAPABILITY:
-	case RATBAG_ERROR_VALUE:
-	case RATBAG_ERROR_SYSTEM:
-	case RATBAG_ERROR_IMPLEMENTATION:
-		break;
-	default:
-		assert(!"Invalid error code. This is a library bug.");
-	}
-	return code;
+static enum ratbag_error_code error_code(enum ratbag_error_code code) {
+  switch (code) {
+  case RATBAG_SUCCESS:
+  case RATBAG_ERROR_DEVICE:
+  case RATBAG_ERROR_CAPABILITY:
+  case RATBAG_ERROR_VALUE:
+  case RATBAG_ERROR_SYSTEM:
+  case RATBAG_ERROR_IMPLEMENTATION:
+    break;
+  default:
+    assert(!"Invalid error code. This is a library bug.");
+  }
+  return code;
 }
 
-static void
-ratbag_profile_destroy(struct ratbag_profile *profile);
-static void
-ratbag_button_destroy(struct ratbag_button *button);
-static void
-ratbag_led_destroy(struct ratbag_led *led);
-static void
-ratbag_resolution_destroy(struct ratbag_resolution *resolution);
+static void ratbag_profile_destroy(struct ratbag_profile *profile);
+static void ratbag_button_destroy(struct ratbag_button *button);
+static void ratbag_led_destroy(struct ratbag_led *led);
+static void ratbag_resolution_destroy(struct ratbag_resolution *resolution);
 
-static void
-ratbag_default_log_func(struct ratbag *ratbag,
-			enum ratbag_log_priority priority,
-			const char *format, va_list args)
-{
-	const char *prefix;
-	FILE *out = stdout;
+static void ratbag_default_log_func(struct ratbag *ratbag,
+                                    enum ratbag_log_priority priority,
+                                    const char *format, va_list args) {
+  const char *prefix;
+  FILE *out = stdout;
 
-	switch(priority) {
-	case RATBAG_LOG_PRIORITY_RAW:
-		prefix = "raw";
-		break;
-	case RATBAG_LOG_PRIORITY_DEBUG:
-		prefix = "debug";
-		break;
-	case RATBAG_LOG_PRIORITY_INFO:
-		prefix = "info";
-		break;
-	case RATBAG_LOG_PRIORITY_ERROR:
-		prefix = "error";
-		out = stderr;
-		break;
-	default:
-		prefix="<invalid priority>";
-		break;
-	}
+  switch (priority) {
+  case RATBAG_LOG_PRIORITY_RAW:
+    prefix = "raw";
+    break;
+  case RATBAG_LOG_PRIORITY_DEBUG:
+    prefix = "debug";
+    break;
+  case RATBAG_LOG_PRIORITY_INFO:
+    prefix = "info";
+    break;
+  case RATBAG_LOG_PRIORITY_ERROR:
+    prefix = "error";
+    out = stderr;
+    break;
+  default:
+    prefix = "<invalid priority>";
+    break;
+  }
 
-	fprintf(out, "ratbag %s: ", prefix);
-	vfprintf(out, format, args);
+  fprintf(out, "ratbag %s: ", prefix);
+  vfprintf(out, format, args);
 }
 
-void
-log_msg_va(struct ratbag *ratbag,
-	   enum ratbag_log_priority priority,
-	   const char *format,
-	   va_list args)
-{
-	if (ratbag->log_handler &&
-	    ratbag->log_priority <= priority)
-		ratbag->log_handler(ratbag, priority, format, args);
+void log_msg_va(struct ratbag *ratbag, enum ratbag_log_priority priority,
+                const char *format, va_list args) {
+  if (ratbag->log_handler && ratbag->log_priority <= priority)
+    ratbag->log_handler(ratbag, priority, format, args);
 }
 
-void
-log_msg(struct ratbag *ratbag,
-	enum ratbag_log_priority priority,
-	const char *format, ...)
-{
-	va_list args;
+void log_msg(struct ratbag *ratbag, enum ratbag_log_priority priority,
+             const char *format, ...) {
+  va_list args;
 
-	va_start(args, format);
-	log_msg_va(ratbag, priority, format, args);
-	va_end(args);
+  va_start(args, format);
+  log_msg_va(ratbag, priority, format, args);
+  va_end(args);
 }
 
-void
-log_buffer(struct ratbag *ratbag,
-	enum ratbag_log_priority priority,
-	const char *header,
-	const uint8_t *buf, size_t len)
-{
-	_cleanup_free_ char *output_buf = NULL;
-	char *sep = "";
-	unsigned int i, n;
-	unsigned int buf_len;
+void log_buffer(struct ratbag *ratbag, enum ratbag_log_priority priority,
+                const char *header, const uint8_t *buf, size_t len) {
+  _cleanup_free_ char *output_buf = NULL;
+  char *sep = "";
+  unsigned int i, n;
+  unsigned int buf_len;
 
-	if (ratbag->log_handler &&
-	    ratbag->log_priority > priority)
-		return;
+  if (ratbag->log_handler && ratbag->log_priority > priority)
+    return;
 
-	buf_len = header ? strlen(header) : 0;
-	buf_len += len * 3;
-	buf_len += 1; /* terminating '\0' */
+  buf_len = header ? strlen(header) : 0;
+  buf_len += len * 3;
+  buf_len += 1; /* terminating '\0' */
 
-	output_buf = zalloc(buf_len);
-	n = 0;
-	if (header)
-		n += snprintf_safe(output_buf, buf_len - n, "%s", header);
+  output_buf = zalloc(buf_len);
+  n = 0;
+  if (header)
+    n += snprintf_safe(output_buf, buf_len - n, "%s", header);
 
-	for (i = 0; i < len; ++i) {
-		n += snprintf_safe(&output_buf[n], buf_len - n, "%s%02x", sep, buf[i] & 0xFF);
-		sep = " ";
-	}
+  for (i = 0; i < len; ++i) {
+    n += snprintf_safe(&output_buf[n], buf_len - n, "%s%02x", sep,
+                       buf[i] & 0xFF);
+    sep = " ";
+  }
 
-	log_msg(ratbag, priority, "%s\n", output_buf);
+  log_msg(ratbag, priority, "%s\n", output_buf);
 }
 
 LIBRATBAG_EXPORT void
 ratbag_log_set_priority(struct ratbag *ratbag,
-			enum ratbag_log_priority priority)
-{
-	switch (priority) {
-	case RATBAG_LOG_PRIORITY_RAW:
-	case RATBAG_LOG_PRIORITY_DEBUG:
-	case RATBAG_LOG_PRIORITY_INFO:
-	case RATBAG_LOG_PRIORITY_ERROR:
-		break;
-	default:
-		log_bug_client(ratbag,
-			       "Invalid log priority %d. Using INFO instead\n",
-			       priority);
-		priority = RATBAG_LOG_PRIORITY_INFO;
-	}
-	ratbag->log_priority = priority;
+                        enum ratbag_log_priority priority) {
+  switch (priority) {
+  case RATBAG_LOG_PRIORITY_RAW:
+  case RATBAG_LOG_PRIORITY_DEBUG:
+  case RATBAG_LOG_PRIORITY_INFO:
+  case RATBAG_LOG_PRIORITY_ERROR:
+    break;
+  default:
+    log_bug_client(ratbag, "Invalid log priority %d. Using INFO instead\n",
+                   priority);
+    priority = RATBAG_LOG_PRIORITY_INFO;
+  }
+  ratbag->log_priority = priority;
 }
 
 LIBRATBAG_EXPORT enum ratbag_log_priority
-ratbag_log_get_priority(const struct ratbag *ratbag)
-{
-	return ratbag->log_priority;
+ratbag_log_get_priority(const struct ratbag *ratbag) {
+  return ratbag->log_priority;
 }
 
-LIBRATBAG_EXPORT void
-ratbag_log_set_handler(struct ratbag *ratbag,
-		       ratbag_log_handler log_handler)
-{
-	ratbag->log_handler = log_handler;
+LIBRATBAG_EXPORT void ratbag_log_set_handler(struct ratbag *ratbag,
+                                             ratbag_log_handler log_handler) {
+  ratbag->log_handler = log_handler;
 }
 
-struct ratbag_device*
-ratbag_device_new(struct ratbag *ratbag, struct udev_device *udev_device,
-		  const char *name, const struct input_id *id)
-{
-	struct ratbag_device *device = NULL;
+struct ratbag_device *ratbag_device_new(struct ratbag *ratbag,
+                                        struct udev_device *udev_device,
+                                        const char *name,
+                                        const struct input_id *id) {
+  struct ratbag_device *device = NULL;
 
-	device = zalloc(sizeof(*device));
-	device->name = strdup_safe(name);
-	device->ratbag = ratbag_ref(ratbag);
-	device->refcount = 1;
-	device->udev_device = udev_device_ref(udev_device);
-	device->ids = *id;
-	device->data = ratbag_device_data_new_for_id(ratbag, id);
+  device = zalloc(sizeof(*device));
+  device->name = strdup_safe(name);
+  device->ratbag = ratbag_ref(ratbag);
+  device->refcount = 1;
+  device->udev_device = udev_device_ref(udev_device);
+  device->ids = *id;
+  device->data = ratbag_device_data_new_for_id(ratbag, id);
 
-	if (device->data != NULL)
-		device->devicetype = ratbag_device_data_get_device_type(device->data);
+  if (device->data != NULL)
+    device->devicetype = ratbag_device_data_get_device_type(device->data);
 
-	list_init(&device->profiles);
+  list_init(&device->profiles);
 
-	list_insert(&ratbag->devices, &device->link);
+  list_insert(&ratbag->devices, &device->link);
 
-	return device;
+  return device;
 }
 
-void
-ratbag_device_destroy(struct ratbag_device *device)
-{
-	struct ratbag_profile *profile, *next;
+void ratbag_device_destroy(struct ratbag_device *device) {
+  struct ratbag_profile *profile, *next;
 
-	if (!device)
-		return;
+  if (!device)
+    return;
 
-	/* if we get to the point where the device is destroyed, profiles,
-	 * buttons, etc. are at a refcount of 0, so we can destroy
-	 * everything */
-	if (device->driver && device->driver->remove)
-		device->driver->remove(device);
+  /* if we get to the point where the device is destroyed, profiles,
+   * buttons, etc. are at a refcount of 0, so we can destroy
+   * everything */
+  if (device->driver && device->driver->remove)
+    device->driver->remove(device);
 
-	list_for_each_safe(profile, next, &device->profiles, link)
-		ratbag_profile_destroy(profile);
+  list_for_each_safe(profile, next, &device->profiles, link)
+      ratbag_profile_destroy(profile);
 
-	if (device->udev_device)
-		udev_device_unref(device->udev_device);
+  if (device->udev_device)
+    udev_device_unref(device->udev_device);
 
-	list_remove(&device->link);
+  list_remove(&device->link);
 
-	ratbag_unref(device->ratbag);
-	ratbag_device_data_unref(device->data);
-	free(device->name);
-	free(device->firmware_version);
-	free(device);
+  ratbag_unref(device->ratbag);
+  ratbag_device_data_unref(device->data);
+  free(device->name);
+  free(device->firmware_version);
+  free(device);
 }
 
-static inline bool
-ratbag_sanity_check_device(struct ratbag_device *device)
-{
-	struct ratbag *ratbag = device->ratbag;
-	struct ratbag_profile *profile = NULL;
-	bool has_active = false;
-	unsigned int nres;
-	bool rc = false;
+static inline bool ratbag_sanity_check_device(struct ratbag_device *device) {
+  struct ratbag *ratbag = device->ratbag;
+  struct ratbag_profile *profile = NULL;
+  bool has_active = false;
+  unsigned int nres;
+  bool rc = false;
 
-	/* arbitrary number: max 16 profiles, does any mouse have more? but
-	 * since we have num_profiles unsigned, it also checks for
-	 * accidental negative */
-	if (device->num_profiles == 0 || device->num_profiles > 16) {
-		log_bug_libratbag(ratbag,
-				  "%s: invalid number of profiles (%d)\n",
-				  device->name,
-				  device->num_profiles);
-		goto out;
-	}
+  /* arbitrary number: max 16 profiles, does any mouse have more? but
+   * since we have num_profiles unsigned, it also checks for
+   * accidental negative */
+  if (device->num_profiles == 0 || device->num_profiles > 16) {
+    log_bug_libratbag(ratbag, "%s: invalid number of profiles (%d)\n",
+                      device->name, device->num_profiles);
+    goto out;
+  }
 
-	ratbag_device_for_each_profile(device, profile) {
-		struct ratbag_resolution *resolution;
-		unsigned int vals[300];
-		unsigned int nvals = ARRAY_LENGTH(vals);
+  ratbag_device_for_each_profile(device, profile) {
+    struct ratbag_resolution *resolution;
+    unsigned int vals[300];
+    unsigned int nvals = ARRAY_LENGTH(vals);
 
-		/* Allow max 1 active profile */
-		if (profile->is_active) {
-			if (has_active) {
-				log_bug_libratbag(ratbag,
-						  "%s: multiple active profiles\n",
-						  device->name);
-				goto out;
-			}
-			has_active = true;
-		}
+    /* Allow max 1 active profile */
+    if (profile->is_active) {
+      if (has_active) {
+        log_bug_libratbag(ratbag, "%s: multiple active profiles\n",
+                          device->name);
+        goto out;
+      }
+      has_active = true;
+    }
 
-		nres = ratbag_profile_get_num_resolutions(profile);
-		if (nres > 16) {
-				log_bug_libratbag(ratbag,
-						  "%s: invalid number of resolutions (%d)\n",
-						  device->name,
-						  nres);
-				goto out;
-		}
+    nres = ratbag_profile_get_num_resolutions(profile);
+    if (nres > 16) {
+      log_bug_libratbag(ratbag, "%s: invalid number of resolutions (%d)\n",
+                        device->name, nres);
+      goto out;
+    }
 
-		ratbag_profile_for_each_resolution(profile, resolution) {
-			nvals = ratbag_resolution_get_dpi_list(resolution, vals, nvals);
-			if (nvals == 0) {
-				log_bug_libratbag(ratbag,
-						  "%s: invalid dpi list\n",
-						  device->name);
-				goto out;
-			}
+    ratbag_profile_for_each_resolution(profile, resolution) {
+      nvals = ratbag_resolution_get_dpi_list(resolution, vals, nvals);
+      if (nvals == 0) {
+        log_bug_libratbag(ratbag, "%s: invalid dpi list\n", device->name);
+        goto out;
+      }
+    }
 
-		}
+    nvals = ratbag_profile_get_report_rate_list(profile, vals, nvals);
+    if (nvals == 0) {
+      log_bug_libratbag(ratbag, "%s: invalid report rate list\n", device->name);
+      goto out;
+    }
 
-		nvals = ratbag_profile_get_report_rate_list(profile, vals, nvals);
-		if (nvals == 0) {
-			log_bug_libratbag(ratbag,
-					  "%s: invalid report rate list\n",
-					  device->name);
-			goto out;
-		}
+    if (profile->dirty) {
+      log_bug_libratbag(ratbag, "%s: profile is dirty while probing\n",
+                        device->name);
+      /* Don't bail yet, as we may have some drivers that do this. */
+    }
+  }
 
-		if (profile->dirty) {
-			log_bug_libratbag(ratbag,
-					  "%s: profile is dirty while probing\n",
-					  device->name);
-			/* Don't bail yet, as we may have some drivers that do this. */
-		}
-	}
+  /* Require 1 active profile */
+  if (!has_active) {
+    log_bug_libratbag(ratbag, "%s: no profile set as active profile\n",
+                      device->name);
+    goto out;
+  }
 
-	/* Require 1 active profile */
-	if (!has_active) {
-		log_bug_libratbag(ratbag,
-				  "%s: no profile set as active profile\n",
-				  device->name);
-		goto out;
-	}
-
-	rc = true;
+  rc = true;
 
 out:
-	return rc;
+  return rc;
 }
 
 static inline bool
-ratbag_try_driver(struct ratbag_device *device,
-		   const struct input_id *dev_id,
-		   const char *driver_name,
-		   const struct ratbag_test_device *test_device)
-{
-	struct ratbag *ratbag = device->ratbag;
-	struct ratbag_driver *driver;
-	int rc;
+ratbag_try_driver(struct ratbag_device *device, const struct input_id *dev_id,
+                  const char *driver_name,
+                  const struct ratbag_test_device *test_device) {
+  struct ratbag *ratbag = device->ratbag;
+  struct ratbag_driver *driver;
+  int rc;
 
-	list_for_each(driver, &ratbag->drivers, link) {
-		if (streq(driver->id, driver_name)) {
-			device->driver = driver;
-			break;
-		}
-	}
+  list_for_each(driver, &ratbag->drivers, link) {
+    if (streq(driver->id, driver_name)) {
+      device->driver = driver;
+      break;
+    }
+  }
 
-	if (!device->driver) {
-		log_error(ratbag, "%s: driver '%s' does not exist\n",
-			  device->name, driver_name);
-		goto error;
-	}
+  if (!device->driver) {
+    log_error(ratbag, "%s: driver '%s' does not exist\n", device->name,
+              driver_name);
+    goto error;
+  }
 
-	if (test_device)
-		rc = device->driver->test_probe(device, test_device);
-	else
-		rc = device->driver->probe(device);
-	if (rc == 0) {
-		if (!ratbag_sanity_check_device(device)) {
-			goto error;
-		} else {
-			log_debug(ratbag,
-				  "driver match found: %s\n",
-				  device->driver->name);
-			return true;
-		}
-	}
+  if (test_device)
+    rc = device->driver->test_probe(device, test_device);
+  else
+    rc = device->driver->probe(device);
+  if (rc == 0) {
+    if (!ratbag_sanity_check_device(device)) {
+      goto error;
+    } else {
+      log_debug(ratbag, "driver match found: %s\n", device->driver->name);
+      return true;
+    }
+  }
 
-	if (rc != -ENODEV)
-		log_error(ratbag, "%s: error opening hidraw node (%s)\n",
-			  device->name, strerror(-rc));
+  if (rc != -ENODEV)
+    log_error(ratbag, "%s: error opening hidraw node (%s)\n", device->name,
+              strerror(-rc));
 
-	device->driver = NULL;
+  device->driver = NULL;
 error:
-	return false;
+  return false;
 }
 
-bool
-ratbag_assign_driver(struct ratbag_device *device,
-		     const struct input_id *dev_id,
-		     const struct ratbag_test_device *test_device)
-{
-	const char *driver_name;
+bool ratbag_assign_driver(struct ratbag_device *device,
+                          const struct input_id *dev_id,
+                          const struct ratbag_test_device *test_device) {
+  const char *driver_name;
 
-	if (!test_device) {
-		driver_name = ratbag_device_data_get_driver(device->data);
-	} else {
-		log_debug(device->ratbag, "This is a test device\n");
-		driver_name = "test_driver";
-	}
+  if (!test_device) {
+    driver_name = ratbag_device_data_get_driver(device->data);
+  } else {
+    log_debug(device->ratbag, "This is a test device\n");
+    driver_name = "test_driver";
+  }
 
-	log_debug(device->ratbag, "device assigned driver %s\n", driver_name);
-	return ratbag_try_driver(device, dev_id, driver_name, test_device);
+  log_debug(device->ratbag, "device assigned driver %s\n", driver_name);
+  return ratbag_try_driver(device, dev_id, driver_name, test_device);
 }
 
-static char *
-get_device_name(struct udev_device *device)
-{
-	const char *prop;
+static char *get_device_name(struct udev_device *device) {
+  const char *prop;
 
-	prop = udev_prop_value(device, "HID_NAME");
+  prop = udev_prop_value(device, "HID_NAME");
 
-	return strdup_safe(prop);
+  return strdup_safe(prop);
 }
 
-static inline int
-get_product_id(struct udev_device *device, struct input_id *id)
-{
-	const char *product;
-	struct input_id ids  = {0};
-	int rc;
+static inline int get_product_id(struct udev_device *device,
+                                 struct input_id *id) {
+  const char *product;
+  struct input_id ids = {0};
+  int rc;
 
-	product = udev_prop_value(device, "HID_ID");
-	if (!product)
-		return -1;
+  product = udev_prop_value(device, "HID_ID");
+  if (!product)
+    return -1;
 
-	rc = sscanf(product, "%hx:%hx:%hx", &ids.bustype, &ids.vendor, &ids.product);
-	if (rc != 3)
-		return -1;
+  rc = sscanf(product, "%hx:%hx:%hx", &ids.bustype, &ids.vendor, &ids.product);
+  if (rc != 3)
+    return -1;
 
-	*id = ids;
-	return 0;
+  *id = ids;
+  return 0;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
 ratbag_device_new_from_udev_device(struct ratbag *ratbag,
-				   struct udev_device *udev_device,
-				   struct ratbag_device **device_out)
-{
-	struct ratbag_device *device = NULL;
-	enum ratbag_error_code error = RATBAG_ERROR_DEVICE;
-	_cleanup_free_ char *name = NULL;
-	struct input_id id;
+                                   struct udev_device *udev_device,
+                                   struct ratbag_device **device_out) {
+  struct ratbag_device *device = NULL;
+  enum ratbag_error_code error = RATBAG_ERROR_DEVICE;
+  _cleanup_free_ char *name = NULL;
+  struct input_id id;
 
-	assert(ratbag != NULL);
-	assert(udev_device != NULL);
-	assert(device_out != NULL);
+  assert(ratbag != NULL);
+  assert(udev_device != NULL);
+  assert(device_out != NULL);
 
-	if (get_product_id(udev_device, &id) != 0)
-		goto out_err;
+  if (get_product_id(udev_device, &id) != 0)
+    goto out_err;
 
-	if ((name = get_device_name(udev_device)) == 0)
-		goto out_err;
+  if ((name = get_device_name(udev_device)) == 0)
+    goto out_err;
 
-	log_debug(ratbag, "New device: %s\n", name);
+  log_debug(ratbag, "New device: %s\n", name);
 
-	device = ratbag_device_new(ratbag, udev_device, name, &id);
-	if (!device || !device->data)
-		goto out_err;
+  device = ratbag_device_new(ratbag, udev_device, name, &id);
+  if (!device || !device->data)
+    goto out_err;
 
-	if (!ratbag_assign_driver(device, &device->ids, NULL))
-		goto out_err;
+  if (!ratbag_assign_driver(device, &device->ids, NULL))
+    goto out_err;
 
-	error = RATBAG_SUCCESS;
+  error = RATBAG_SUCCESS;
 
 out_err:
 
-	if (error != RATBAG_SUCCESS)
-		ratbag_device_destroy(device);
-	else
-		*device_out = device;
+  if (error != RATBAG_SUCCESS)
+    ratbag_device_destroy(device);
+  else
+    *device_out = device;
 
-	return error_code(error);
+  return error_code(error);
 }
 
 LIBRATBAG_EXPORT struct ratbag_device *
-ratbag_device_ref(struct ratbag_device *device)
-{
-	assert(device->refcount < INT_MAX);
+ratbag_device_ref(struct ratbag_device *device) {
+  assert(device->refcount < INT_MAX);
 
-	device->refcount++;
-	return device;
+  device->refcount++;
+  return device;
 }
 
 LIBRATBAG_EXPORT struct ratbag_device *
-ratbag_device_unref(struct ratbag_device *device)
-{
-	if (device == NULL)
-		return NULL;
+ratbag_device_unref(struct ratbag_device *device) {
+  if (device == NULL)
+    return NULL;
 
-	assert(device->refcount > 0);
-	device->refcount--;
-	if (device->refcount == 0)
-		ratbag_device_destroy(device);
+  assert(device->refcount > 0);
+  device->refcount--;
+  if (device->refcount == 0)
+    ratbag_device_destroy(device);
 
-	return NULL;
+  return NULL;
 }
 
 LIBRATBAG_EXPORT const char *
-ratbag_device_get_name(const struct ratbag_device* device)
-{
-	return device->name;
+ratbag_device_get_name(const struct ratbag_device *device) {
+  return device->name;
 }
 
 LIBRATBAG_EXPORT enum ratbag_device_type
-ratbag_device_get_device_type(const struct ratbag_device *device)
-{
-	return device->devicetype;
+ratbag_device_get_device_type(const struct ratbag_device *device) {
+  return device->devicetype;
 }
 
 LIBRATBAG_EXPORT const char *
-ratbag_device_get_bustype(const struct ratbag_device *device)
-{
-	switch (device->ids.bustype) {
-	case BUS_USB:
-		return "usb";
-	case BUS_BLUETOOTH:
-		return "bluetooth";
-	default:
-		return NULL;
-	}
+ratbag_device_get_bustype(const struct ratbag_device *device) {
+  switch (device->ids.bustype) {
+  case BUS_USB:
+    return "usb";
+  case BUS_BLUETOOTH:
+    return "bluetooth";
+  default:
+    return NULL;
+  }
 }
 
 LIBRATBAG_EXPORT uint32_t
-ratbag_device_get_vendor_id(const struct ratbag_device *device)
-{
-	return device->ids.vendor;
+ratbag_device_get_vendor_id(const struct ratbag_device *device) {
+  return device->ids.vendor;
 }
 
 LIBRATBAG_EXPORT uint32_t
-ratbag_device_get_product_id(const struct ratbag_device *device)
-{
-	return device->ids.product;
+ratbag_device_get_product_id(const struct ratbag_device *device) {
+  return device->ids.product;
 }
 
 LIBRATBAG_EXPORT uint32_t
-ratbag_device_get_product_version(const struct ratbag_device *device)
-{
-	/* change this when we have a need for it, i.e. when we start supporting devices
-	 * where the USB ID gets reused */
-	return 0;
+ratbag_device_get_product_version(const struct ratbag_device *device) {
+  /* change this when we have a need for it, i.e. when we start supporting
+   * devices where the USB ID gets reused */
+  return 0;
 }
 
-void
-ratbag_register_driver(struct ratbag *ratbag, struct ratbag_driver *driver)
-{
-	if (!driver->name) {
-		log_bug_libratbag(ratbag, "Driver is missing name\n");
-		return;
-	}
+void ratbag_register_driver(struct ratbag *ratbag,
+                            struct ratbag_driver *driver) {
+  if (!driver->name) {
+    log_bug_libratbag(ratbag, "Driver is missing name\n");
+    return;
+  }
 
-	if (!driver->probe || !driver->remove) {
-		log_bug_libratbag(ratbag, "Driver %s is incomplete.\n", driver->name);
-		return;
-	}
-	list_insert(&ratbag->drivers, &driver->link);
+  if (!driver->probe || !driver->remove) {
+    log_bug_libratbag(ratbag, "Driver %s is incomplete.\n", driver->name);
+    return;
+  }
+  list_insert(&ratbag->drivers, &driver->link);
 }
 
 LIBRATBAG_EXPORT struct ratbag *
 ratbag_create_context(const struct ratbag_interface *interface,
-		      void *userdata)
-{
-	struct ratbag *ratbag;
+                      void *userdata) {
+  struct ratbag *ratbag;
 
-	assert(interface != NULL);
-	assert(interface->open_restricted != NULL);
-	assert(interface->close_restricted != NULL);
+  assert(interface != NULL);
+  assert(interface->open_restricted != NULL);
+  assert(interface->close_restricted != NULL);
 
-	ratbag = zalloc(sizeof(*ratbag));
-	ratbag->refcount = 1;
-	ratbag->interface = interface;
-	ratbag->userdata = userdata;
+  ratbag = zalloc(sizeof(*ratbag));
+  ratbag->refcount = 1;
+  ratbag->interface = interface;
+  ratbag->userdata = userdata;
 
-	list_init(&ratbag->drivers);
-	list_init(&ratbag->devices);
-	ratbag->udev = udev_new();
-	if (!ratbag->udev) {
-		free(ratbag);
-		return NULL;
-	}
+  list_init(&ratbag->drivers);
+  list_init(&ratbag->devices);
+  ratbag->udev = udev_new();
+  if (!ratbag->udev) {
+    free(ratbag);
+    return NULL;
+  }
 
-	ratbag->log_handler = ratbag_default_log_func;
-	ratbag->log_priority = RATBAG_LOG_PRIORITY_INFO;
+  ratbag->log_handler = ratbag_default_log_func;
+  ratbag->log_priority = RATBAG_LOG_PRIORITY_INFO;
 
-	ratbag_register_driver(ratbag, &etekcity_driver);
-	ratbag_register_driver(ratbag, &hidpp20_driver);
-	ratbag_register_driver(ratbag, &hidpp10_driver);
-	ratbag_register_driver(ratbag, &logitech_g300_driver);
-	ratbag_register_driver(ratbag, &logitech_g600_driver);
-	ratbag_register_driver(ratbag, &marsgaming_driver);
-	ratbag_register_driver(ratbag, &roccat_driver);
-	ratbag_register_driver(ratbag, &roccat_kone_pure_driver);
-	ratbag_register_driver(ratbag, &roccat_emp_driver);
-	ratbag_register_driver(ratbag, &gskill_driver);
-	ratbag_register_driver(ratbag, &steelseries_driver);
-	ratbag_register_driver(ratbag, &asus_driver);
-	ratbag_register_driver(ratbag, &sinowealth_driver);
-	ratbag_register_driver(ratbag, &sinowealth_nubwo_driver);
-	ratbag_register_driver(ratbag, &openinput_driver);
+  ratbag_register_driver(ratbag, &etekcity_driver);
+  ratbag_register_driver(ratbag, &hidpp20_driver);
+  ratbag_register_driver(ratbag, &hidpp10_driver);
+  ratbag_register_driver(ratbag, &logitech_g300_driver);
+  ratbag_register_driver(ratbag, &logitech_g600_driver);
+  ratbag_register_driver(ratbag, &marsgaming_driver);
+  ratbag_register_driver(ratbag, &roccat_driver);
+  ratbag_register_driver(ratbag, &roccat_kone_pure_driver);
+  ratbag_register_driver(ratbag, &roccat_emp_driver);
+  ratbag_register_driver(ratbag, &gskill_driver);
+  ratbag_register_driver(ratbag, &steelseries_driver);
+  ratbag_register_driver(ratbag, &asus_driver);
+  ratbag_register_driver(ratbag, &sinowealth_driver);
+  ratbag_register_driver(ratbag, &sinowealth_nubwo_driver);
+  ratbag_register_driver(ratbag, &openinput_driver);
 
-	return ratbag;
+  return ratbag;
 }
 
-LIBRATBAG_EXPORT struct ratbag *
-ratbag_ref(struct ratbag *ratbag)
-{
-	ratbag->refcount++;
-	return ratbag;
+LIBRATBAG_EXPORT struct ratbag *ratbag_ref(struct ratbag *ratbag) {
+  ratbag->refcount++;
+  return ratbag;
 }
 
-LIBRATBAG_EXPORT struct ratbag *
-ratbag_unref(struct ratbag *ratbag)
-{
-	if (ratbag == NULL)
-		return NULL;
+LIBRATBAG_EXPORT struct ratbag *ratbag_unref(struct ratbag *ratbag) {
+  if (ratbag == NULL)
+    return NULL;
 
-	assert(ratbag->refcount > 0);
-	ratbag->refcount--;
-	if (ratbag->refcount == 0) {
-		ratbag->udev = udev_unref(ratbag->udev);
-		free(ratbag);
-	}
+  assert(ratbag->refcount > 0);
+  ratbag->refcount--;
+  if (ratbag->refcount == 0) {
+    ratbag->udev = udev_unref(ratbag->udev);
+    free(ratbag);
+  }
 
-	return NULL;
+  return NULL;
 }
 
 static struct ratbag_button *
-ratbag_create_button(struct ratbag_profile *profile, unsigned int index)
-{
-	struct ratbag_button *button;
+ratbag_create_button(struct ratbag_profile *profile, unsigned int index) {
+  struct ratbag_button *button;
 
-	button = zalloc(sizeof(*button));
-	button->refcount = 0;
-	button->profile = profile;
-	button->index = index;
+  button = zalloc(sizeof(*button));
+  button->refcount = 0;
+  button->profile = profile;
+  button->index = index;
 
-	list_append(&profile->buttons, &button->link);
+  list_append(&profile->buttons, &button->link);
 
-	return button;
+  return button;
 }
 
-static struct ratbag_led *
-ratbag_create_led(struct ratbag_profile *profile, unsigned int index)
-{
-	struct ratbag_led *led;
+static struct ratbag_led *ratbag_create_led(struct ratbag_profile *profile,
+                                            unsigned int index) {
+  struct ratbag_led *led;
 
-	led = zalloc(sizeof(*led));
-	led->refcount = 0;
-	led->profile = profile;
-	led->index = index;
-	led->colordepth = RATBAG_LED_COLORDEPTH_RGB_888;
+  led = zalloc(sizeof(*led));
+  led->refcount = 0;
+  led->profile = profile;
+  led->index = index;
+  led->colordepth = RATBAG_LED_COLORDEPTH_RGB_888;
 
-	list_append(&profile->leds, &led->link);
+  list_append(&profile->leds, &led->link);
 
-	return led;
+  return led;
 }
 
 LIBRATBAG_EXPORT bool
 ratbag_profile_has_capability(const struct ratbag_profile *profile,
-			      enum ratbag_profile_capability cap)
-{
-	if (cap == RATBAG_PROFILE_CAP_NONE || cap >= MAX_CAP)
-		abort();
+                              enum ratbag_profile_capability cap) {
+  if (cap == RATBAG_PROFILE_CAP_NONE || cap >= MAX_CAP)
+    abort();
 
-	return long_bit_is_set(profile->capabilities, cap);
+  return long_bit_is_set(profile->capabilities, cap);
 }
 
-static inline void
-ratbag_create_resolution(struct ratbag_profile *profile, int index)
-{
-	struct ratbag_resolution *res;
+static inline void ratbag_create_resolution(struct ratbag_profile *profile,
+                                            int index) {
+  struct ratbag_resolution *res;
 
-	res = zalloc(sizeof(*res));
-	res->refcount = 0;
-	res->profile = profile;
-	res->index = index;
+  res = zalloc(sizeof(*res));
+  res->refcount = 0;
+  res->profile = profile;
+  res->index = index;
 
-	list_append(&profile->resolutions, &res->link);
+  list_append(&profile->resolutions, &res->link);
 
-	profile->num_resolutions++;
+  profile->num_resolutions++;
 }
-
 
 static struct ratbag_profile *
-ratbag_create_profile(struct ratbag_device *device,
-		      unsigned int index,
-		      unsigned int num_resolutions,
-		      unsigned int num_buttons,
-		      unsigned int num_leds)
-{
-	struct ratbag_profile *profile;
-	unsigned i;
+ratbag_create_profile(struct ratbag_device *device, unsigned int index,
+                      unsigned int num_resolutions, unsigned int num_buttons,
+                      unsigned int num_leds) {
+  struct ratbag_profile *profile;
+  unsigned i;
 
-	profile = zalloc(sizeof(*profile));
-	profile->refcount = 0;
-	profile->device = device;
-	profile->index = index;
-	profile->num_resolutions = 0;
-	profile->is_enabled = true;
-	profile->name = NULL;
-	profile->angle_snapping = -1;
-	profile->motion_sync = -1;
-	profile->ripple_control = -1;
-	profile->debounce = -1;
-	profile->lod = -1;
-	profile->autosleep = -1;
+  profile = zalloc(sizeof(*profile));
+  profile->refcount = 0;
+  profile->device = device;
+  profile->index = index;
+  profile->num_resolutions = 0;
+  profile->is_enabled = true;
+  profile->name = NULL;
+  profile->angle_snapping = -1;
+  profile->motion_sync = -1;
+  profile->ripple_control = -1;
+  profile->debounce = -1;
+  profile->lod = -1;
+  profile->autosleep = -1;
 
-	list_append(&device->profiles, &profile->link);
-	list_init(&profile->buttons);
-	list_init(&profile->leds);
-	list_init(&profile->resolutions);
+  list_append(&device->profiles, &profile->link);
+  list_init(&profile->buttons);
+  list_init(&profile->leds);
+  list_init(&profile->resolutions);
 
-	profile->device->num_buttons = num_buttons;
-	profile->device->num_leds = num_leds;
+  profile->device->num_buttons = num_buttons;
+  profile->device->num_leds = num_leds;
 
-	for (i = 0; i < num_resolutions; i++)
-		ratbag_create_resolution(profile, i);
+  for (i = 0; i < num_resolutions; i++)
+    ratbag_create_resolution(profile, i);
 
-	for (i = 0; i < num_buttons; i++)
-		ratbag_create_button(profile, i);
+  for (i = 0; i < num_buttons; i++)
+    ratbag_create_button(profile, i);
 
-	for (i = 0; i < num_leds; i++)
-		ratbag_create_led(profile, i);
+  for (i = 0; i < num_leds; i++)
+    ratbag_create_led(profile, i);
 
-	return profile;
+  return profile;
 }
 
-int
-ratbag_device_init_profiles(struct ratbag_device *device,
-			    unsigned int num_profiles,
-			    unsigned int num_resolutions,
-			    unsigned int num_buttons,
-			    unsigned int num_leds)
-{
-	unsigned int i;
+int ratbag_device_init_profiles(struct ratbag_device *device,
+                                unsigned int num_profiles,
+                                unsigned int num_resolutions,
+                                unsigned int num_buttons,
+                                unsigned int num_leds) {
+  unsigned int i;
 
-	for (i = 0; i < num_profiles; i++) {
-		ratbag_create_profile(device, i, num_resolutions, num_buttons, num_leds);
-	}
+  for (i = 0; i < num_profiles; i++) {
+    ratbag_create_profile(device, i, num_resolutions, num_buttons, num_leds);
+  }
 
-	device->num_profiles = num_profiles;
+  device->num_profiles = num_profiles;
 
-	return 0;
+  return 0;
 }
 
 LIBRATBAG_EXPORT struct ratbag_profile *
-ratbag_profile_ref(struct ratbag_profile *profile)
-{
-	assert(profile->refcount < INT_MAX);
+ratbag_profile_ref(struct ratbag_profile *profile) {
+  assert(profile->refcount < INT_MAX);
 
-	ratbag_device_ref(profile->device);
-	profile->refcount++;
-	return profile;
+  ratbag_device_ref(profile->device);
+  profile->refcount++;
+  return profile;
 }
 
-static void
-ratbag_profile_destroy(struct ratbag_profile *profile)
-{
-	struct ratbag_button *button, *b_next;
-	struct ratbag_led *led, *l_next;
-	struct ratbag_resolution *res, *r_next;
+static void ratbag_profile_destroy(struct ratbag_profile *profile) {
+  struct ratbag_button *button, *b_next;
+  struct ratbag_led *led, *l_next;
+  struct ratbag_resolution *res, *r_next;
 
-	/* if we get to the point where the profile is destroyed, buttons,
-	 * resolutions , etc. are at a refcount of 0, so we can destroy
-	 * everything */
-	list_for_each_safe(button, b_next, &profile->buttons, link)
-		ratbag_button_destroy(button);
+  /* if we get to the point where the profile is destroyed, buttons,
+   * resolutions , etc. are at a refcount of 0, so we can destroy
+   * everything */
+  list_for_each_safe(button, b_next, &profile->buttons, link)
+      ratbag_button_destroy(button);
 
-	list_for_each_safe(led, l_next, &profile->leds, link)
-		ratbag_led_destroy(led);
+  list_for_each_safe(led, l_next, &profile->leds, link) ratbag_led_destroy(led);
 
-	list_for_each_safe(res, r_next, &profile->resolutions, link)
-		ratbag_resolution_destroy(res);
+  list_for_each_safe(res, r_next, &profile->resolutions, link)
+      ratbag_resolution_destroy(res);
 
-	free(profile->name);
-	free(profile->lods);
-	free(profile->autosleeps);
+  free(profile->name);
+  free(profile->debounces);
+  free(profile->lods);
+  free(profile->autosleeps);
 
-	list_remove(&profile->link);
-	free(profile);
+  list_remove(&profile->link);
+  free(profile);
 }
 
 LIBRATBAG_EXPORT struct ratbag_profile *
-ratbag_profile_unref(struct ratbag_profile *profile)
-{
-	if (profile == NULL)
-		return NULL;
+ratbag_profile_unref(struct ratbag_profile *profile) {
+  if (profile == NULL)
+    return NULL;
 
-	assert(profile->refcount > 0);
-	profile->refcount--;
+  assert(profile->refcount > 0);
+  profile->refcount--;
 
-	ratbag_device_unref(profile->device);
+  ratbag_device_unref(profile->device);
 
-	return NULL;
+  return NULL;
 }
 
 LIBRATBAG_EXPORT struct ratbag_profile *
-ratbag_device_get_profile(struct ratbag_device *device, unsigned int index)
-{
-	struct ratbag_profile *profile;
+ratbag_device_get_profile(struct ratbag_device *device, unsigned int index) {
+  struct ratbag_profile *profile;
 
-	if (index >= ratbag_device_get_num_profiles(device)) {
-		log_bug_client(device->ratbag, "Requested invalid profile %d\n", index);
-		return NULL;
-	}
+  if (index >= ratbag_device_get_num_profiles(device)) {
+    log_bug_client(device->ratbag, "Requested invalid profile %d\n", index);
+    return NULL;
+  }
 
-	list_for_each(profile, &device->profiles, link) {
-		if (profile->index == index)
-			return ratbag_profile_ref(profile);
-	}
+  list_for_each(profile, &device->profiles, link) {
+    if (profile->index == index)
+      return ratbag_profile_ref(profile);
+  }
 
-	log_bug_libratbag(device->ratbag, "Profile %d not found\n", index);
+  log_bug_libratbag(device->ratbag, "Profile %d not found\n", index);
 
-	return NULL;
+  return NULL;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_profile_set_enabled(struct ratbag_profile *profile, bool enabled)
-{
-	if (!ratbag_profile_has_capability(profile, RATBAG_PROFILE_CAP_DISABLE))
-		return RATBAG_ERROR_CAPABILITY;
+ratbag_profile_set_enabled(struct ratbag_profile *profile, bool enabled) {
+  if (!ratbag_profile_has_capability(profile, RATBAG_PROFILE_CAP_DISABLE))
+    return RATBAG_ERROR_CAPABILITY;
 
-	if (profile->is_active && !enabled)
-		return RATBAG_ERROR_VALUE;
+  if (profile->is_active && !enabled)
+    return RATBAG_ERROR_VALUE;
 
-	profile->is_enabled = enabled;
-	profile->dirty = true;
+  profile->is_enabled = enabled;
+  profile->dirty = true;
 
-	return RATBAG_SUCCESS;
+  return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT bool
-ratbag_profile_is_active(const struct ratbag_profile *profile)
-{
-	return !!profile->is_active;
+ratbag_profile_is_active(const struct ratbag_profile *profile) {
+  return !!profile->is_active;
 }
 
 LIBRATBAG_EXPORT bool
-ratbag_profile_is_dirty(const struct ratbag_profile *profile)
-{
-	return !!profile->dirty;
+ratbag_profile_is_dirty(const struct ratbag_profile *profile) {
+  return !!profile->dirty;
 }
 
 LIBRATBAG_EXPORT bool
-ratbag_profile_is_enabled(const struct ratbag_profile *profile)
-{
-	return !!profile->is_enabled;
+ratbag_profile_is_enabled(const struct ratbag_profile *profile) {
+  return !!profile->is_enabled;
 }
 
 LIBRATBAG_EXPORT unsigned int
-ratbag_device_get_num_profiles(const struct ratbag_device *device)
-{
-	return device->num_profiles;
+ratbag_device_get_num_profiles(const struct ratbag_device *device) {
+  return device->num_profiles;
 }
 
 LIBRATBAG_EXPORT unsigned int
-ratbag_device_get_num_buttons(const struct ratbag_device *device)
-{
-	return device->num_buttons;
+ratbag_device_get_num_buttons(const struct ratbag_device *device) {
+  return device->num_buttons;
 }
 
 LIBRATBAG_EXPORT unsigned int
-ratbag_device_get_num_leds(const struct ratbag_device *device)
-{
-	return device->num_leds;
+ratbag_device_get_num_leds(const struct ratbag_device *device) {
+  return device->num_leds;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_device_commit(struct ratbag_device *device)
-{
-	struct ratbag_profile *profile;
-	struct ratbag_button *button;
-	struct ratbag_led *led;
-	struct ratbag_resolution *resolution;
-	int rc;
+ratbag_device_commit(struct ratbag_device *device) {
+  struct ratbag_profile *profile;
+  struct ratbag_button *button;
+  struct ratbag_led *led;
+  struct ratbag_resolution *resolution;
+  int rc;
 
-	if (device->driver->commit == NULL) {
-		log_error(device->ratbag,
-			  "Trying to commit with a driver that doesn't support committing\n");
-		return RATBAG_ERROR_CAPABILITY;
-	}
+  if (device->driver->commit == NULL) {
+    log_error(
+        device->ratbag,
+        "Trying to commit with a driver that doesn't support committing\n");
+    return RATBAG_ERROR_CAPABILITY;
+  }
 
-	rc = device->driver->commit(device);
-	if (rc)
-		return RATBAG_ERROR_DEVICE;
+  rc = device->driver->commit(device);
+  if (rc)
+    return RATBAG_ERROR_DEVICE;
 
-	list_for_each(profile, &device->profiles, link) {
-		profile->dirty = false;
+  list_for_each(profile, &device->profiles, link) {
+    profile->dirty = false;
 
-		profile->angle_snapping_dirty = false;
-		profile->debounce_dirty = false;
-		profile->lod_dirty = false;
-		profile->autosleep_dirty = false;
-		profile->rate_dirty = false;
+    profile->angle_snapping_dirty = false;
+    profile->debounce_dirty = false;
+    profile->lod_dirty = false;
+    profile->autosleep_dirty = false;
+    profile->rate_dirty = false;
 
-		list_for_each(button, &profile->buttons, link)
-			button->dirty = false;
+    list_for_each(button, &profile->buttons, link) button->dirty = false;
 
-		list_for_each(led, &profile->leds, link)
-			led->dirty = false;
+    list_for_each(led, &profile->leds, link) led->dirty = false;
 
-		list_for_each(resolution, &profile->resolutions, link)
-			resolution->dirty = false;
+    list_for_each(resolution, &profile->resolutions, link) resolution->dirty =
+        false;
 
-		/* TODO: think if this should be moved into `driver-commit`. */
-		if (profile->is_active_dirty && profile->is_active) {
-			if (device->driver->set_active_profile == NULL)
-				return RATBAG_ERROR_IMPLEMENTATION;
+    /* TODO: think if this should be moved into `driver-commit`. */
+    if (profile->is_active_dirty && profile->is_active) {
+      if (device->driver->set_active_profile == NULL)
+        return RATBAG_ERROR_IMPLEMENTATION;
 
-			rc = device->driver->set_active_profile(device, profile->index);
-			if (rc)
-				return RATBAG_ERROR_DEVICE;
-		}
-		profile->is_active_dirty = false;
-	}
+      rc = device->driver->set_active_profile(device, profile->index);
+      if (rc)
+        return RATBAG_ERROR_DEVICE;
+    }
+    profile->is_active_dirty = false;
+  }
 
-	return RATBAG_SUCCESS;
+  return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_device_reset(struct ratbag_device *device)
-{
-	int rc;
+ratbag_device_reset(struct ratbag_device *device) {
+  int rc;
 
-	if (device->driver->reset == NULL) {
-		log_error(device->ratbag,
-			  "Trying to reset a device whose driver doesn't support reset\n");
-		return RATBAG_ERROR_CAPABILITY;
-	}
+  if (device->driver->reset == NULL) {
+    log_error(device->ratbag,
+              "Trying to reset a device whose driver doesn't support reset\n");
+    return RATBAG_ERROR_CAPABILITY;
+  }
 
-	rc = device->driver->reset(device);
-	if (rc)
-		return RATBAG_ERROR_DEVICE;
+  rc = device->driver->reset(device);
+  if (rc)
+    return RATBAG_ERROR_DEVICE;
 
-	return RATBAG_SUCCESS;
+  return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_profile_set_active(struct ratbag_profile *profile)
-{
-	struct ratbag_device *device = profile->device;
-	struct ratbag_profile *p;
+ratbag_profile_set_active(struct ratbag_profile *profile) {
+  struct ratbag_device *device = profile->device;
+  struct ratbag_profile *p;
 
-	if (!profile->is_enabled)
-		return RATBAG_ERROR_VALUE;
+  if (!profile->is_enabled)
+    return RATBAG_ERROR_VALUE;
 
-	if (device->num_profiles == 1)
-		return RATBAG_SUCCESS;
+  if (device->num_profiles == 1)
+    return RATBAG_SUCCESS;
 
-	list_for_each(p, &device->profiles, link) {
-		if (p->is_active) {
-			p->is_active = false;
-			p->is_active_dirty = true;
-			p->dirty = true;
-		}
-	}
+  list_for_each(p, &device->profiles, link) {
+    if (p->is_active) {
+      p->is_active = false;
+      p->is_active_dirty = true;
+      p->dirty = true;
+    }
+  }
 
-	profile->is_active = true;
-	profile->is_active_dirty = true;
-	profile->dirty = true;
-	return RATBAG_SUCCESS;
+  profile->is_active = true;
+  profile->is_active_dirty = true;
+  profile->dirty = true;
+  return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT unsigned int
-ratbag_profile_get_num_resolutions(const struct ratbag_profile *profile)
-{
-	return profile->num_resolutions;
+ratbag_profile_get_num_resolutions(const struct ratbag_profile *profile) {
+  return profile->num_resolutions;
 }
 
 LIBRATBAG_EXPORT struct ratbag_resolution *
-ratbag_profile_get_resolution(struct ratbag_profile *profile, unsigned int idx)
-{
-	struct ratbag_device *device = profile->device;
-	struct ratbag_resolution *res;
-	unsigned max = ratbag_profile_get_num_resolutions(profile);
+ratbag_profile_get_resolution(struct ratbag_profile *profile,
+                              unsigned int idx) {
+  struct ratbag_device *device = profile->device;
+  struct ratbag_resolution *res;
+  unsigned max = ratbag_profile_get_num_resolutions(profile);
 
-	if (idx >= max) {
-		log_bug_client(profile->device->ratbag,
-			       "Requested invalid resolution %d\n", idx);
-		return NULL;
-	}
+  if (idx >= max) {
+    log_bug_client(profile->device->ratbag, "Requested invalid resolution %d\n",
+                   idx);
+    return NULL;
+  }
 
-	ratbag_profile_for_each_resolution(profile, res) {
-		if (res->index == idx)
-			return ratbag_resolution_ref(res);
-	}
+  ratbag_profile_for_each_resolution(profile, res) {
+    if (res->index == idx)
+      return ratbag_resolution_ref(res);
+  }
 
-	log_bug_libratbag(device->ratbag, "Resolution %d, profile %d not found\n",
-			  idx, profile->index);
+  log_bug_libratbag(device->ratbag, "Resolution %d, profile %d not found\n",
+                    idx, profile->index);
 
-	return NULL;
+  return NULL;
 }
 
 LIBRATBAG_EXPORT struct ratbag_resolution *
-ratbag_resolution_ref(struct ratbag_resolution *resolution)
-{
-	assert(resolution->refcount < INT_MAX);
+ratbag_resolution_ref(struct ratbag_resolution *resolution) {
+  assert(resolution->refcount < INT_MAX);
 
-	ratbag_profile_ref(resolution->profile);
-	resolution->refcount++;
-	return resolution;
+  ratbag_profile_ref(resolution->profile);
+  resolution->refcount++;
+  return resolution;
 }
 
 LIBRATBAG_EXPORT struct ratbag_resolution *
-ratbag_resolution_unref(struct ratbag_resolution *resolution)
-{
-	if (resolution == NULL)
-		return NULL;
+ratbag_resolution_unref(struct ratbag_resolution *resolution) {
+  if (resolution == NULL)
+    return NULL;
 
-	assert(resolution->refcount > 0);
-	resolution->refcount--;
+  assert(resolution->refcount > 0);
+  resolution->refcount--;
 
-	ratbag_profile_unref(resolution->profile);
+  ratbag_profile_unref(resolution->profile);
 
-	return NULL;
+  return NULL;
 }
 
 LIBRATBAG_EXPORT bool
 ratbag_resolution_has_capability(const struct ratbag_resolution *resolution,
-				 enum ratbag_resolution_capability cap)
-{
-	assert(cap <= RATBAG_RESOLUTION_CAP_DISABLE);
+                                 enum ratbag_resolution_capability cap) {
+  assert(cap <= RATBAG_RESOLUTION_CAP_DISABLE);
 
-	return !!(resolution->capabilities & (1 << cap));
+  return !!(resolution->capabilities & (1 << cap));
 }
 
 static inline bool
 resolution_has_dpi(const struct ratbag_resolution *resolution,
-		   unsigned int dpi)
-{
-	for (size_t i = 0; i < resolution->ndpis; i++) {
-		if (dpi == resolution->dpis[i])
-			return true;
-	}
+                   unsigned int dpi) {
+  for (size_t i = 0; i < resolution->ndpis; i++) {
+    if (dpi == resolution->dpis[i])
+      return true;
+  }
 
-	return false;
+  return false;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
 ratbag_resolution_set_dpi(struct ratbag_resolution *resolution,
-			  unsigned int dpi)
-{
-	struct ratbag_profile *profile = resolution->profile;
+                          unsigned int dpi) {
+  struct ratbag_profile *profile = resolution->profile;
 
-	if (!resolution_has_dpi(resolution, dpi))
-		return RATBAG_ERROR_VALUE;
+  if (!resolution_has_dpi(resolution, dpi))
+    return RATBAG_ERROR_VALUE;
 
-	if (resolution->dpi_x != dpi || resolution->dpi_y != dpi) {
-		resolution->dpi_x = dpi;
-		resolution->dpi_y = dpi;
-		resolution->dirty = true;
-		profile->dirty = true;
-	}
+  if (resolution->dpi_x != dpi || resolution->dpi_y != dpi) {
+    resolution->dpi_x = dpi;
+    resolution->dpi_y = dpi;
+    resolution->dirty = true;
+    profile->dirty = true;
+  }
 
-	return RATBAG_SUCCESS;
+  return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
 ratbag_resolution_set_dpi_xy(struct ratbag_resolution *resolution,
-			     unsigned int x, unsigned int y)
-{
-	struct ratbag_profile *profile = resolution->profile;
+                             unsigned int x, unsigned int y) {
+  struct ratbag_profile *profile = resolution->profile;
 
-	if (!ratbag_resolution_has_capability(resolution,
-					      RATBAG_RESOLUTION_CAP_SEPARATE_XY_RESOLUTION))
-		return RATBAG_ERROR_CAPABILITY;
+  if (!ratbag_resolution_has_capability(
+          resolution, RATBAG_RESOLUTION_CAP_SEPARATE_XY_RESOLUTION))
+    return RATBAG_ERROR_CAPABILITY;
 
-	if ((x == 0 && y != 0) || (x != 0 && y == 0))
-		return RATBAG_ERROR_VALUE;
+  if ((x == 0 && y != 0) || (x != 0 && y == 0))
+    return RATBAG_ERROR_VALUE;
 
-	if (!resolution_has_dpi(resolution, x) || !resolution_has_dpi(resolution, y))
-		return RATBAG_ERROR_VALUE;
+  if (!resolution_has_dpi(resolution, x) || !resolution_has_dpi(resolution, y))
+    return RATBAG_ERROR_VALUE;
 
-	if (resolution->dpi_x != x || resolution->dpi_y != y) {
-		resolution->dpi_x = x;
-		resolution->dpi_y = y;
-		resolution->dirty = true;
-		profile->dirty = true;
-	}
+  if (resolution->dpi_x != x || resolution->dpi_y != y) {
+    resolution->dpi_x = x;
+    resolution->dpi_y = y;
+    resolution->dirty = true;
+    profile->dirty = true;
+  }
 
-	return RATBAG_SUCCESS;
+  return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
 ratbag_profile_set_report_rate(struct ratbag_profile *profile,
-			       unsigned int hz)
-{
-	if (profile->hz != hz) {
-		profile->hz = hz;
-		profile->dirty = true;
-		profile->rate_dirty = true;
-	}
+                               unsigned int hz) {
+  if (profile->hz != hz) {
+    profile->hz = hz;
+    profile->dirty = true;
+    profile->rate_dirty = true;
+  }
 
-	return RATBAG_SUCCESS;
+  return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_profile_set_angle_snapping(struct ratbag_profile *profile,
-				  int value)
-{
-	if (profile->angle_snapping != value) {
-		profile->angle_snapping = value;
-		profile->dirty = true;
-		profile->angle_snapping_dirty = true;
-	}
+ratbag_profile_set_angle_snapping(struct ratbag_profile *profile, int value) {
+  if (profile->angle_snapping != value) {
+    profile->angle_snapping = value;
+    profile->dirty = true;
+    profile->angle_snapping_dirty = true;
+  }
 
-	return RATBAG_SUCCESS;
+  return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_profile_set_motion_sync(struct ratbag_profile *profile,
-			       int value)
-{
-	if (profile->motion_sync != value) {
-		profile->motion_sync = value;
-		profile->dirty = true;
-		profile->motion_sync_dirty = true;
-	}
+ratbag_profile_set_motion_sync(struct ratbag_profile *profile, int value) {
+  if (profile->motion_sync != value) {
+    profile->motion_sync = value;
+    profile->dirty = true;
+    profile->motion_sync_dirty = true;
+  }
 
-	return RATBAG_SUCCESS;
+  return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_profile_set_ripple_control(struct ratbag_profile *profile,
-				  int value)
-{
-	if (profile->ripple_control != value) {
-		profile->ripple_control = value;
-		profile->dirty = true;
-		profile->ripple_control_dirty = true;
-	}
+ratbag_profile_set_ripple_control(struct ratbag_profile *profile, int value) {
+  if (profile->ripple_control != value) {
+    profile->ripple_control = value;
+    profile->dirty = true;
+    profile->ripple_control_dirty = true;
+  }
 
-	return RATBAG_SUCCESS;
+  return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_profile_set_debounce(struct ratbag_profile *profile,
-			    int value)
-{
-	if (profile->debounce != value) {
-		profile->debounce = value;
-		profile->dirty = true;
-		profile->debounce_dirty = true;
-	}
+ratbag_profile_set_debounce(struct ratbag_profile *profile, int value) {
+  if (profile->debounce != value) {
+    profile->debounce = value;
+    profile->dirty = true;
+    profile->debounce_dirty = true;
+  }
 
-	return RATBAG_SUCCESS;
+  return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT int
-ratbag_resolution_get_dpi(const struct ratbag_resolution *resolution)
-{
-	return resolution->dpi_x;
+ratbag_resolution_get_dpi(const struct ratbag_resolution *resolution) {
+  return resolution->dpi_x;
 }
 
 LIBRATBAG_EXPORT size_t
 ratbag_resolution_get_dpi_list(const struct ratbag_resolution *resolution,
-			       unsigned int *resolutions,
-			       size_t nres)
-{
-	_Static_assert(sizeof(*resolutions) == sizeof(*resolution->dpis), "type mismatch");
+                               unsigned int *resolutions, size_t nres) {
+  _Static_assert(sizeof(*resolutions) == sizeof(*resolution->dpis),
+                 "type mismatch");
 
-	assert(nres > 0);
+  assert(nres > 0);
 
-	if (resolution->ndpis == 0)
-		return 0;
+  if (resolution->ndpis == 0)
+    return 0;
 
-	memcpy(resolutions, resolution->dpis,
-	       sizeof(unsigned int) * min(nres, resolution->ndpis));
+  memcpy(resolutions, resolution->dpis,
+         sizeof(unsigned int) * min(nres, resolution->ndpis));
 
-	return resolution->ndpis;
+  return resolution->ndpis;
 }
 
 LIBRATBAG_EXPORT int
-ratbag_resolution_get_dpi_x(const struct ratbag_resolution *resolution)
-{
-	return resolution->dpi_x;
+ratbag_resolution_get_dpi_x(const struct ratbag_resolution *resolution) {
+  return resolution->dpi_x;
 }
 
 LIBRATBAG_EXPORT int
-ratbag_resolution_get_dpi_y(const struct ratbag_resolution *resolution)
-{
-	return resolution->dpi_y;
+ratbag_resolution_get_dpi_y(const struct ratbag_resolution *resolution) {
+  return resolution->dpi_y;
 }
 
 LIBRATBAG_EXPORT int
-ratbag_profile_get_report_rate(const struct ratbag_profile *profile)
-{
-	return profile->hz;
+ratbag_profile_get_report_rate(const struct ratbag_profile *profile) {
+  return profile->hz;
 }
 
 LIBRATBAG_EXPORT int
-ratbag_profile_get_angle_snapping(const struct ratbag_profile *profile)
-{
-	return profile->angle_snapping;
+ratbag_profile_get_angle_snapping(const struct ratbag_profile *profile) {
+  return profile->angle_snapping;
 }
 
 LIBRATBAG_EXPORT int
-ratbag_profile_get_motion_sync(const struct ratbag_profile *profile)
-{
-	return profile->motion_sync;
+ratbag_profile_get_motion_sync(const struct ratbag_profile *profile) {
+  return profile->motion_sync;
 }
 
 LIBRATBAG_EXPORT int
-ratbag_profile_get_ripple_control(const struct ratbag_profile *profile)
-{
-	return profile->ripple_control;
+ratbag_profile_get_ripple_control(const struct ratbag_profile *profile) {
+  return profile->ripple_control;
 }
 
 LIBRATBAG_EXPORT int
-ratbag_profile_get_debounce(const struct ratbag_profile *profile)
-{
-	return profile->debounce;
+ratbag_profile_get_debounce(const struct ratbag_profile *profile) {
+  return profile->debounce;
 }
 
 LIBRATBAG_EXPORT size_t
 ratbag_profile_get_debounce_list(const struct ratbag_profile *profile,
-				 unsigned int *debounces,
-				 size_t ndebounces)
-{
-	_Static_assert(sizeof(*debounces) == sizeof(*profile->debounces), "type mismatch");
+                                 unsigned int *debounces, size_t ndebounces) {
+  _Static_assert(sizeof(*debounces) == sizeof(*profile->debounces),
+                 "type mismatch");
 
-	assert(ndebounces > 0);
+  assert(ndebounces > 0);
 
-	if (profile->ndebounces == 0)
-		return 0;
+  if (profile->ndebounces == 0)
+    return 0;
 
-	memcpy(debounces, profile->debounces,
-	       sizeof(unsigned int) * min(ndebounces, profile->ndebounces));
+  memcpy(debounces, profile->debounces,
+         sizeof(unsigned int) * min(ndebounces, profile->ndebounces));
 
-	return profile->ndebounces;
+  return profile->ndebounces;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_profile_set_lod(struct ratbag_profile *profile,
-		       double value)
-{
-	if (profile->lod != value) {
-		profile->lod = value;
-		profile->dirty = true;
-		profile->lod_dirty = true;
-	}
+ratbag_profile_set_lod(struct ratbag_profile *profile, double value) {
+  if (profile->lod != value) {
+    profile->lod = value;
+    profile->dirty = true;
+    profile->lod_dirty = true;
+  }
 
-	return RATBAG_SUCCESS;
+  return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT double
-ratbag_profile_get_lod(const struct ratbag_profile *profile)
-{
-	return profile->lod;
+ratbag_profile_get_lod(const struct ratbag_profile *profile) {
+  return profile->lod;
 }
 
-LIBRATBAG_EXPORT size_t
-ratbag_profile_get_lod_list(const struct ratbag_profile *profile,
-			    double *lods,
-			    size_t nlods)
-{
-	_Static_assert(sizeof(*lods) == sizeof(*profile->lods), "type mismatch");
+LIBRATBAG_EXPORT size_t ratbag_profile_get_lod_list(
+    const struct ratbag_profile *profile, double *lods, size_t nlods) {
+  _Static_assert(sizeof(*lods) == sizeof(*profile->lods), "type mismatch");
 
-	assert(nlods > 0);
+  assert(nlods > 0);
 
-	if (profile->nlods == 0)
-		return 0;
+  if (profile->nlods == 0)
+    return 0;
 
-	memcpy(lods, profile->lods,
-	       sizeof(double) * min(nlods, profile->nlods));
+  memcpy(lods, profile->lods, sizeof(double) * min(nlods, profile->nlods));
 
-	return profile->nlods;
+  return profile->nlods;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_profile_set_autosleep(struct ratbag_profile *profile,
-			     int value)
-{
-	if (profile->autosleep != value) {
-		profile->autosleep = value;
-		profile->dirty = true;
-		profile->autosleep_dirty = true;
-	}
+ratbag_profile_set_autosleep(struct ratbag_profile *profile, int value) {
+  if (profile->autosleep != value) {
+    profile->autosleep = value;
+    profile->dirty = true;
+    profile->autosleep_dirty = true;
+  }
 
-	return RATBAG_SUCCESS;
+  return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT int
-ratbag_profile_get_autosleep(const struct ratbag_profile *profile)
-{
-	return profile->autosleep;
+ratbag_profile_get_autosleep(const struct ratbag_profile *profile) {
+  return profile->autosleep;
 }
 
-LIBRATBAG_EXPORT size_t
-ratbag_profile_get_autosleep_list(const struct ratbag_profile *profile,
-				  unsigned int *autosleeps,
-				  size_t nautosleeps)
-{
-	_Static_assert(sizeof(*autosleeps) == sizeof(*profile->autosleeps), "type mismatch");
+LIBRATBAG_EXPORT size_t ratbag_profile_get_autosleep_list(
+    const struct ratbag_profile *profile, unsigned int *autosleeps,
+    size_t nautosleeps) {
+  _Static_assert(sizeof(*autosleeps) == sizeof(*profile->autosleeps),
+                 "type mismatch");
 
-	assert(nautosleeps > 0);
+  assert(nautosleeps > 0);
 
-	if (profile->nautosleeps == 0)
-		return 0;
+  if (profile->nautosleeps == 0)
+    return 0;
 
-	memcpy(autosleeps, profile->autosleeps,
-	       sizeof(unsigned int) * min(nautosleeps, profile->nautosleeps));
+  memcpy(autosleeps, profile->autosleeps,
+         sizeof(unsigned int) * min(nautosleeps, profile->nautosleeps));
 
-	return profile->nautosleeps;
+  return profile->nautosleeps;
 }
 
-LIBRATBAG_EXPORT size_t
-ratbag_profile_get_report_rate_list(const struct ratbag_profile *profile,
-				    unsigned int *rates,
-				    size_t nrates)
-{
-	_Static_assert(sizeof(*rates) == sizeof(*profile->rates), "type mismatch");
+LIBRATBAG_EXPORT size_t ratbag_profile_get_report_rate_list(
+    const struct ratbag_profile *profile, unsigned int *rates, size_t nrates) {
+  _Static_assert(sizeof(*rates) == sizeof(*profile->rates), "type mismatch");
 
-	assert(nrates > 0);
+  assert(nrates > 0);
 
-	if (profile->nrates == 0)
-		return 0;
+  if (profile->nrates == 0)
+    return 0;
 
-	memcpy(rates, profile->rates,
-	       sizeof(unsigned int) * min(nrates, profile->nrates));
+  memcpy(rates, profile->rates,
+         sizeof(unsigned int) * min(nrates, profile->nrates));
 
-	return profile->nrates;
+  return profile->nrates;
 }
 
 LIBRATBAG_EXPORT bool
-ratbag_resolution_is_active(const struct ratbag_resolution *resolution)
-{
-	return !!resolution->is_active;
+ratbag_resolution_is_active(const struct ratbag_resolution *resolution) {
+  return !!resolution->is_active;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_resolution_set_active(struct ratbag_resolution *resolution)
-{
-	struct ratbag_profile *profile = resolution->profile;
-	struct ratbag_resolution *res;
+ratbag_resolution_set_active(struct ratbag_resolution *resolution) {
+  struct ratbag_profile *profile = resolution->profile;
+  struct ratbag_resolution *res;
 
-	if (resolution->is_disabled) {
-		log_error(profile->device->ratbag, "%s: setting the active resolution to a disabled resolution is not allowed\n", profile->device->name);
-		return RATBAG_ERROR_VALUE;
-	}
+  if (resolution->is_disabled) {
+    log_error(profile->device->ratbag,
+              "%s: setting the active resolution to a disabled resolution is "
+              "not allowed\n",
+              profile->device->name);
+    return RATBAG_ERROR_VALUE;
+  }
 
-	ratbag_profile_for_each_resolution(profile, res)
-		res->is_active = false;
+  ratbag_profile_for_each_resolution(profile, res) res->is_active = false;
 
-	resolution->is_active = true;
-	resolution->dirty = true;
-	profile->dirty = true;
-	return RATBAG_SUCCESS;
+  resolution->is_active = true;
+  resolution->dirty = true;
+  profile->dirty = true;
+  return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT bool
-ratbag_resolution_is_default(const struct ratbag_resolution *resolution)
-{
-	return !!resolution->is_default;
+ratbag_resolution_is_default(const struct ratbag_resolution *resolution) {
+  return !!resolution->is_default;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_resolution_set_default(struct ratbag_resolution *resolution)
-{
-	struct ratbag_profile *profile = resolution->profile;
-	struct ratbag_resolution *other;
+ratbag_resolution_set_default(struct ratbag_resolution *resolution) {
+  struct ratbag_profile *profile = resolution->profile;
+  struct ratbag_resolution *other;
 
-	if (resolution->is_disabled) {
-		log_error(profile->device->ratbag, "%s: setting the default resolution to a disabled resolution is not allowed\n", profile->device->name);
-		return RATBAG_ERROR_VALUE;
-	}
+  if (resolution->is_disabled) {
+    log_error(profile->device->ratbag,
+              "%s: setting the default resolution to a disabled resolution is "
+              "not allowed\n",
+              profile->device->name);
+    return RATBAG_ERROR_VALUE;
+  }
 
-	/* Unset the default on the other resolutions */
-	ratbag_profile_for_each_resolution(profile, other) {
-		if (other == resolution || !other->is_default)
-			continue;
+  /* Unset the default on the other resolutions */
+  ratbag_profile_for_each_resolution(profile, other) {
+    if (other == resolution || !other->is_default)
+      continue;
 
-		other->is_default = false;
-		resolution->dirty = true;
-		profile->dirty = true;
-	}
+    other->is_default = false;
+    resolution->dirty = true;
+    profile->dirty = true;
+  }
 
-	if (!resolution->is_default) {
-		resolution->is_default = true;
-		resolution->dirty = true;
-		profile->dirty = true;
-	}
+  if (!resolution->is_default) {
+    resolution->is_default = true;
+    resolution->dirty = true;
+    profile->dirty = true;
+  }
 
-	return RATBAG_SUCCESS;
+  return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT bool
-ratbag_resolution_is_disabled(const struct ratbag_resolution *resolution)
-{
-	return !!resolution->is_disabled;
+ratbag_resolution_is_disabled(const struct ratbag_resolution *resolution) {
+  return !!resolution->is_disabled;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_resolution_set_disabled(struct ratbag_resolution *resolution, bool disable)
-{
-	struct ratbag_profile *profile = resolution->profile;
+ratbag_resolution_set_disabled(struct ratbag_resolution *resolution,
+                               bool disable) {
+  struct ratbag_profile *profile = resolution->profile;
 
-	if (!ratbag_resolution_has_capability(resolution, RATBAG_RESOLUTION_CAP_DISABLE))
-		return RATBAG_ERROR_CAPABILITY;
+  if (!ratbag_resolution_has_capability(resolution,
+                                        RATBAG_RESOLUTION_CAP_DISABLE))
+    return RATBAG_ERROR_CAPABILITY;
 
-	if (disable) {
-		if (resolution->is_active) {
-			log_error(profile->device->ratbag, "%s: disabling the active resolution is not allowed\n", profile->device->name);
-			return RATBAG_ERROR_VALUE;
-		}
-		if (resolution->is_default) {
-			log_error(profile->device->ratbag, "%s: disabling the default resolution is not allowed\n", profile->device->name);
-			return RATBAG_ERROR_VALUE;
-		}
-	}
+  if (disable) {
+    if (resolution->is_active) {
+      log_error(profile->device->ratbag,
+                "%s: disabling the active resolution is not allowed\n",
+                profile->device->name);
+      return RATBAG_ERROR_VALUE;
+    }
+    if (resolution->is_default) {
+      log_error(profile->device->ratbag,
+                "%s: disabling the default resolution is not allowed\n",
+                profile->device->name);
+      return RATBAG_ERROR_VALUE;
+    }
+  }
 
-	resolution->is_disabled = disable;
-	resolution->dirty = true;
-	profile->dirty = true;
+  resolution->is_disabled = disable;
+  resolution->dirty = true;
+  profile->dirty = true;
 
-	return RATBAG_SUCCESS;
+  return RATBAG_SUCCESS;
 }
 
-LIBRATBAG_EXPORT struct ratbag_button*
-ratbag_profile_get_button(struct ratbag_profile *profile,
-				   unsigned int index)
-{
-	struct ratbag_device *device = profile->device;
-	struct ratbag_button *button;
+LIBRATBAG_EXPORT struct ratbag_button *
+ratbag_profile_get_button(struct ratbag_profile *profile, unsigned int index) {
+  struct ratbag_device *device = profile->device;
+  struct ratbag_button *button;
 
-	if (index >= ratbag_device_get_num_buttons(device)) {
-		log_bug_client(device->ratbag, "Requested invalid button %d\n", index);
-		return NULL;
-	}
+  if (index >= ratbag_device_get_num_buttons(device)) {
+    log_bug_client(device->ratbag, "Requested invalid button %d\n", index);
+    return NULL;
+  }
 
-	list_for_each(button, &profile->buttons, link) {
-		if (button->index == index)
-			return ratbag_button_ref(button);
-	}
+  list_for_each(button, &profile->buttons, link) {
+    if (button->index == index)
+      return ratbag_button_ref(button);
+  }
 
-	log_bug_libratbag(device->ratbag, "Button %d, profile %d not found\n",
-			  index, profile->index);
+  log_bug_libratbag(device->ratbag, "Button %d, profile %d not found\n", index,
+                    profile->index);
 
-	return NULL;
+  return NULL;
 }
 
 LIBRATBAG_EXPORT enum ratbag_button_action_type
-ratbag_button_get_action_type(const struct ratbag_button *button)
-{
-	return button->action.type;
+ratbag_button_get_action_type(const struct ratbag_button *button) {
+  return button->action.type;
 }
 
 LIBRATBAG_EXPORT bool
 ratbag_button_has_action_type(const struct ratbag_button *button,
-			      enum ratbag_button_action_type action_type)
-{
-	switch (action_type) {
-	case RATBAG_BUTTON_ACTION_TYPE_NONE:
-	case RATBAG_BUTTON_ACTION_TYPE_BUTTON:
-	case RATBAG_BUTTON_ACTION_TYPE_SPECIAL:
-	case RATBAG_BUTTON_ACTION_TYPE_KEY:
-	case RATBAG_BUTTON_ACTION_TYPE_MACRO:
-		break;
-	default:
-		return 0;
-	}
+                              enum ratbag_button_action_type action_type) {
+  switch (action_type) {
+  case RATBAG_BUTTON_ACTION_TYPE_NONE:
+  case RATBAG_BUTTON_ACTION_TYPE_BUTTON:
+  case RATBAG_BUTTON_ACTION_TYPE_SPECIAL:
+  case RATBAG_BUTTON_ACTION_TYPE_KEY:
+  case RATBAG_BUTTON_ACTION_TYPE_MACRO:
+    break;
+  default:
+    return 0;
+  }
 
-	return !!(button->action_caps & (1 << action_type));
+  return !!(button->action_caps & (1 << action_type));
 }
 
 LIBRATBAG_EXPORT unsigned int
-ratbag_button_get_button(const struct ratbag_button *button)
-{
-	if (button->action.type != RATBAG_BUTTON_ACTION_TYPE_BUTTON)
-		return 0;
+ratbag_button_get_button(const struct ratbag_button *button) {
+  if (button->action.type != RATBAG_BUTTON_ACTION_TYPE_BUTTON)
+    return 0;
 
-	return button->action.action.button;
+  return button->action.action.button;
 }
 
-void
-ratbag_button_set_action(struct ratbag_button *button,
-			 const struct ratbag_button_action *action)
-{
-	struct ratbag_macro *macro = button->action.macro;
+void ratbag_button_set_action(struct ratbag_button *button,
+                              const struct ratbag_button_action *action) {
+  struct ratbag_macro *macro = button->action.macro;
 
-	button->action = *action;
-	if (action->type != RATBAG_BUTTON_ACTION_TYPE_MACRO)
-		button->action.macro = macro;
+  button->action = *action;
+  if (action->type != RATBAG_BUTTON_ACTION_TYPE_MACRO)
+    button->action.macro = macro;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_button_set_button(struct ratbag_button *button, unsigned int btn)
-{
-	struct ratbag_button_action action = {0};
+ratbag_button_set_button(struct ratbag_button *button, unsigned int btn) {
+  struct ratbag_button_action action = {0};
 
-	if (!ratbag_button_has_action_type(button,
-					   RATBAG_BUTTON_ACTION_TYPE_BUTTON))
-		return RATBAG_ERROR_CAPABILITY;
+  if (!ratbag_button_has_action_type(button, RATBAG_BUTTON_ACTION_TYPE_BUTTON))
+    return RATBAG_ERROR_CAPABILITY;
 
-	action.type = RATBAG_BUTTON_ACTION_TYPE_BUTTON;
-	action.action.button = btn;
+  action.type = RATBAG_BUTTON_ACTION_TYPE_BUTTON;
+  action.action.button = btn;
 
-	ratbag_button_set_action(button, &action);
-	button->dirty = true;
-	button->profile->dirty = true;
+  ratbag_button_set_action(button, &action);
+  button->dirty = true;
+  button->profile->dirty = true;
 
-	return RATBAG_SUCCESS;
+  return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT enum ratbag_button_action_special
-ratbag_button_get_special(const struct ratbag_button *button)
-{
-	if (button->action.type != RATBAG_BUTTON_ACTION_TYPE_SPECIAL)
-		return RATBAG_BUTTON_ACTION_SPECIAL_INVALID;
+ratbag_button_get_special(const struct ratbag_button *button) {
+  if (button->action.type != RATBAG_BUTTON_ACTION_TYPE_SPECIAL)
+    return RATBAG_BUTTON_ACTION_SPECIAL_INVALID;
 
-	return button->action.action.special;
+  return button->action.action.special;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
 ratbag_button_set_special(struct ratbag_button *button,
-			  enum ratbag_button_action_special act)
-{
-	struct ratbag_button_action action = {0};
+                          enum ratbag_button_action_special act) {
+  struct ratbag_button_action action = {0};
 
-	/* FIXME: range checks */
+  /* FIXME: range checks */
 
-	if (!ratbag_button_has_action_type(button,
-					   RATBAG_BUTTON_ACTION_TYPE_SPECIAL))
-		return RATBAG_ERROR_CAPABILITY;
+  if (!ratbag_button_has_action_type(button, RATBAG_BUTTON_ACTION_TYPE_SPECIAL))
+    return RATBAG_ERROR_CAPABILITY;
 
-	action.type = RATBAG_BUTTON_ACTION_TYPE_SPECIAL;
-	action.action.special = act;
+  action.type = RATBAG_BUTTON_ACTION_TYPE_SPECIAL;
+  action.action.special = act;
 
-	ratbag_button_set_action(button, &action);
-	button->dirty = true;
-	button->profile->dirty = true;
+  ratbag_button_set_action(button, &action);
+  button->dirty = true;
+  button->profile->dirty = true;
 
-	return RATBAG_SUCCESS;
+  return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT unsigned int
-ratbag_button_get_key(const struct ratbag_button *button)
-{
-	if (button->action.type != RATBAG_BUTTON_ACTION_TYPE_KEY)
-		return 0;
+ratbag_button_get_key(const struct ratbag_button *button) {
+  if (button->action.type != RATBAG_BUTTON_ACTION_TYPE_KEY)
+    return 0;
 
-	return button->action.action.key;
+  return button->action.action.key;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_button_set_key(struct ratbag_button *button, unsigned int key)
-{
-	struct ratbag_button_action action = {0};
+ratbag_button_set_key(struct ratbag_button *button, unsigned int key) {
+  struct ratbag_button_action action = {0};
 
-	/* FIXME: range checks */
+  /* FIXME: range checks */
 
-	if (!ratbag_button_has_action_type(button,
-					   RATBAG_BUTTON_ACTION_TYPE_KEY))
-		return RATBAG_ERROR_CAPABILITY;
+  if (!ratbag_button_has_action_type(button, RATBAG_BUTTON_ACTION_TYPE_KEY))
+    return RATBAG_ERROR_CAPABILITY;
 
-	action.type = RATBAG_BUTTON_ACTION_TYPE_KEY;
-	action.action.key = key;
+  action.type = RATBAG_BUTTON_ACTION_TYPE_KEY;
+  action.action.key = key;
 
-	ratbag_button_set_action(button, &action);
-	button->dirty = true;
-	button->profile->dirty = true;
+  ratbag_button_set_action(button, &action);
+  button->dirty = true;
+  button->profile->dirty = true;
 
-	return RATBAG_SUCCESS;
+  return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_button_disable(struct ratbag_button *button)
-{
-	if (!ratbag_button_has_action_type(button,
-					   RATBAG_BUTTON_ACTION_TYPE_NONE))
-		return RATBAG_ERROR_CAPABILITY;
+ratbag_button_disable(struct ratbag_button *button) {
+  if (!ratbag_button_has_action_type(button, RATBAG_BUTTON_ACTION_TYPE_NONE))
+    return RATBAG_ERROR_CAPABILITY;
 
-	struct ratbag_button_action action = {0};
+  struct ratbag_button_action action = {0};
 
-	action.type = RATBAG_BUTTON_ACTION_TYPE_NONE;
+  action.type = RATBAG_BUTTON_ACTION_TYPE_NONE;
 
-	ratbag_button_set_action(button, &action);
-	button->dirty = true;
-	button->profile->dirty = true;
+  ratbag_button_set_action(button, &action);
+  button->dirty = true;
+  button->profile->dirty = true;
 
-	return RATBAG_SUCCESS;
+  return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT struct ratbag_button *
-ratbag_button_ref(struct ratbag_button *button)
-{
-	assert(button->refcount < INT_MAX);
+ratbag_button_ref(struct ratbag_button *button) {
+  assert(button->refcount < INT_MAX);
 
-	ratbag_profile_ref(button->profile);
-	button->refcount++;
-	return button;
+  ratbag_profile_ref(button->profile);
+  button->refcount++;
+  return button;
 }
 
-LIBRATBAG_EXPORT struct ratbag_led *
-ratbag_led_ref(struct ratbag_led *led)
-{
-	assert(led->refcount < INT_MAX);
+LIBRATBAG_EXPORT struct ratbag_led *ratbag_led_ref(struct ratbag_led *led) {
+  assert(led->refcount < INT_MAX);
 
-	ratbag_profile_ref(led->profile);
-	led->refcount++;
-	return led;
+  ratbag_profile_ref(led->profile);
+  led->refcount++;
+  return led;
 }
 
-static void
-ratbag_button_destroy(struct ratbag_button *button)
-{
-	list_remove(&button->link);
-	if (button->action.macro) {
-		free(button->action.macro->name);
-		free(button->action.macro->group);
-		free(button->action.macro);
-	}
-	free(button);
+static void ratbag_button_destroy(struct ratbag_button *button) {
+  list_remove(&button->link);
+  if (button->action.macro) {
+    free(button->action.macro->name);
+    free(button->action.macro->group);
+    free(button->action.macro);
+  }
+  free(button);
 }
 
-static void
-ratbag_led_destroy(struct ratbag_led *led)
-{
-	list_remove(&led->link);
-	free(led);
+static void ratbag_led_destroy(struct ratbag_led *led) {
+  list_remove(&led->link);
+  free(led);
 }
 
-static void
-ratbag_resolution_destroy(struct ratbag_resolution *res)
-{
-	list_remove(&res->link);
-	free(res);
+static void ratbag_resolution_destroy(struct ratbag_resolution *res) {
+  list_remove(&res->link);
+  free(res);
 }
 
 LIBRATBAG_EXPORT struct ratbag_button *
-ratbag_button_unref(struct ratbag_button *button)
-{
-	if (button == NULL)
-		return NULL;
+ratbag_button_unref(struct ratbag_button *button) {
+  if (button == NULL)
+    return NULL;
 
-	assert(button->refcount > 0);
-	button->refcount--;
+  assert(button->refcount > 0);
+  button->refcount--;
 
-	ratbag_profile_unref(button->profile);
+  ratbag_profile_unref(button->profile);
 
-	return NULL;
+  return NULL;
 }
 
-LIBRATBAG_EXPORT struct ratbag_led *
-ratbag_led_unref(struct ratbag_led *led)
-{
-	if (led == NULL)
-		return NULL;
+LIBRATBAG_EXPORT struct ratbag_led *ratbag_led_unref(struct ratbag_led *led) {
+  if (led == NULL)
+    return NULL;
 
-	assert(led->refcount > 0);
-	led->refcount--;
+  assert(led->refcount > 0);
+  led->refcount--;
 
-	ratbag_profile_unref(led->profile);
+  ratbag_profile_unref(led->profile);
 
-	return NULL;
+  return NULL;
 }
 
 LIBRATBAG_EXPORT enum ratbag_led_mode
-ratbag_led_get_mode(const struct ratbag_led *led)
-{
-	return led->mode;
+ratbag_led_get_mode(const struct ratbag_led *led) {
+  return led->mode;
 }
 
-LIBRATBAG_EXPORT bool
-ratbag_led_has_mode(const struct ratbag_led *led,
-		    enum ratbag_led_mode mode)
-{
-	assert(mode <= RATBAG_LED_BREATHING);
+LIBRATBAG_EXPORT bool ratbag_led_has_mode(const struct ratbag_led *led,
+                                          enum ratbag_led_mode mode) {
+  assert(mode <= RATBAG_LED_BREATHING);
 
-	if (mode == RATBAG_LED_OFF)
-		return 1;
+  if (mode == RATBAG_LED_OFF)
+    return 1;
 
-	return !!(led->modes & (1 << mode));
+  return !!(led->modes & (1 << mode));
 }
 
 LIBRATBAG_EXPORT struct ratbag_color
-ratbag_led_get_color(const struct ratbag_led *led)
-{
-	return led->color;
+ratbag_led_get_color(const struct ratbag_led *led) {
+  return led->color;
 }
 
 LIBRATBAG_EXPORT int
-ratbag_led_get_effect_duration(const struct ratbag_led *led)
-{
-	return led->ms;
+ratbag_led_get_effect_duration(const struct ratbag_led *led) {
+  return led->ms;
 }
 
 LIBRATBAG_EXPORT unsigned int
-ratbag_led_get_brightness(const struct ratbag_led *led)
-{
-	return led->brightness;
+ratbag_led_get_brightness(const struct ratbag_led *led) {
+  return led->brightness;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_led_set_mode(struct ratbag_led *led, enum ratbag_led_mode mode)
-{
-	led->mode = mode;
-	led->dirty = true;
-	led->profile->dirty = true;
-	return RATBAG_SUCCESS;
+ratbag_led_set_mode(struct ratbag_led *led, enum ratbag_led_mode mode) {
+  led->mode = mode;
+  led->dirty = true;
+  led->profile->dirty = true;
+  return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_led_set_color(struct ratbag_led *led, struct ratbag_color color)
-{
-	led->color = color;
-	led->dirty = true;
-	led->profile->dirty = true;
-	return RATBAG_SUCCESS;
+ratbag_led_set_color(struct ratbag_led *led, struct ratbag_color color) {
+  led->color = color;
+  led->dirty = true;
+  led->profile->dirty = true;
+  return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT enum ratbag_led_colordepth
-ratbag_led_get_colordepth(const struct ratbag_led *led)
-{
-	return led->colordepth;
+ratbag_led_get_colordepth(const struct ratbag_led *led) {
+  return led->colordepth;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_led_set_effect_duration(struct ratbag_led *led, unsigned int ms)
-{
-	led->ms = ms;
-	led->dirty = true;
-	led->profile->dirty = true;
-	return RATBAG_SUCCESS;
+ratbag_led_set_effect_duration(struct ratbag_led *led, unsigned int ms) {
+  led->ms = ms;
+  led->dirty = true;
+  led->profile->dirty = true;
+  return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_led_set_brightness(struct ratbag_led *led, unsigned int brightness)
-{
-	led->brightness = brightness;
-	led->dirty = true;
-	led->profile->dirty = true;
-	return RATBAG_SUCCESS;
+ratbag_led_set_brightness(struct ratbag_led *led, unsigned int brightness) {
+  led->brightness = brightness;
+  led->dirty = true;
+  led->profile->dirty = true;
+  return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT struct ratbag_led *
-ratbag_profile_get_led(struct ratbag_profile *profile,
-		       unsigned int index)
-{
-	struct ratbag_device *device = profile->device;
-	struct ratbag_led *led;
+ratbag_profile_get_led(struct ratbag_profile *profile, unsigned int index) {
+  struct ratbag_device *device = profile->device;
+  struct ratbag_led *led;
 
-	if (index >= ratbag_device_get_num_leds(device)) {
-		log_bug_client(device->ratbag, "Requested invalid led %d\n", index);
-		return NULL;
-	}
+  if (index >= ratbag_device_get_num_leds(device)) {
+    log_bug_client(device->ratbag, "Requested invalid led %d\n", index);
+    return NULL;
+  }
 
-	list_for_each(led, &profile->leds, link) {
-		if (led->index == index)
-			return ratbag_led_ref(led);
-	}
+  list_for_each(led, &profile->leds, link) {
+    if (led->index == index)
+      return ratbag_led_ref(led);
+  }
 
-	log_bug_libratbag(device->ratbag, "Led %d, profile %d not found\n",
-			  index, profile->index);
+  log_bug_libratbag(device->ratbag, "Led %d, profile %d not found\n", index,
+                    profile->index);
 
-	return NULL;
+  return NULL;
 }
 
 LIBRATBAG_EXPORT const char *
-ratbag_profile_get_name(const struct ratbag_profile *profile)
-{
-	return profile->name;
+ratbag_profile_get_name(const struct ratbag_profile *profile) {
+  return profile->name;
 }
 
-LIBRATBAG_EXPORT int
-ratbag_profile_set_name(struct ratbag_profile *profile,
-			const char *name)
-{
-	char *name_copy;
+LIBRATBAG_EXPORT int ratbag_profile_set_name(struct ratbag_profile *profile,
+                                             const char *name) {
+  char *name_copy;
 
-	if (!profile->name)
-		return RATBAG_ERROR_CAPABILITY;
+  if (!profile->name)
+    return RATBAG_ERROR_CAPABILITY;
 
-	name_copy = strdup_safe(name);
-	if (profile->name)
-		free(profile->name);
+  name_copy = strdup_safe(name);
+  if (profile->name)
+    free(profile->name);
 
-	profile->name = name_copy;
-	profile->dirty = true;
+  profile->name = name_copy;
+  profile->dirty = true;
 
-	return 0;
+  return 0;
 }
 
-LIBRATBAG_EXPORT void
-ratbag_set_user_data(struct ratbag *ratbag, void *userdata)
-{
-	ratbag->userdata = userdata;
+LIBRATBAG_EXPORT void ratbag_set_user_data(struct ratbag *ratbag,
+                                           void *userdata) {
+  ratbag->userdata = userdata;
 }
 
 LIBRATBAG_EXPORT void
-ratbag_device_set_user_data(struct ratbag_device *ratbag_device, void *userdata)
-{
-	ratbag_device->userdata = userdata;
+ratbag_device_set_user_data(struct ratbag_device *ratbag_device,
+                            void *userdata) {
+  ratbag_device->userdata = userdata;
 }
 
 LIBRATBAG_EXPORT void
-ratbag_profile_set_user_data(struct ratbag_profile *ratbag_profile, void *userdata)
-{
-	ratbag_profile->userdata = userdata;
+ratbag_profile_set_user_data(struct ratbag_profile *ratbag_profile,
+                             void *userdata) {
+  ratbag_profile->userdata = userdata;
 }
 
 LIBRATBAG_EXPORT void
-ratbag_button_set_user_data(struct ratbag_button *ratbag_button, void *userdata)
-{
-	ratbag_button->userdata = userdata;
+ratbag_button_set_user_data(struct ratbag_button *ratbag_button,
+                            void *userdata) {
+  ratbag_button->userdata = userdata;
 }
 
 LIBRATBAG_EXPORT void
-ratbag_resolution_set_user_data(struct ratbag_resolution *ratbag_resolution, void *userdata)
-{
-	ratbag_resolution->userdata = userdata;
+ratbag_resolution_set_user_data(struct ratbag_resolution *ratbag_resolution,
+                                void *userdata) {
+  ratbag_resolution->userdata = userdata;
 }
 
-LIBRATBAG_EXPORT void*
-ratbag_get_user_data(const struct ratbag *ratbag)
-{
-	return ratbag->userdata;
+LIBRATBAG_EXPORT void *ratbag_get_user_data(const struct ratbag *ratbag) {
+  return ratbag->userdata;
 }
 
-LIBRATBAG_EXPORT void*
-ratbag_device_get_user_data(const struct ratbag_device *ratbag_device)
-{
-	return ratbag_device->userdata;
+LIBRATBAG_EXPORT void *
+ratbag_device_get_user_data(const struct ratbag_device *ratbag_device) {
+  return ratbag_device->userdata;
 }
 
-LIBRATBAG_EXPORT const char*
-ratbag_device_get_firmware_version(const struct ratbag_device *ratbag_device)
-{
-	return ratbag_device->firmware_version;
+LIBRATBAG_EXPORT const char *
+ratbag_device_get_firmware_version(const struct ratbag_device *ratbag_device) {
+  return ratbag_device->firmware_version;
 }
 
 LIBRATBAG_EXPORT void
-ratbag_device_set_firmware_version(struct ratbag_device *device, const char* fw)
-{
-	free(device->firmware_version);
-	device->firmware_version = strdup_safe(fw);
+ratbag_device_set_firmware_version(struct ratbag_device *device,
+                                   const char *fw) {
+  free(device->firmware_version);
+  device->firmware_version = strdup_safe(fw);
 }
 
-LIBRATBAG_EXPORT void*
-ratbag_profile_get_user_data(const struct ratbag_profile *ratbag_profile)
-{
-	return ratbag_profile->userdata;
+LIBRATBAG_EXPORT void *
+ratbag_profile_get_user_data(const struct ratbag_profile *ratbag_profile) {
+  return ratbag_profile->userdata;
 }
 
-LIBRATBAG_EXPORT void*
-ratbag_button_get_user_data(const struct ratbag_button *ratbag_button)
-{
-	return ratbag_button->userdata;
+LIBRATBAG_EXPORT void *
+ratbag_button_get_user_data(const struct ratbag_button *ratbag_button) {
+  return ratbag_button->userdata;
 }
 
-LIBRATBAG_EXPORT void*
-ratbag_resolution_get_user_data(const struct ratbag_resolution *ratbag_resolution)
-{
-	return ratbag_resolution->userdata;
+LIBRATBAG_EXPORT void *ratbag_resolution_get_user_data(
+    const struct ratbag_resolution *ratbag_resolution) {
+  return ratbag_resolution->userdata;
 }
 
 LIBRATBAG_EXPORT struct ratbag_button_macro *
-ratbag_button_get_macro(struct ratbag_button *button)
-{
-	struct ratbag_button_macro *macro;
+ratbag_button_get_macro(struct ratbag_button *button) {
+  struct ratbag_button_macro *macro;
 
-	if (button->action.type != RATBAG_BUTTON_ACTION_TYPE_MACRO)
-		return NULL;
+  if (button->action.type != RATBAG_BUTTON_ACTION_TYPE_MACRO)
+    return NULL;
 
-	macro = ratbag_button_macro_new(button->action.macro->name);
-	memcpy(macro->macro.events,
-	       button->action.macro->events,
-	       sizeof(macro->macro.events));
+  macro = ratbag_button_macro_new(button->action.macro->name);
+  memcpy(macro->macro.events, button->action.macro->events,
+         sizeof(macro->macro.events));
 
-	return macro;
+  return macro;
 }
 
-void
-ratbag_button_copy_macro(struct ratbag_button *button,
-			 const struct ratbag_button_macro *macro)
-{
-	if (!button->action.macro)
-		button->action.macro = zalloc(sizeof(struct ratbag_macro));
-	else {
-		free(button->action.macro->name);
-		free(button->action.macro->group);
-		memset(button->action.macro, 0, sizeof(struct ratbag_macro));
-	}
+void ratbag_button_copy_macro(struct ratbag_button *button,
+                              const struct ratbag_button_macro *macro) {
+  if (!button->action.macro)
+    button->action.macro = zalloc(sizeof(struct ratbag_macro));
+  else {
+    free(button->action.macro->name);
+    free(button->action.macro->group);
+    memset(button->action.macro, 0, sizeof(struct ratbag_macro));
+  }
 
-	button->action.type = RATBAG_BUTTON_ACTION_TYPE_MACRO;
-	memcpy(button->action.macro->events,
-	       macro->macro.events,
-	       sizeof(macro->macro.events));
-	button->action.macro->name = strdup_safe(macro->macro.name);
-	button->action.macro->group = strdup_safe(macro->macro.group);
+  button->action.type = RATBAG_BUTTON_ACTION_TYPE_MACRO;
+  memcpy(button->action.macro->events, macro->macro.events,
+         sizeof(macro->macro.events));
+  button->action.macro->name = strdup_safe(macro->macro.name);
+  button->action.macro->group = strdup_safe(macro->macro.group);
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
 ratbag_button_set_macro(struct ratbag_button *button,
-			const struct ratbag_button_macro *macro)
-{
-	if (!ratbag_button_has_action_type(button,
-					   RATBAG_BUTTON_ACTION_TYPE_MACRO))
-		return RATBAG_ERROR_CAPABILITY;
+                        const struct ratbag_button_macro *macro) {
+  if (!ratbag_button_has_action_type(button, RATBAG_BUTTON_ACTION_TYPE_MACRO))
+    return RATBAG_ERROR_CAPABILITY;
 
-	ratbag_button_copy_macro(button, macro);
-	button->dirty = true;
-	button->profile->dirty = true;
+  ratbag_button_copy_macro(button, macro);
+  button->dirty = true;
+  button->profile->dirty = true;
 
-	return RATBAG_SUCCESS;
+  return RATBAG_SUCCESS;
 }
 
 LIBRATBAG_EXPORT enum ratbag_error_code
-ratbag_button_macro_set_event(struct ratbag_button_macro *m,
-			      unsigned int index,
-			      enum ratbag_macro_event_type type,
-			      unsigned int data)
-{
-	struct ratbag_macro *macro = &m->macro;
+ratbag_button_macro_set_event(struct ratbag_button_macro *m, unsigned int index,
+                              enum ratbag_macro_event_type type,
+                              unsigned int data) {
+  struct ratbag_macro *macro = &m->macro;
 
-	if (index >= MAX_MACRO_EVENTS)
-		return RATBAG_ERROR_VALUE;
+  if (index >= MAX_MACRO_EVENTS)
+    return RATBAG_ERROR_VALUE;
 
-	switch (type) {
-	case RATBAG_MACRO_EVENT_KEY_PRESSED:
-	case RATBAG_MACRO_EVENT_KEY_RELEASED:
-		macro->events[index].type = type;
-		macro->events[index].event.key = data;
-		break;
-	case RATBAG_MACRO_EVENT_WAIT:
-		macro->events[index].type = type;
-		macro->events[index].event.timeout = data;
-		break;
-	case RATBAG_MACRO_EVENT_NONE:
-		macro->events[index].type = type;
-		break;
-	default:
-		return RATBAG_ERROR_VALUE;
-	}
+  switch (type) {
+  case RATBAG_MACRO_EVENT_KEY_PRESSED:
+  case RATBAG_MACRO_EVENT_KEY_RELEASED:
+    macro->events[index].type = type;
+    macro->events[index].event.key = data;
+    break;
+  case RATBAG_MACRO_EVENT_WAIT:
+    macro->events[index].type = type;
+    macro->events[index].event.timeout = data;
+    break;
+  case RATBAG_MACRO_EVENT_NONE:
+    macro->events[index].type = type;
+    break;
+  default:
+    return RATBAG_ERROR_VALUE;
+  }
 
-	return 0;
+  return 0;
 }
 
 LIBRATBAG_EXPORT enum ratbag_macro_event_type
 ratbag_button_macro_get_event_type(const struct ratbag_button_macro *macro,
-				   unsigned int index)
-{
-	if (index >= MAX_MACRO_EVENTS)
-		return RATBAG_MACRO_EVENT_INVALID;
+                                   unsigned int index) {
+  if (index >= MAX_MACRO_EVENTS)
+    return RATBAG_MACRO_EVENT_INVALID;
 
-	return macro->macro.events[index].type;
+  return macro->macro.events[index].type;
 }
 
 LIBRATBAG_EXPORT int
 ratbag_button_macro_get_event_key(const struct ratbag_button_macro *m,
-				  unsigned int index)
-{
-	const struct ratbag_macro *macro = &m->macro;
+                                  unsigned int index) {
+  const struct ratbag_macro *macro = &m->macro;
 
-	if (index >= MAX_MACRO_EVENTS)
-		return 0;
+  if (index >= MAX_MACRO_EVENTS)
+    return 0;
 
-	if (macro->events[index].type != RATBAG_MACRO_EVENT_KEY_PRESSED &&
-	    macro->events[index].type != RATBAG_MACRO_EVENT_KEY_RELEASED)
-		return -EINVAL;
+  if (macro->events[index].type != RATBAG_MACRO_EVENT_KEY_PRESSED &&
+      macro->events[index].type != RATBAG_MACRO_EVENT_KEY_RELEASED)
+    return -EINVAL;
 
-	return macro->events[index].event.key;
+  return macro->events[index].event.key;
 }
 
 LIBRATBAG_EXPORT int
 ratbag_button_macro_get_event_timeout(const struct ratbag_button_macro *m,
-				      unsigned int index)
-{
-	const struct ratbag_macro *macro = &m->macro;
+                                      unsigned int index) {
+  const struct ratbag_macro *macro = &m->macro;
 
-	if (index >= MAX_MACRO_EVENTS)
-		return 0;
+  if (index >= MAX_MACRO_EVENTS)
+    return 0;
 
-	if (macro->events[index].type != RATBAG_MACRO_EVENT_WAIT)
-		return 0;
+  if (macro->events[index].type != RATBAG_MACRO_EVENT_WAIT)
+    return 0;
 
-	return macro->events[index].event.timeout;
+  return macro->events[index].event.timeout;
 }
 
 LIBRATBAG_EXPORT unsigned int
-ratbag_button_macro_get_num_events(const struct ratbag_button_macro *macro)
-{
-	return MAX_MACRO_EVENTS;
+ratbag_button_macro_get_num_events(const struct ratbag_button_macro *macro) {
+  return MAX_MACRO_EVENTS;
 }
 
 LIBRATBAG_EXPORT const char *
-ratbag_button_macro_get_name(const struct ratbag_button_macro *macro)
-{
-	return macro->macro.name;
+ratbag_button_macro_get_name(const struct ratbag_button_macro *macro) {
+  return macro->macro.name;
 }
 
-static void
-ratbag_button_macro_destroy(struct ratbag_button_macro *macro)
-{
-	assert(macro->refcount == 0);
-	free(macro->macro.name);
-	free(macro->macro.group);
-	free(macro);
+static void ratbag_button_macro_destroy(struct ratbag_button_macro *macro) {
+  assert(macro->refcount == 0);
+  free(macro->macro.name);
+  free(macro->macro.group);
+  free(macro);
 }
 
 LIBRATBAG_EXPORT struct ratbag_button_macro *
-ratbag_button_macro_ref(struct ratbag_button_macro *macro)
-{
-	assert(macro->refcount < INT_MAX);
+ratbag_button_macro_ref(struct ratbag_button_macro *macro) {
+  assert(macro->refcount < INT_MAX);
 
-	macro->refcount++;
-	return macro;
+  macro->refcount++;
+  return macro;
 }
 
 LIBRATBAG_EXPORT struct ratbag_button_macro *
-ratbag_button_macro_unref(struct ratbag_button_macro *macro)
-{
-	if (macro == NULL)
-		return NULL;
+ratbag_button_macro_unref(struct ratbag_button_macro *macro) {
+  if (macro == NULL)
+    return NULL;
 
-	assert(macro->refcount > 0);
-	macro->refcount--;
-	if (macro->refcount == 0)
-		ratbag_button_macro_destroy(macro);
+  assert(macro->refcount > 0);
+  macro->refcount--;
+  if (macro->refcount == 0)
+    ratbag_button_macro_destroy(macro);
 
-	return NULL;
+  return NULL;
 }
 
 LIBRATBAG_EXPORT struct ratbag_button_macro *
-ratbag_button_macro_new(const char *name)
-{
-	struct ratbag_button_macro *macro;
+ratbag_button_macro_new(const char *name) {
+  struct ratbag_button_macro *macro;
 
-	macro = zalloc(sizeof *macro);
-	macro->refcount = 1;
-	macro->macro.name = strdup_safe(name);
+  macro = zalloc(sizeof *macro);
+  macro->refcount = 1;
+  macro->macro.name = strdup_safe(name);
 
-	return macro;
+  return macro;
 }
 
 struct ratbag_modifier_mapping {
-	unsigned int modifier_mask;
-	unsigned int key;
+  unsigned int modifier_mask;
+  unsigned int key;
 };
 
 struct ratbag_modifier_mapping ratbag_modifier_mapping[] = {
-	{ MODIFIER_LEFTCTRL, KEY_LEFTCTRL },
-	{ MODIFIER_LEFTSHIFT, KEY_LEFTSHIFT },
-	{ MODIFIER_LEFTALT, KEY_LEFTALT },
-	{ MODIFIER_LEFTMETA, KEY_LEFTMETA },
-	{ MODIFIER_RIGHTCTRL, KEY_RIGHTCTRL },
-	{ MODIFIER_RIGHTSHIFT, KEY_RIGHTSHIFT },
-	{ MODIFIER_RIGHTALT, KEY_RIGHTALT },
-	{ MODIFIER_RIGHTMETA, KEY_RIGHTMETA },
+    {MODIFIER_LEFTCTRL, KEY_LEFTCTRL},   {MODIFIER_LEFTSHIFT, KEY_LEFTSHIFT},
+    {MODIFIER_LEFTALT, KEY_LEFTALT},     {MODIFIER_LEFTMETA, KEY_LEFTMETA},
+    {MODIFIER_RIGHTCTRL, KEY_RIGHTCTRL}, {MODIFIER_RIGHTSHIFT, KEY_RIGHTSHIFT},
+    {MODIFIER_RIGHTALT, KEY_RIGHTALT},   {MODIFIER_RIGHTMETA, KEY_RIGHTMETA},
 };
 
-int
-ratbag_button_macro_new_from_keycode(struct ratbag_button *button,
-				     unsigned int key,
-				     unsigned int modifiers)
-{
-	struct ratbag_button_macro *macro;
-	struct ratbag_modifier_mapping *mapping;
-	int i;
+int ratbag_button_macro_new_from_keycode(struct ratbag_button *button,
+                                         unsigned int key,
+                                         unsigned int modifiers) {
+  struct ratbag_button_macro *macro;
+  struct ratbag_modifier_mapping *mapping;
+  int i;
 
-	macro = ratbag_button_macro_new("key");
-	i = 0;
+  macro = ratbag_button_macro_new("key");
+  i = 0;
 
-	ARRAY_FOR_EACH(ratbag_modifier_mapping, mapping) {
-		if (modifiers & mapping->modifier_mask)
-			ratbag_button_macro_set_event(macro,
-						      i++,
-						      RATBAG_MACRO_EVENT_KEY_PRESSED,
-						      mapping->key);
-	}
+  ARRAY_FOR_EACH(ratbag_modifier_mapping, mapping) {
+    if (modifiers & mapping->modifier_mask)
+      ratbag_button_macro_set_event(macro, i++, RATBAG_MACRO_EVENT_KEY_PRESSED,
+                                    mapping->key);
+  }
 
-	ratbag_button_macro_set_event(macro,
-				      i++,
-				      RATBAG_MACRO_EVENT_KEY_PRESSED,
-				      key);
-	ratbag_button_macro_set_event(macro,
-				      i++,
-				      RATBAG_MACRO_EVENT_KEY_RELEASED,
-				      key);
+  ratbag_button_macro_set_event(macro, i++, RATBAG_MACRO_EVENT_KEY_PRESSED,
+                                key);
+  ratbag_button_macro_set_event(macro, i++, RATBAG_MACRO_EVENT_KEY_RELEASED,
+                                key);
 
-	ARRAY_FOR_EACH(ratbag_modifier_mapping, mapping) {
-		if (modifiers & mapping->modifier_mask)
-			ratbag_button_macro_set_event(macro,
-						      i++,
-						      RATBAG_MACRO_EVENT_KEY_RELEASED,
-						      mapping->key);
-	}
+  ARRAY_FOR_EACH(ratbag_modifier_mapping, mapping) {
+    if (modifiers & mapping->modifier_mask)
+      ratbag_button_macro_set_event(macro, i++, RATBAG_MACRO_EVENT_KEY_RELEASED,
+                                    mapping->key);
+  }
 
-	ratbag_button_copy_macro(button, macro);
-	ratbag_button_macro_unref(macro);
+  ratbag_button_copy_macro(button, macro);
+  ratbag_button_macro_unref(macro);
 
-	return 0;
+  return 0;
 }
 
-int
-ratbag_action_macro_num_keys(const struct ratbag_button_action *action)
-{
-	const struct ratbag_macro *macro = action->macro;
-	int count = 0;
-	for (int i = 0; i < MAX_MACRO_EVENTS; i++) {
-		struct ratbag_macro_event event = macro->events[i];
-		if (event.type == RATBAG_MACRO_EVENT_NONE ||
-		    event.type == RATBAG_MACRO_EVENT_INVALID) {
-			break;
-		}
-		if (ratbag_key_is_modifier(event.event.key)) {
-			continue;
-		}
-		if (event.type == RATBAG_MACRO_EVENT_KEY_PRESSED) {
-			count += 1;
-		}
-	}
-	return count;
+int ratbag_action_macro_num_keys(const struct ratbag_button_action *action) {
+  const struct ratbag_macro *macro = action->macro;
+  int count = 0;
+  for (int i = 0; i < MAX_MACRO_EVENTS; i++) {
+    struct ratbag_macro_event event = macro->events[i];
+    if (event.type == RATBAG_MACRO_EVENT_NONE ||
+        event.type == RATBAG_MACRO_EVENT_INVALID) {
+      break;
+    }
+    if (ratbag_key_is_modifier(event.event.key)) {
+      continue;
+    }
+    if (event.type == RATBAG_MACRO_EVENT_KEY_PRESSED) {
+      count += 1;
+    }
+  }
+  return count;
 }
 
-int
-ratbag_action_keycode_from_macro(const struct ratbag_button_action *action,
-				 unsigned int *key_out,
-				 unsigned int *modifiers_out)
-{
-	const struct ratbag_macro *macro = action->macro;
-	unsigned int key = KEY_RESERVED;
-	unsigned int modifiers = 0;
-	unsigned int i;
+int ratbag_action_keycode_from_macro(const struct ratbag_button_action *action,
+                                     unsigned int *key_out,
+                                     unsigned int *modifiers_out) {
+  const struct ratbag_macro *macro = action->macro;
+  unsigned int key = KEY_RESERVED;
+  unsigned int modifiers = 0;
+  unsigned int i;
 
-	if (!macro || action->type != RATBAG_BUTTON_ACTION_TYPE_MACRO)
-		return -EINVAL;
+  if (!macro || action->type != RATBAG_BUTTON_ACTION_TYPE_MACRO)
+    return -EINVAL;
 
-	if (macro->events[0].type == RATBAG_MACRO_EVENT_NONE)
-		return -EINVAL;
+  if (macro->events[0].type == RATBAG_MACRO_EVENT_NONE)
+    return -EINVAL;
 
-	if (ratbag_action_macro_num_keys(action) != 1)
-		return -EINVAL;
+  if (ratbag_action_macro_num_keys(action) != 1)
+    return -EINVAL;
 
-	for (i = 0; i < MAX_MACRO_EVENTS; i++) {
-		struct ratbag_macro_event event;
+  for (i = 0; i < MAX_MACRO_EVENTS; i++) {
+    struct ratbag_macro_event event;
 
-		event = macro->events[i];
-		switch (event.type) {
-		case RATBAG_MACRO_EVENT_INVALID:
-			return -EINVAL;
-		case RATBAG_MACRO_EVENT_NONE:
-			return 0;
-		case RATBAG_MACRO_EVENT_KEY_PRESSED:
-			switch(event.event.key) {
-			case KEY_LEFTCTRL: modifiers |= MODIFIER_LEFTCTRL; break;
-			case KEY_LEFTSHIFT: modifiers |= MODIFIER_LEFTSHIFT; break;
-			case KEY_LEFTALT: modifiers |= MODIFIER_LEFTALT; break;
-			case KEY_LEFTMETA: modifiers |= MODIFIER_LEFTMETA; break;
-			case KEY_RIGHTCTRL: modifiers |= MODIFIER_RIGHTCTRL; break;
-			case KEY_RIGHTSHIFT: modifiers |= MODIFIER_RIGHTSHIFT; break;
-			case KEY_RIGHTALT: modifiers |= MODIFIER_RIGHTALT; break;
-			case KEY_RIGHTMETA: modifiers |= MODIFIER_RIGHTMETA; break;
-			default:
-				if (key != KEY_RESERVED)
-					return -EINVAL;
+    event = macro->events[i];
+    switch (event.type) {
+    case RATBAG_MACRO_EVENT_INVALID:
+      return -EINVAL;
+    case RATBAG_MACRO_EVENT_NONE:
+      return 0;
+    case RATBAG_MACRO_EVENT_KEY_PRESSED:
+      switch (event.event.key) {
+      case KEY_LEFTCTRL:
+        modifiers |= MODIFIER_LEFTCTRL;
+        break;
+      case KEY_LEFTSHIFT:
+        modifiers |= MODIFIER_LEFTSHIFT;
+        break;
+      case KEY_LEFTALT:
+        modifiers |= MODIFIER_LEFTALT;
+        break;
+      case KEY_LEFTMETA:
+        modifiers |= MODIFIER_LEFTMETA;
+        break;
+      case KEY_RIGHTCTRL:
+        modifiers |= MODIFIER_RIGHTCTRL;
+        break;
+      case KEY_RIGHTSHIFT:
+        modifiers |= MODIFIER_RIGHTSHIFT;
+        break;
+      case KEY_RIGHTALT:
+        modifiers |= MODIFIER_RIGHTALT;
+        break;
+      case KEY_RIGHTMETA:
+        modifiers |= MODIFIER_RIGHTMETA;
+        break;
+      default:
+        if (key != KEY_RESERVED)
+          return -EINVAL;
 
-				key = event.event.key;
-			}
-			break;
-		case RATBAG_MACRO_EVENT_KEY_RELEASED:
-			switch(event.event.key) {
-			case KEY_LEFTCTRL: modifiers &= ~MODIFIER_LEFTCTRL; break;
-			case KEY_LEFTSHIFT: modifiers &= ~MODIFIER_LEFTSHIFT; break;
-			case KEY_LEFTALT: modifiers &= ~MODIFIER_LEFTALT; break;
-			case KEY_LEFTMETA: modifiers &= ~MODIFIER_LEFTMETA; break;
-			case KEY_RIGHTCTRL: modifiers &= ~MODIFIER_RIGHTCTRL; break;
-			case KEY_RIGHTSHIFT: modifiers &= ~MODIFIER_RIGHTSHIFT; break;
-			case KEY_RIGHTALT: modifiers &= ~MODIFIER_RIGHTALT; break;
-			case KEY_RIGHTMETA: modifiers &= ~MODIFIER_RIGHTMETA; break;
-			default:
-				if (event.event.key != key)
-					return -EINVAL;
+        key = event.event.key;
+      }
+      break;
+    case RATBAG_MACRO_EVENT_KEY_RELEASED:
+      switch (event.event.key) {
+      case KEY_LEFTCTRL:
+        modifiers &= ~MODIFIER_LEFTCTRL;
+        break;
+      case KEY_LEFTSHIFT:
+        modifiers &= ~MODIFIER_LEFTSHIFT;
+        break;
+      case KEY_LEFTALT:
+        modifiers &= ~MODIFIER_LEFTALT;
+        break;
+      case KEY_LEFTMETA:
+        modifiers &= ~MODIFIER_LEFTMETA;
+        break;
+      case KEY_RIGHTCTRL:
+        modifiers &= ~MODIFIER_RIGHTCTRL;
+        break;
+      case KEY_RIGHTSHIFT:
+        modifiers &= ~MODIFIER_RIGHTSHIFT;
+        break;
+      case KEY_RIGHTALT:
+        modifiers &= ~MODIFIER_RIGHTALT;
+        break;
+      case KEY_RIGHTMETA:
+        modifiers &= ~MODIFIER_RIGHTMETA;
+        break;
+      default:
+        if (event.event.key != key)
+          return -EINVAL;
 
-				*key_out = key;
-				*modifiers_out = modifiers;
-				return 1;
-			}
-		case RATBAG_MACRO_EVENT_WAIT:
-			break;
-		default:
-			return -EINVAL;
-		}
-	}
+        *key_out = key;
+        *modifiers_out = modifiers;
+        return 1;
+      }
+    case RATBAG_MACRO_EVENT_WAIT:
+      break;
+    default:
+      return -EINVAL;
+    }
+  }
 
-	return -EINVAL;
+  return -EINVAL;
 }

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -687,6 +687,7 @@ ratbag_create_profile(struct ratbag_device *device,
 	profile->ripple_control = -1;
 	profile->debounce = -1;
 	profile->lod = -1;
+	profile->autosleep = -1;
 
 	list_append(&device->profiles, &profile->link);
 	list_init(&profile->buttons);
@@ -757,6 +758,7 @@ ratbag_profile_destroy(struct ratbag_profile *profile)
 
 	free(profile->name);
 	free(profile->lods);
+	free(profile->autosleeps);
 
 	list_remove(&profile->link);
 	free(profile);
@@ -872,6 +874,7 @@ ratbag_device_commit(struct ratbag_device *device)
 		profile->angle_snapping_dirty = false;
 		profile->debounce_dirty = false;
 		profile->lod_dirty = false;
+		profile->autosleep_dirty = false;
 		profile->rate_dirty = false;
 
 		list_for_each(button, &profile->buttons, link)
@@ -1228,6 +1231,43 @@ ratbag_profile_get_lod_list(const struct ratbag_profile *profile,
 	       sizeof(double) * min(nlods, profile->nlods));
 
 	return profile->nlods;
+}
+
+LIBRATBAG_EXPORT enum ratbag_error_code
+ratbag_profile_set_autosleep(struct ratbag_profile *profile,
+			     int value)
+{
+	if (profile->autosleep != value) {
+		profile->autosleep = value;
+		profile->dirty = true;
+		profile->autosleep_dirty = true;
+	}
+
+	return RATBAG_SUCCESS;
+}
+
+LIBRATBAG_EXPORT int
+ratbag_profile_get_autosleep(const struct ratbag_profile *profile)
+{
+	return profile->autosleep;
+}
+
+LIBRATBAG_EXPORT size_t
+ratbag_profile_get_autosleep_list(const struct ratbag_profile *profile,
+				  unsigned int *autosleeps,
+				  size_t nautosleeps)
+{
+	_Static_assert(sizeof(*autosleeps) == sizeof(*profile->autosleeps), "type mismatch");
+
+	assert(nautosleeps > 0);
+
+	if (profile->nautosleeps == 0)
+		return 0;
+
+	memcpy(autosleeps, profile->autosleeps,
+	       sizeof(unsigned int) * min(nautosleeps, profile->nautosleeps));
+
+	return profile->nautosleeps;
 }
 
 LIBRATBAG_EXPORT size_t

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -829,6 +829,27 @@ ratbag_device_reset(struct ratbag_device *device) {
   return RATBAG_SUCCESS;
 }
 
+LIBRATBAG_EXPORT bool
+ratbag_device_has_event_support(struct ratbag_device *device) {
+  return device->driver && device->driver->handle_event != NULL;
+}
+
+LIBRATBAG_EXPORT int
+ratbag_device_get_hidraw_fd(struct ratbag_device *device, unsigned int index) {
+  if (index >= MAX_HIDRAW)
+    return -1;
+  return device->hidraw[index].fd;
+}
+
+LIBRATBAG_EXPORT unsigned int
+ratbag_device_dispatch_event(struct ratbag_device *device,
+                             const uint8_t *buf, size_t len,
+                             int hidraw_index) {
+  if (!device->driver || !device->driver->handle_event)
+    return RATBAG_EVENT_NONE;
+  return device->driver->handle_event(device, buf, len, hidraw_index);
+}
+
 LIBRATBAG_EXPORT enum ratbag_error_code
 ratbag_profile_set_active(struct ratbag_profile *profile) {
   struct ratbag_device *device = profile->device;

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -209,11 +209,44 @@ void ratbag_device_destroy(struct ratbag_device *device) {
   free(device);
 }
 
+static bool
+ratbag_sanity_check_profile(struct ratbag_profile *profile)
+{
+  struct ratbag_device *device = profile->device;
+  struct ratbag *ratbag = device->ratbag;
+  struct ratbag_resolution *resolution;
+  unsigned int vals[300];
+  unsigned int nvals = ARRAY_LENGTH(vals);
+  unsigned int nres;
+
+  nres = ratbag_profile_get_num_resolutions(profile);
+  if (nres > 16) {
+    log_bug_libratbag(ratbag, "%s: invalid number of resolutions (%d)\n",
+                      device->name, nres);
+    return false;
+  }
+
+  ratbag_profile_for_each_resolution(profile, resolution) {
+    nvals = ratbag_resolution_get_dpi_list(resolution, vals, nvals);
+    if (nvals == 0) {
+      log_bug_libratbag(ratbag, "%s: invalid dpi list\n", device->name);
+      return false;
+    }
+  }
+
+  nvals = ratbag_profile_get_report_rate_list(profile, vals, nvals);
+  if (nvals == 0) {
+    log_bug_libratbag(ratbag, "%s: invalid report rate list\n", device->name);
+    return false;
+  }
+
+  return true;
+}
+
 static inline bool ratbag_sanity_check_device(struct ratbag_device *device) {
   struct ratbag *ratbag = device->ratbag;
   struct ratbag_profile *profile = NULL;
   bool has_active = false;
-  unsigned int nres;
   bool rc = false;
 
   /* arbitrary number: max 16 profiles, does any mouse have more? but
@@ -226,10 +259,6 @@ static inline bool ratbag_sanity_check_device(struct ratbag_device *device) {
   }
 
   ratbag_device_for_each_profile(device, profile) {
-    struct ratbag_resolution *resolution;
-    unsigned int vals[300];
-    unsigned int nvals = ARRAY_LENGTH(vals);
-
     /* Allow max 1 active profile */
     if (profile->is_active) {
       if (has_active) {
@@ -240,26 +269,13 @@ static inline bool ratbag_sanity_check_device(struct ratbag_device *device) {
       has_active = true;
     }
 
-    nres = ratbag_profile_get_num_resolutions(profile);
-    if (nres > 16) {
-      log_bug_libratbag(ratbag, "%s: invalid number of resolutions (%d)\n",
-                        device->name, nres);
-      goto out;
-    }
+    /* Skip data validation for profiles not yet loaded by
+     * drivers that support lazy loading via read_profile. */
+    if (!profile->loaded && device->driver->read_profile)
+      continue;
 
-    ratbag_profile_for_each_resolution(profile, resolution) {
-      nvals = ratbag_resolution_get_dpi_list(resolution, vals, nvals);
-      if (nvals == 0) {
-        log_bug_libratbag(ratbag, "%s: invalid dpi list\n", device->name);
-        goto out;
-      }
-    }
-
-    nvals = ratbag_profile_get_report_rate_list(profile, vals, nvals);
-    if (nvals == 0) {
-      log_bug_libratbag(ratbag, "%s: invalid report rate list\n", device->name);
+    if (!ratbag_sanity_check_profile(profile))
       goto out;
-    }
 
     if (profile->dirty) {
       log_bug_libratbag(ratbag, "%s: profile is dirty while probing\n",
@@ -730,6 +746,38 @@ ratbag_profile_set_enabled(struct ratbag_profile *profile, bool enabled) {
   profile->dirty = true;
 
   return RATBAG_SUCCESS;
+}
+
+LIBRATBAG_EXPORT int
+ratbag_profile_load(struct ratbag_profile *profile)
+{
+  struct ratbag_device *device = profile->device;
+
+  if (profile->loaded)
+    return 0;
+
+  if (!device->driver->read_profile) {
+    profile->loaded = true;
+    return 0;
+  }
+
+  int rc = device->driver->read_profile(profile);
+  if (rc) {
+    log_error(device->ratbag,
+              "Failed to load profile %d: %d\n",
+              profile->index, rc);
+    return rc;
+  }
+
+  if (!ratbag_sanity_check_profile(profile)) {
+    log_error(device->ratbag,
+              "Profile %d failed sanity check after loading\n",
+              profile->index);
+    return -EINVAL;
+  }
+
+  profile->loaded = true;
+  return 0;
 }
 
 LIBRATBAG_EXPORT bool

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -1378,6 +1378,7 @@ ratbag_button_has_action_type(const struct ratbag_button *button,
   case RATBAG_BUTTON_ACTION_TYPE_SPECIAL:
   case RATBAG_BUTTON_ACTION_TYPE_KEY:
   case RATBAG_BUTTON_ACTION_TYPE_MACRO:
+  case RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK:
     break;
   default:
     return 0;
@@ -1467,6 +1468,51 @@ ratbag_button_set_key(struct ratbag_button *button, unsigned int key) {
 
   action.type = RATBAG_BUTTON_ACTION_TYPE_KEY;
   action.action.key = key;
+
+  ratbag_button_set_action(button, &action);
+  button->dirty = true;
+  button->profile->dirty = true;
+
+  return RATBAG_SUCCESS;
+}
+
+LIBRATBAG_EXPORT int
+ratbag_button_get_dpi_lock(const struct ratbag_button *button) {
+  return ratbag_button_get_dpi_lock_x(button);
+}
+
+LIBRATBAG_EXPORT int
+ratbag_button_get_dpi_lock_x(const struct ratbag_button *button) {
+  if (button->action.type != RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK)
+    return -1;
+
+  return (int)button->action.action.dpi_lock.x;
+}
+
+LIBRATBAG_EXPORT int
+ratbag_button_get_dpi_lock_y(const struct ratbag_button *button) {
+  if (button->action.type != RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK)
+    return -1;
+
+  return (int)button->action.action.dpi_lock.y;
+}
+
+LIBRATBAG_EXPORT enum ratbag_error_code
+ratbag_button_set_dpi_lock(struct ratbag_button *button, unsigned int dpi) {
+  return ratbag_button_set_dpi_lock_xy(button, dpi, dpi);
+}
+
+LIBRATBAG_EXPORT enum ratbag_error_code
+ratbag_button_set_dpi_lock_xy(struct ratbag_button *button,
+                              unsigned int x, unsigned int y) {
+  struct ratbag_button_action action = {0};
+
+  if (!ratbag_button_has_action_type(button, RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK))
+    return RATBAG_ERROR_CAPABILITY;
+
+  action.type = RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK;
+  action.action.dpi_lock.x = x;
+  action.action.dpi_lock.y = y;
 
   ratbag_button_set_action(button, &action);
   button->dirty = true;

--- a/src/libratbag.h
+++ b/src/libratbag.h
@@ -817,6 +817,37 @@ ratbag_profile_get_angle_snapping(const struct ratbag_profile *profile);
 /**
  * @ingroup profile
  *
+ * Set the motion sync option for the profile.
+ *
+ * A value of 0 disables the mode.
+ *
+ * If the profile mode is the currently active profile,
+ * the change takes effect immediately.
+ *
+ * @param profile A previously initialized ratbag profile
+ * @param value Motion sync value
+ *
+ * @return zero on success or an error code on failure
+ */
+enum ratbag_error_code
+ratbag_profile_set_motion_sync(struct ratbag_profile *profile,
+			       int value);
+
+/**
+ * @ingroup profile
+ *
+ * Get the motion sync option for the profile.
+ *
+ * @param profile A previously initialized ratbag profile
+ *
+ * @return Motion sync value
+ */
+int
+ratbag_profile_get_motion_sync(const struct ratbag_profile *profile);
+
+/**
+ * @ingroup profile
+ *
  * Set the debounce time in ms for the profile.
  *
  * If the profile mode is the currently active profile,

--- a/src/libratbag.h
+++ b/src/libratbag.h
@@ -749,6 +749,27 @@ ratbag_device_get_profile(struct ratbag_device *device, unsigned int index);
 /**
  * @ingroup profile
  *
+ * Ensure the profile's data has been loaded from the device.
+ *
+ * For drivers that support lazy profile loading, this triggers the
+ * actual device read the first time it is called. Subsequent calls
+ * are no-ops. For drivers that do not support lazy loading this
+ * function always returns success immediately.
+ *
+ * Callers should invoke this before reading any profile properties
+ * (resolutions, buttons, report rate, etc.) if the profile may not
+ * have been loaded during probe.
+ *
+ * @param profile A previously initialized ratbag profile
+ *
+ * @return 0 on success or a negative errno on failure
+ */
+int
+ratbag_profile_load(struct ratbag_profile *profile);
+
+/**
+ * @ingroup profile
+ *
  * Check if the given profile is the currently active one. Note that some
  * devices allow switching profiles with hardware buttons thus making the
  * use of this function racy.

--- a/src/libratbag.h
+++ b/src/libratbag.h
@@ -1738,6 +1738,77 @@ ratbag_led_set_brightness(struct ratbag_led *led, unsigned int brightness);
 /**
  * @ingroup button
  *
+ * If a button's action is @ref RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK,
+ * this function returns the DPI lock target value for the X axis.
+ * If X and Y are the same, this is the uniform DPI lock value.
+ *
+ * If the button's action type is not @ref RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK,
+ * this function returns -1.
+ *
+ * @return The DPI lock target X value, or -1 on error.
+ */
+int
+ratbag_button_get_dpi_lock(const struct ratbag_button *button);
+
+/**
+ * @ingroup button
+ *
+ * If a button's action is @ref RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK,
+ * this function returns the DPI lock target value for the X axis.
+ *
+ * If the button's action type is not @ref RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK,
+ * this function returns -1.
+ *
+ * @return The DPI lock target X value, or -1 on error.
+ */
+int
+ratbag_button_get_dpi_lock_x(const struct ratbag_button *button);
+
+/**
+ * @ingroup button
+ *
+ * If a button's action is @ref RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK,
+ * this function returns the DPI lock target value for the Y axis.
+ *
+ * If the button's action type is not @ref RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK,
+ * this function returns -1.
+ *
+ * @return The DPI lock target Y value, or -1 on error.
+ */
+int
+ratbag_button_get_dpi_lock_y(const struct ratbag_button *button);
+
+/**
+ * @ingroup button
+ *
+ * Set the DPI lock target to a uniform value for both axes.
+ *
+ * @param button A previously initialized ratbag button
+ * @param dpi The DPI value to lock to while the button is held.
+ * @return 0 on success or an error code otherwise. On success, the button's
+ * action is set to @ref RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK.
+ */
+enum ratbag_error_code
+ratbag_button_set_dpi_lock(struct ratbag_button *button, unsigned int dpi);
+
+/**
+ * @ingroup button
+ *
+ * Set the DPI lock target with independent X and Y values.
+ *
+ * @param button A previously initialized ratbag button
+ * @param x The DPI value for the X axis.
+ * @param y The DPI value for the Y axis.
+ * @return 0 on success or an error code otherwise. On success, the button's
+ * action is set to @ref RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK.
+ */
+enum ratbag_error_code
+ratbag_button_set_dpi_lock_xy(struct ratbag_button *button,
+			      unsigned int x, unsigned int y);
+
+/**
+ * @ingroup button
+ *
  * This function sets the special function assigned to this button.
  *
  * @param button A previously initialized ratbag button

--- a/src/libratbag.h
+++ b/src/libratbag.h
@@ -985,6 +985,59 @@ ratbag_profile_get_lod_list(const struct ratbag_profile *profile,
 /**
  * @ingroup profile
  *
+ * Set the autosleep timeout in seconds for the profile.
+ *
+ * If the profile mode is the currently active profile,
+ * the change takes effect immediately.
+ *
+ * @param profile A previously initialized ratbag profile
+ * @param value Autosleep timeout in seconds
+ *
+ * @return zero on success or an error code on failure
+ */
+enum ratbag_error_code
+ratbag_profile_set_autosleep(struct ratbag_profile *profile,
+			     int value);
+
+/**
+ * @ingroup profile
+ *
+ * Get the autosleep timeout in seconds for the profile.
+ *
+ * @param profile A previously initialized ratbag profile
+ *
+ * @return Autosleep timeout for this profile in seconds
+ */
+int
+ratbag_profile_get_autosleep(const struct ratbag_profile *profile);
+
+/**
+ * @ingroup profile
+ *
+ * Get the number of autosleep timeouts in seconds available for this profile.
+ * The list of autosleep timeouts is sorted in ascending order but may be
+ * filtered by libratbag and does not necessarily reflect all values supported
+ * by the physical device.
+ *
+ * This function writes at most nautosleeps values but returns the number of
+ * autosleep timeouts available on this profile. In other words, if it returns
+ * a number larger than nautosleeps, call it again with an array the size of
+ * the return value.
+ *
+ * @param[out] autosleeps Set to the supported autosleep timeouts in ascending order
+ * @param[in] nautosleeps The number of elements
+ *
+ * @return The number of valid items in values. If the returned value
+ * is larger than nautosleeps, the list was truncated.
+ */
+size_t
+ratbag_profile_get_autosleep_list(const struct ratbag_profile *profile,
+				  unsigned int *autosleeps,
+				  size_t nautosleeps);
+
+/**
+ * @ingroup profile
+ *
  * Get the number of @ref ratbag_resolution available in this profile. A
  * resolution mode is a tuple of (resolution, report rate), each mode can be
  * fetched with ratbag_profile_get_resolution().

--- a/src/libratbag.h
+++ b/src/libratbag.h
@@ -515,6 +515,21 @@ ratbag_device_commit(struct ratbag_device *device);
 /**
  * @ingroup device
  *
+ * Instruct the device to perform a factory reset, restoring all
+ * settings to their hardware defaults.
+ *
+ * Not all devices support hardware reset. If the device's driver
+ * does not implement reset, RATBAG_ERROR_CAPABILITY is returned.
+ *
+ * @param device A previously initialized ratbag device
+ * @return RATBAG_SUCCESS on success or an error code otherwise
+ */
+enum ratbag_error_code
+ratbag_device_reset(struct ratbag_device *device);
+
+/**
+ * @ingroup device
+ *
  * Return the number of profiles supported by this device.
  *
  * Note that the number of profiles available may be different to the number

--- a/src/libratbag.h
+++ b/src/libratbag.h
@@ -870,6 +870,59 @@ ratbag_profile_get_debounce_list(const struct ratbag_profile *profile,
 /**
  * @ingroup profile
  *
+ * Set the lift off distance in mm for the profile.
+ *
+ * If the profile mode is the currently active profile,
+ * the change takes effect immediately.
+ *
+ * @param profile A previously initialized ratbag profile
+ * @param value Lift off distance in mm
+ *
+ * @return zero on success or an error code on failure
+ */
+enum ratbag_error_code
+ratbag_profile_set_lod(struct ratbag_profile *profile,
+		       double value);
+
+/**
+ * @ingroup profile
+ *
+ * Get the lift off distance in mm for the profile.
+ *
+ * @param profile A previously initialized ratbag profile
+ *
+ * @return Lift off distance for this profile in mm
+ */
+double
+ratbag_profile_get_lod(const struct ratbag_profile *profile);
+
+/**
+ * @ingroup profile
+ *
+ * Get the number of lift off distances in mm available for this profile.
+ * The list of lift off distances is sorted in ascending order but may be
+ * filtered by libratbag and does not necessarily reflect all values supported
+ * by the physical device.
+ *
+ * This function writes at most nlods values but returns the number of
+ * lift off distances available on this profile. In other words, if it returns
+ * a number larger than nlods, call it again with an array the size of the
+ * return value.
+ *
+ * @param[out] lods Set to the supported lift off distances in ascending order
+ * @param[in] nlods The number of elements
+ *
+ * @return The number of valid items in values. If the returned value
+ * is larger than nlods, the list was truncated.
+ */
+size_t
+ratbag_profile_get_lod_list(const struct ratbag_profile *profile,
+			    double *lods,
+			    size_t nlods);
+
+/**
+ * @ingroup profile
+ *
  * Get the number of @ref ratbag_resolution available in this profile. A
  * resolution mode is a tuple of (resolution, report rate), each mode can be
  * fetched with ratbag_profile_get_resolution().

--- a/src/libratbag.h
+++ b/src/libratbag.h
@@ -848,6 +848,37 @@ ratbag_profile_get_motion_sync(const struct ratbag_profile *profile);
 /**
  * @ingroup profile
  *
+ * Set the ripple control option for the profile.
+ *
+ * A value of 0 disables the mode.
+ *
+ * If the profile mode is the currently active profile,
+ * the change takes effect immediately.
+ *
+ * @param profile A previously initialized ratbag profile
+ * @param value Ripple control value
+ *
+ * @return zero on success or an error code on failure
+ */
+enum ratbag_error_code
+ratbag_profile_set_ripple_control(struct ratbag_profile *profile,
+				  int value);
+
+/**
+ * @ingroup profile
+ *
+ * Get the ripple control option for the profile.
+ *
+ * @param profile A previously initialized ratbag profile
+ *
+ * @return Ripple control value
+ */
+int
+ratbag_profile_get_ripple_control(const struct ratbag_profile *profile);
+
+/**
+ * @ingroup profile
+ *
  * Set the debounce time in ms for the profile.
  *
  * If the profile mode is the currently active profile,

--- a/src/libratbag.h
+++ b/src/libratbag.h
@@ -2015,6 +2015,48 @@ ratbag_button_macro_set_event(struct ratbag_button_macro *macro,
 /**
  * @ingroup button
  *
+ * Return the repeat mode of this macro.
+ *
+ * @param macro A previously initialized ratbag button macro
+ *
+ * @return The repeat mode
+ */
+enum ratbag_macro_repeat_mode
+ratbag_button_macro_get_repeat_mode(const struct ratbag_button_macro *macro);
+
+/**
+ * @ingroup button
+ *
+ * Return the repeat count of this macro. Only meaningful when the
+ * repeat mode is @ref RATBAG_MACRO_REPEAT_COUNT.
+ *
+ * @param macro A previously initialized ratbag button macro
+ *
+ * @return The repeat count
+ */
+unsigned int
+ratbag_button_macro_get_repeat_count(const struct ratbag_button_macro *macro);
+
+/**
+ * @ingroup button
+ *
+ * Set the repeat mode and count for this macro.
+ *
+ * The count is only used when mode is @ref RATBAG_MACRO_REPEAT_COUNT
+ * and is ignored for other modes.
+ *
+ * @param macro A previously initialized ratbag button macro
+ * @param mode The repeat mode
+ * @param count The repeat count (for RATBAG_MACRO_REPEAT_COUNT)
+ */
+void
+ratbag_button_macro_set_repeat(struct ratbag_button_macro *macro,
+			       enum ratbag_macro_repeat_mode mode,
+			       unsigned int count);
+
+/**
+ * @ingroup button
+ *
  * Add a reference to the macro. A macro is destroyed whenever the
  * reference count reaches 0. See @ref ratbag_button_macro_unref.
  *

--- a/src/libratbag.h
+++ b/src/libratbag.h
@@ -530,6 +530,49 @@ ratbag_device_reset(struct ratbag_device *device);
 /**
  * @ingroup device
  *
+ * Returns whether the device supports asynchronous event monitoring.
+ * A device supports it if its driver implements the handle_event callback.
+ *
+ * @param device A previously initialized ratbag device
+ * @return true if the device supports event monitoring
+ */
+bool
+ratbag_device_has_event_support(struct ratbag_device *device);
+
+/**
+ * @ingroup device
+ *
+ * Returns the hidraw file descriptor for the given index, or -1 if not
+ * open or the index is out of range. The caller must NOT close this fd.
+ *
+ * @param device A previously initialized ratbag device
+ * @param index The hidraw index (0 or 1)
+ * @return The file descriptor, or -1
+ */
+int
+ratbag_device_get_hidraw_fd(struct ratbag_device *device, unsigned int index);
+
+/**
+ * @ingroup device
+ *
+ * Dispatch a raw HID input report to the device's driver for event
+ * handling. The driver parses the report, updates internal state, and
+ * returns a bitmask indicating what changed.
+ *
+ * @param device A previously initialized ratbag device
+ * @param buf The raw report data
+ * @param len Length of buf in bytes
+ * @param hidraw_index Which hidraw fd the data was read from
+ * @return Bitmask of enum ratbag_event_type, or RATBAG_EVENT_NONE
+ */
+unsigned int
+ratbag_device_dispatch_event(struct ratbag_device *device,
+			     const uint8_t *buf, size_t len,
+			     int hidraw_index);
+
+/**
+ * @ingroup device
+ *
  * Return the number of profiles supported by this device.
  *
  * Note that the number of profiles available may be different to the number

--- a/test/test-device.c
+++ b/test/test-device.c
@@ -1168,6 +1168,74 @@ START_TEST(device_angle_snapping_get_set)
 }
 END_TEST
 
+START_TEST(device_event_no_handler)
+{
+	struct ratbag *r;
+	struct ratbag_device *d;
+	unsigned int events;
+	uint8_t buf[] = { 0x01, 0x02, 0x03 };
+
+	struct ratbag_test_device td = sane_device;
+
+	r = ratbag_create_context(&abort_iface, NULL);
+	d = ratbag_device_new_test_device(r, &td);
+	ck_assert(d != NULL);
+
+	ck_assert(ratbag_device_has_event_support(d));
+
+	/* no per-device handler set, should return NONE */
+	events = ratbag_device_dispatch_event(d, buf, sizeof(buf), 0);
+	ck_assert_int_eq(events, RATBAG_EVENT_NONE);
+
+	ratbag_device_unref(d);
+	ratbag_unref(r);
+}
+END_TEST
+
+static unsigned int
+test_event_handler(struct ratbag_device *device,
+		   const uint8_t *buf, size_t len,
+		   int hidraw_index)
+{
+	if (len >= 1 && buf[0] == 0x01)
+		return RATBAG_EVENT_RESOLUTION_CHANGED;
+	if (len >= 1 && buf[0] == 0x02)
+		return RATBAG_EVENT_PROFILE_CHANGED;
+	return RATBAG_EVENT_NONE;
+}
+
+START_TEST(device_event_dispatch)
+{
+	struct ratbag *r;
+	struct ratbag_device *d;
+	unsigned int events;
+
+	struct ratbag_test_device td = sane_device;
+	td.handle_event = test_event_handler;
+
+	r = ratbag_create_context(&abort_iface, NULL);
+	d = ratbag_device_new_test_device(r, &td);
+	ck_assert(d != NULL);
+
+	ck_assert(ratbag_device_has_event_support(d));
+
+	uint8_t buf_dpi[] = { 0x01 };
+	events = ratbag_device_dispatch_event(d, buf_dpi, sizeof(buf_dpi), 0);
+	ck_assert_int_eq(events, RATBAG_EVENT_RESOLUTION_CHANGED);
+
+	uint8_t buf_profile[] = { 0x02 };
+	events = ratbag_device_dispatch_event(d, buf_profile, sizeof(buf_profile), 0);
+	ck_assert_int_eq(events, RATBAG_EVENT_PROFILE_CHANGED);
+
+	uint8_t buf_unknown[] = { 0xFF };
+	events = ratbag_device_dispatch_event(d, buf_unknown, sizeof(buf_unknown), 0);
+	ck_assert_int_eq(events, RATBAG_EVENT_NONE);
+
+	ratbag_device_unref(d);
+	ratbag_unref(r);
+}
+END_TEST
+
 START_TEST(device_reset_no_support)
 {
 	struct ratbag *r;
@@ -1244,6 +1312,11 @@ test_context_suite(void)
 
 	tc = tcase_create("reset");
 	tcase_add_test(tc, device_reset_no_support);
+	suite_add_tcase(s, tc);
+
+	tc = tcase_create("events");
+	tcase_add_test(tc, device_event_no_handler);
+	tcase_add_test(tc, device_event_dispatch);
 	suite_add_tcase(s, tc);
 
 	return s;

--- a/test/test-device.c
+++ b/test/test-device.c
@@ -964,6 +964,230 @@ START_TEST(device_leds_set)
 }
 END_TEST
 
+START_TEST(device_motion_sync)
+{
+	struct ratbag *r;
+	struct ratbag_device *d;
+	struct ratbag_profile *p;
+	int val;
+
+	struct ratbag_test_device td = sane_device;
+	td.profiles[0].motion_sync = 1;
+
+	r = ratbag_create_context(&abort_iface, NULL);
+	d = ratbag_device_new_test_device(r, &td);
+	ck_assert(d != NULL);
+
+	p = ratbag_device_get_profile(d, 0);
+	val = ratbag_profile_get_motion_sync(p);
+	ck_assert_int_eq(val, 1);
+
+	ratbag_profile_set_motion_sync(p, 0);
+	val = ratbag_profile_get_motion_sync(p);
+	ck_assert_int_eq(val, 0);
+
+	ratbag_profile_unref(p);
+	ratbag_device_unref(d);
+	ratbag_unref(r);
+}
+END_TEST
+
+START_TEST(device_ripple_control)
+{
+	struct ratbag *r;
+	struct ratbag_device *d;
+	struct ratbag_profile *p;
+	int val;
+
+	struct ratbag_test_device td = sane_device;
+	td.profiles[0].ripple_control = 1;
+
+	r = ratbag_create_context(&abort_iface, NULL);
+	d = ratbag_device_new_test_device(r, &td);
+	ck_assert(d != NULL);
+
+	p = ratbag_device_get_profile(d, 0);
+	val = ratbag_profile_get_ripple_control(p);
+	ck_assert_int_eq(val, 1);
+
+	ratbag_profile_set_ripple_control(p, 0);
+	val = ratbag_profile_get_ripple_control(p);
+	ck_assert_int_eq(val, 0);
+
+	ratbag_profile_unref(p);
+	ratbag_device_unref(d);
+	ratbag_unref(r);
+}
+END_TEST
+
+START_TEST(device_lod_get_set)
+{
+	struct ratbag *r;
+	struct ratbag_device *d;
+	struct ratbag_profile *p;
+	double val;
+	double lods[8];
+	size_t nlods;
+
+	struct ratbag_test_device td = sane_device;
+	td.profiles[0].lod = 2.0;
+	td.profiles[0].lods[0] = 1.0;
+	td.profiles[0].lods[1] = 2.0;
+	td.profiles[0].lods[2] = 3.0;
+	td.profiles[0].nlods = 3;
+
+	r = ratbag_create_context(&abort_iface, NULL);
+	d = ratbag_device_new_test_device(r, &td);
+	ck_assert(d != NULL);
+
+	p = ratbag_device_get_profile(d, 0);
+	val = ratbag_profile_get_lod(p);
+	ck_assert(val == 2.0);
+
+	nlods = ratbag_profile_get_lod_list(p, lods, ARRAY_LENGTH(lods));
+	ck_assert_int_eq(nlods, 3);
+	ck_assert(lods[0] == 1.0);
+	ck_assert(lods[1] == 2.0);
+	ck_assert(lods[2] == 3.0);
+
+	ratbag_profile_set_lod(p, 3.0);
+	val = ratbag_profile_get_lod(p);
+	ck_assert(val == 3.0);
+
+	ratbag_profile_unref(p);
+	ratbag_device_unref(d);
+	ratbag_unref(r);
+}
+END_TEST
+
+START_TEST(device_autosleep_get_set)
+{
+	struct ratbag *r;
+	struct ratbag_device *d;
+	struct ratbag_profile *p;
+	int val;
+	unsigned int sleeps[8];
+	size_t nsleeps;
+
+	struct ratbag_test_device td = sane_device;
+	td.profiles[0].autosleep = 60;
+	td.profiles[0].autosleeps[0] = 30;
+	td.profiles[0].autosleeps[1] = 60;
+	td.profiles[0].autosleeps[2] = 120;
+	td.profiles[0].nautosleeps = 3;
+
+	r = ratbag_create_context(&abort_iface, NULL);
+	d = ratbag_device_new_test_device(r, &td);
+	ck_assert(d != NULL);
+
+	p = ratbag_device_get_profile(d, 0);
+	val = ratbag_profile_get_autosleep(p);
+	ck_assert_int_eq(val, 60);
+
+	nsleeps = ratbag_profile_get_autosleep_list(p, sleeps, ARRAY_LENGTH(sleeps));
+	ck_assert_int_eq(nsleeps, 3);
+	ck_assert_int_eq(sleeps[0], 30);
+	ck_assert_int_eq(sleeps[1], 60);
+	ck_assert_int_eq(sleeps[2], 120);
+
+	ratbag_profile_set_autosleep(p, 120);
+	val = ratbag_profile_get_autosleep(p);
+	ck_assert_int_eq(val, 120);
+
+	ratbag_profile_unref(p);
+	ratbag_device_unref(d);
+	ratbag_unref(r);
+}
+END_TEST
+
+START_TEST(device_debounce_get_set)
+{
+	struct ratbag *r;
+	struct ratbag_device *d;
+	struct ratbag_profile *p;
+	int val;
+	unsigned int debounces[8];
+	size_t ndebounces;
+
+	struct ratbag_test_device td = sane_device;
+	td.profiles[0].debounce = 10;
+	td.profiles[0].debounces[0] = 5;
+	td.profiles[0].debounces[1] = 10;
+	td.profiles[0].debounces[2] = 15;
+	td.profiles[0].ndebounces = 3;
+
+	r = ratbag_create_context(&abort_iface, NULL);
+	d = ratbag_device_new_test_device(r, &td);
+	ck_assert(d != NULL);
+
+	p = ratbag_device_get_profile(d, 0);
+	val = ratbag_profile_get_debounce(p);
+	ck_assert_int_eq(val, 10);
+
+	ndebounces = ratbag_profile_get_debounce_list(p, debounces, ARRAY_LENGTH(debounces));
+	ck_assert_int_eq(ndebounces, 3);
+	ck_assert_int_eq(debounces[0], 5);
+	ck_assert_int_eq(debounces[1], 10);
+	ck_assert_int_eq(debounces[2], 15);
+
+	ratbag_profile_set_debounce(p, 15);
+	val = ratbag_profile_get_debounce(p);
+	ck_assert_int_eq(val, 15);
+
+	ratbag_profile_unref(p);
+	ratbag_device_unref(d);
+	ratbag_unref(r);
+}
+END_TEST
+
+START_TEST(device_angle_snapping_get_set)
+{
+	struct ratbag *r;
+	struct ratbag_device *d;
+	struct ratbag_profile *p;
+	int val;
+
+	struct ratbag_test_device td = sane_device;
+	td.profiles[0].angle_snapping = 1;
+
+	r = ratbag_create_context(&abort_iface, NULL);
+	d = ratbag_device_new_test_device(r, &td);
+	ck_assert(d != NULL);
+
+	p = ratbag_device_get_profile(d, 0);
+	val = ratbag_profile_get_angle_snapping(p);
+	ck_assert_int_eq(val, 1);
+
+	ratbag_profile_set_angle_snapping(p, 0);
+	val = ratbag_profile_get_angle_snapping(p);
+	ck_assert_int_eq(val, 0);
+
+	ratbag_profile_unref(p);
+	ratbag_device_unref(d);
+	ratbag_unref(r);
+}
+END_TEST
+
+START_TEST(device_reset_no_support)
+{
+	struct ratbag *r;
+	struct ratbag_device *d;
+	enum ratbag_error_code rc;
+
+	struct ratbag_test_device td = sane_device;
+
+	r = ratbag_create_context(&abort_iface, NULL);
+	d = ratbag_device_new_test_device(r, &td);
+	ck_assert(d != NULL);
+
+	rc = ratbag_device_reset(d);
+	ck_assert_int_eq(rc, RATBAG_ERROR_CAPABILITY);
+
+	ratbag_device_unref(d);
+	ratbag_unref(r);
+}
+END_TEST
+
 static Suite *
 test_context_suite(void)
 {
@@ -1007,6 +1231,19 @@ test_context_suite(void)
 	tc = tcase_create("led");
 	tcase_add_test(tc, device_leds);
 	tcase_add_test(tc, device_leds_set);
+	suite_add_tcase(s, tc);
+
+	tc = tcase_create("profile_settings");
+	tcase_add_test(tc, device_angle_snapping_get_set);
+	tcase_add_test(tc, device_motion_sync);
+	tcase_add_test(tc, device_ripple_control);
+	tcase_add_test(tc, device_debounce_get_set);
+	tcase_add_test(tc, device_lod_get_set);
+	tcase_add_test(tc, device_autosleep_get_set);
+	suite_add_tcase(s, tc);
+
+	tc = tcase_create("reset");
+	tcase_add_test(tc, device_reset_no_support);
 	suite_add_tcase(s, tc);
 
 	return s;

--- a/test/test-device.c
+++ b/test/test-device.c
@@ -1256,6 +1256,163 @@ START_TEST(device_reset_no_support)
 }
 END_TEST
 
+START_TEST(device_buttons_dpi_lock_init)
+{
+	struct ratbag *r;
+	struct ratbag_device *d;
+	struct ratbag_profile *p;
+	struct ratbag_button *b;
+	int x, y;
+
+	struct ratbag_test_device td = sane_device;
+	td.num_buttons = 3;
+	td.profiles[0].buttons[1].action_type = RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK;
+	td.profiles[0].buttons[1].dpi_lock.x = 400;
+	td.profiles[0].buttons[1].dpi_lock.y = 400;
+
+	r = ratbag_create_context(&abort_iface, NULL);
+	d = ratbag_device_new_test_device(r, &td);
+	p = ratbag_device_get_profile(d, 0);
+	b = ratbag_profile_get_button(p, 1);
+
+	ck_assert_int_eq(ratbag_button_get_action_type(b),
+			 RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK);
+	x = ratbag_button_get_dpi_lock_x(b);
+	y = ratbag_button_get_dpi_lock_y(b);
+	ck_assert_int_eq(x, 400);
+	ck_assert_int_eq(y, 400);
+	ck_assert_int_eq(ratbag_button_get_dpi_lock(b), 400);
+
+	ratbag_button_unref(b);
+	ratbag_profile_unref(p);
+	ratbag_device_unref(d);
+	ratbag_unref(r);
+}
+END_TEST
+
+START_TEST(device_buttons_dpi_lock_init_xy)
+{
+	struct ratbag *r;
+	struct ratbag_device *d;
+	struct ratbag_profile *p;
+	struct ratbag_button *b;
+
+	struct ratbag_test_device td = sane_device;
+	td.num_buttons = 3;
+	td.profiles[0].buttons[1].action_type = RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK;
+	td.profiles[0].buttons[1].dpi_lock.x = 800;
+	td.profiles[0].buttons[1].dpi_lock.y = 1600;
+
+	r = ratbag_create_context(&abort_iface, NULL);
+	d = ratbag_device_new_test_device(r, &td);
+	p = ratbag_device_get_profile(d, 0);
+	b = ratbag_profile_get_button(p, 1);
+
+	ck_assert_int_eq(ratbag_button_get_action_type(b),
+			 RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK);
+	ck_assert_int_eq(ratbag_button_get_dpi_lock_x(b), 800);
+	ck_assert_int_eq(ratbag_button_get_dpi_lock_y(b), 1600);
+	/* get_dpi_lock returns x value when x != y */
+	ck_assert_int_eq(ratbag_button_get_dpi_lock(b), 800);
+
+	ratbag_button_unref(b);
+	ratbag_profile_unref(p);
+	ratbag_device_unref(d);
+	ratbag_unref(r);
+}
+END_TEST
+
+START_TEST(device_buttons_dpi_lock_set)
+{
+	struct ratbag *r;
+	struct ratbag_device *d;
+	struct ratbag_profile *p;
+	struct ratbag_button *b;
+	int rc;
+
+	struct ratbag_test_device td = sane_device;
+	td.num_buttons = 3;
+
+	r = ratbag_create_context(&abort_iface, NULL);
+	d = ratbag_device_new_test_device(r, &td);
+	p = ratbag_device_get_profile(d, 0);
+	b = ratbag_profile_get_button(p, 0);
+
+	/* button starts as NONE, set to dpi lock uniform */
+	rc = ratbag_button_set_dpi_lock(b, 800);
+	ck_assert_int_eq(rc, RATBAG_SUCCESS);
+	ck_assert_int_eq(ratbag_button_get_action_type(b),
+			 RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK);
+	ck_assert_int_eq(ratbag_button_get_dpi_lock_x(b), 800);
+	ck_assert_int_eq(ratbag_button_get_dpi_lock_y(b), 800);
+
+	/* set to dpi lock with independent x/y */
+	rc = ratbag_button_set_dpi_lock_xy(b, 400, 1600);
+	ck_assert_int_eq(rc, RATBAG_SUCCESS);
+	ck_assert_int_eq(ratbag_button_get_dpi_lock_x(b), 400);
+	ck_assert_int_eq(ratbag_button_get_dpi_lock_y(b), 1600);
+
+	ratbag_button_unref(b);
+	ratbag_profile_unref(p);
+	ratbag_device_unref(d);
+	ratbag_unref(r);
+}
+END_TEST
+
+START_TEST(device_buttons_dpi_lock_has_action_type)
+{
+	struct ratbag *r;
+	struct ratbag_device *d;
+	struct ratbag_profile *p;
+	struct ratbag_button *b;
+
+	struct ratbag_test_device td = sane_device;
+	td.num_buttons = 1;
+
+	r = ratbag_create_context(&abort_iface, NULL);
+	d = ratbag_device_new_test_device(r, &td);
+	p = ratbag_device_get_profile(d, 0);
+	b = ratbag_profile_get_button(p, 0);
+
+	/* test driver enables DPI_LOCK capability */
+	ck_assert(ratbag_button_has_action_type(b,
+		  RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK));
+
+	ratbag_button_unref(b);
+	ratbag_profile_unref(p);
+	ratbag_device_unref(d);
+	ratbag_unref(r);
+}
+END_TEST
+
+START_TEST(device_buttons_dpi_lock_wrong_type)
+{
+	struct ratbag *r;
+	struct ratbag_device *d;
+	struct ratbag_profile *p;
+	struct ratbag_button *b;
+
+	struct ratbag_test_device td = sane_device;
+	td.num_buttons = 1;
+	/* button is default NONE type */
+
+	r = ratbag_create_context(&abort_iface, NULL);
+	d = ratbag_device_new_test_device(r, &td);
+	p = ratbag_device_get_profile(d, 0);
+	b = ratbag_profile_get_button(p, 0);
+
+	/* getters return -1 when action type is not DPI_LOCK */
+	ck_assert_int_eq(ratbag_button_get_dpi_lock(b), -1);
+	ck_assert_int_eq(ratbag_button_get_dpi_lock_x(b), -1);
+	ck_assert_int_eq(ratbag_button_get_dpi_lock_y(b), -1);
+
+	ratbag_button_unref(b);
+	ratbag_profile_unref(p);
+	ratbag_device_unref(d);
+	ratbag_unref(r);
+}
+END_TEST
+
 static Suite *
 test_context_suite(void)
 {
@@ -1294,6 +1451,11 @@ test_context_suite(void)
 	tcase_add_test(tc, device_buttons);
 	tcase_add_test(tc, device_buttons_ref_unref);
 	tcase_add_test(tc, device_buttons_set);
+	tcase_add_test(tc, device_buttons_dpi_lock_init);
+	tcase_add_test(tc, device_buttons_dpi_lock_init_xy);
+	tcase_add_test(tc, device_buttons_dpi_lock_set);
+	tcase_add_test(tc, device_buttons_dpi_lock_has_action_type);
+	tcase_add_test(tc, device_buttons_dpi_lock_wrong_type);
 	suite_add_tcase(s, tc);
 
 	tc = tcase_create("led");

--- a/test/test-device.c
+++ b/test/test-device.c
@@ -1413,6 +1413,179 @@ START_TEST(device_buttons_dpi_lock_wrong_type)
 }
 END_TEST
 
+START_TEST(device_macro_repeat_default)
+{
+	struct ratbag *r;
+	struct ratbag_device *d;
+	struct ratbag_profile *p;
+	struct ratbag_button *b;
+	struct ratbag_button_macro *m;
+
+	struct ratbag_test_device td = sane_device;
+	td.num_buttons = 1;
+	td.profiles[0].buttons[0].action_type = RATBAG_BUTTON_ACTION_TYPE_MACRO;
+	td.profiles[0].buttons[0].macro[0].type = RATBAG_MACRO_EVENT_KEY_PRESSED;
+	td.profiles[0].buttons[0].macro[0].value = KEY_A;
+	td.profiles[0].buttons[0].macro[1].type = RATBAG_MACRO_EVENT_KEY_RELEASED;
+	td.profiles[0].buttons[0].macro[1].value = KEY_A;
+
+	r = ratbag_create_context(&abort_iface, NULL);
+	d = ratbag_device_new_test_device(r, &td);
+	p = ratbag_device_get_profile(d, 0);
+	b = ratbag_profile_get_button(p, 0);
+	m = ratbag_button_get_macro(b);
+
+	ck_assert(m != NULL);
+	ck_assert_int_eq(ratbag_button_macro_get_repeat_mode(m),
+			 RATBAG_MACRO_REPEAT_ONCE);
+	ck_assert_int_eq(ratbag_button_macro_get_repeat_count(m), 0);
+
+	ratbag_button_macro_unref(m);
+	ratbag_button_unref(b);
+	ratbag_profile_unref(p);
+	ratbag_device_unref(d);
+	ratbag_unref(r);
+}
+END_TEST
+
+START_TEST(device_macro_repeat_count)
+{
+	struct ratbag *r;
+	struct ratbag_device *d;
+	struct ratbag_profile *p;
+	struct ratbag_button *b;
+	struct ratbag_button_macro *m;
+
+	struct ratbag_test_device td = sane_device;
+	td.num_buttons = 1;
+	td.profiles[0].buttons[0].action_type = RATBAG_BUTTON_ACTION_TYPE_MACRO;
+	td.profiles[0].buttons[0].macro[0].type = RATBAG_MACRO_EVENT_KEY_PRESSED;
+	td.profiles[0].buttons[0].macro[0].value = KEY_A;
+	td.profiles[0].buttons[0].macro[1].type = RATBAG_MACRO_EVENT_KEY_RELEASED;
+	td.profiles[0].buttons[0].macro[1].value = KEY_A;
+	td.profiles[0].buttons[0].macro_repeat_mode = RATBAG_MACRO_REPEAT_COUNT;
+	td.profiles[0].buttons[0].macro_repeat_count = 5;
+
+	r = ratbag_create_context(&abort_iface, NULL);
+	d = ratbag_device_new_test_device(r, &td);
+	p = ratbag_device_get_profile(d, 0);
+	b = ratbag_profile_get_button(p, 0);
+	m = ratbag_button_get_macro(b);
+
+	ck_assert(m != NULL);
+	ck_assert_int_eq(ratbag_button_macro_get_repeat_mode(m),
+			 RATBAG_MACRO_REPEAT_COUNT);
+	ck_assert_int_eq(ratbag_button_macro_get_repeat_count(m), 5);
+
+	ratbag_button_macro_unref(m);
+	ratbag_button_unref(b);
+	ratbag_profile_unref(p);
+	ratbag_device_unref(d);
+	ratbag_unref(r);
+}
+END_TEST
+
+START_TEST(device_macro_repeat_while_held)
+{
+	struct ratbag *r;
+	struct ratbag_device *d;
+	struct ratbag_profile *p;
+	struct ratbag_button *b;
+	struct ratbag_button_macro *m;
+
+	struct ratbag_test_device td = sane_device;
+	td.num_buttons = 1;
+	td.profiles[0].buttons[0].action_type = RATBAG_BUTTON_ACTION_TYPE_MACRO;
+	td.profiles[0].buttons[0].macro[0].type = RATBAG_MACRO_EVENT_KEY_PRESSED;
+	td.profiles[0].buttons[0].macro[0].value = KEY_A;
+	td.profiles[0].buttons[0].macro[1].type = RATBAG_MACRO_EVENT_KEY_RELEASED;
+	td.profiles[0].buttons[0].macro[1].value = KEY_A;
+	td.profiles[0].buttons[0].macro_repeat_mode = RATBAG_MACRO_REPEAT_WHILE_HELD;
+
+	r = ratbag_create_context(&abort_iface, NULL);
+	d = ratbag_device_new_test_device(r, &td);
+	p = ratbag_device_get_profile(d, 0);
+	b = ratbag_profile_get_button(p, 0);
+	m = ratbag_button_get_macro(b);
+
+	ck_assert(m != NULL);
+	ck_assert_int_eq(ratbag_button_macro_get_repeat_mode(m),
+			 RATBAG_MACRO_REPEAT_WHILE_HELD);
+
+	ratbag_button_macro_unref(m);
+	ratbag_button_unref(b);
+	ratbag_profile_unref(p);
+	ratbag_device_unref(d);
+	ratbag_unref(r);
+}
+END_TEST
+
+START_TEST(device_macro_repeat_until_button_pressed)
+{
+	struct ratbag *r;
+	struct ratbag_device *d;
+	struct ratbag_profile *p;
+	struct ratbag_button *b;
+	struct ratbag_button_macro *m;
+
+	struct ratbag_test_device td = sane_device;
+	td.num_buttons = 1;
+	td.profiles[0].buttons[0].action_type = RATBAG_BUTTON_ACTION_TYPE_MACRO;
+	td.profiles[0].buttons[0].macro[0].type = RATBAG_MACRO_EVENT_KEY_PRESSED;
+	td.profiles[0].buttons[0].macro[0].value = KEY_A;
+	td.profiles[0].buttons[0].macro[1].type = RATBAG_MACRO_EVENT_KEY_RELEASED;
+	td.profiles[0].buttons[0].macro[1].value = KEY_A;
+	td.profiles[0].buttons[0].macro_repeat_mode = RATBAG_MACRO_REPEAT_UNTIL_BUTTON_PRESSED;
+
+	r = ratbag_create_context(&abort_iface, NULL);
+	d = ratbag_device_new_test_device(r, &td);
+	p = ratbag_device_get_profile(d, 0);
+	b = ratbag_profile_get_button(p, 0);
+	m = ratbag_button_get_macro(b);
+
+	ck_assert(m != NULL);
+	ck_assert_int_eq(ratbag_button_macro_get_repeat_mode(m),
+			 RATBAG_MACRO_REPEAT_UNTIL_BUTTON_PRESSED);
+
+	ratbag_button_macro_unref(m);
+	ratbag_button_unref(b);
+	ratbag_profile_unref(p);
+	ratbag_device_unref(d);
+	ratbag_unref(r);
+}
+END_TEST
+
+START_TEST(device_macro_repeat_set)
+{
+	struct ratbag_button_macro *m;
+
+	m = ratbag_button_macro_new("test");
+
+	/* default is ONCE */
+	ck_assert_int_eq(ratbag_button_macro_get_repeat_mode(m),
+			 RATBAG_MACRO_REPEAT_ONCE);
+	ck_assert_int_eq(ratbag_button_macro_get_repeat_count(m), 0);
+
+	/* set to count */
+	ratbag_button_macro_set_repeat(m, RATBAG_MACRO_REPEAT_COUNT, 10);
+	ck_assert_int_eq(ratbag_button_macro_get_repeat_mode(m),
+			 RATBAG_MACRO_REPEAT_COUNT);
+	ck_assert_int_eq(ratbag_button_macro_get_repeat_count(m), 10);
+
+	/* set to while held */
+	ratbag_button_macro_set_repeat(m, RATBAG_MACRO_REPEAT_WHILE_HELD, 0);
+	ck_assert_int_eq(ratbag_button_macro_get_repeat_mode(m),
+			 RATBAG_MACRO_REPEAT_WHILE_HELD);
+
+	/* set to until button pressed */
+	ratbag_button_macro_set_repeat(m, RATBAG_MACRO_REPEAT_UNTIL_BUTTON_PRESSED, 0);
+	ck_assert_int_eq(ratbag_button_macro_get_repeat_mode(m),
+			 RATBAG_MACRO_REPEAT_UNTIL_BUTTON_PRESSED);
+
+	ratbag_button_macro_unref(m);
+}
+END_TEST
+
 static Suite *
 test_context_suite(void)
 {
@@ -1456,6 +1629,11 @@ test_context_suite(void)
 	tcase_add_test(tc, device_buttons_dpi_lock_set);
 	tcase_add_test(tc, device_buttons_dpi_lock_has_action_type);
 	tcase_add_test(tc, device_buttons_dpi_lock_wrong_type);
+	tcase_add_test(tc, device_macro_repeat_default);
+	tcase_add_test(tc, device_macro_repeat_count);
+	tcase_add_test(tc, device_macro_repeat_while_held);
+	tcase_add_test(tc, device_macro_repeat_until_button_pressed);
+	tcase_add_test(tc, device_macro_repeat_set);
 	suite_add_tcase(s, tc);
 
 	tc = tcase_create("led");

--- a/tools/ratbagc.py.in
+++ b/tools/ratbagc.py.in
@@ -461,6 +461,19 @@ class RatbagdProfile(metaclass=MetaRatbag):
         libratbag.ratbag_profile_set_motion_sync(self._profile, value)
 
     @property
+    def ripple_control(self):
+        """The ripple control option."""
+        return libratbag.ratbag_profile_get_ripple_control(self._profile)
+
+    @ripple_control.setter
+    def ripple_control(self, value):
+        """Set the ripple control option.
+
+        @param value The ripple control option as bool
+        """
+        libratbag.ratbag_profile_set_ripple_control(self._profile, value)
+
+    @property
     def debounce(self):
         """The debounce time in ms."""
         return libratbag.ratbag_profile_get_debounce(self._profile)

--- a/tools/ratbagc.py.in
+++ b/tools/ratbagc.py.in
@@ -333,6 +333,14 @@ class RatbagdDevice(metaclass=MetaRatbag):
         """
         return libratbag.ratbag_device_commit(self._device)
 
+    def reset(self):
+        """Instructs the device to perform a factory reset.
+
+        Not all devices support hardware reset. A Resync signal is always
+        emitted after the reset completes.
+        """
+        return libratbag.ratbag_device_reset(self._device)
+
 
 class RatbagdProfile(metaclass=MetaRatbag):
     """Represents a ratbagd profile."""

--- a/tools/ratbagc.py.in
+++ b/tools/ratbagc.py.in
@@ -468,6 +468,49 @@ class RatbagdProfile(metaclass=MetaRatbag):
         return values[:n]
 
     @property
+<<<<<<< Updated upstream
+=======
+    def lod(self):
+        """The lift off distance in mm."""
+        return libratbag.ratbag_profile_get_lod(self._profile)
+
+    @lod.setter
+    def lod(self, value):
+        """Set the lift off distance in mm.
+
+        @param value The new lift off distance, as float
+        """
+        libratbag.ratbag_profile_set_lod(self._profile, value)
+
+    @property
+    def lods(self):
+        """The list of supported lift off distances"""
+        values = [0.0 for i in range(300)]
+        n = libratbag.ratbag_profile_get_lod_list(self._profile, values)
+        return values[:n]
+
+    @property
+    def autosleep(self):
+        """The autosleep timeout in seconds."""
+        return libratbag.ratbag_profile_get_autosleep(self._profile)
+
+    @autosleep.setter
+    def autosleep(self, value):
+        """Set the autosleep timeout in seconds.
+
+        @param value The new autosleep timeout, as int
+        """
+        libratbag.ratbag_profile_set_autosleep(self._profile, value)
+
+    @property
+    def autosleeps(self):
+        """The list of supported autosleep timeouts"""
+        values = [0 for i in range(300)]
+        n = libratbag.ratbag_profile_get_autosleep_list(self._profile, values)
+        return values[:n]
+
+    @property
+>>>>>>> Stashed changes
     def resolutions(self):
         """A list of RatbagdResolution objects with this profile's resolutions.
         Note that the list of resolutions differs between profiles but the number

--- a/tools/ratbagc.py.in
+++ b/tools/ratbagc.py.in
@@ -448,6 +448,19 @@ class RatbagdProfile(metaclass=MetaRatbag):
         libratbag.ratbag_profile_set_angle_snapping(self._profile, value)
 
     @property
+    def motion_sync(self):
+        """The motion sync option."""
+        return libratbag.ratbag_profile_get_motion_sync(self._profile)
+
+    @motion_sync.setter
+    def motion_sync(self, value):
+        """Set the motion sync option.
+
+        @param value The motion sync option as bool
+        """
+        libratbag.ratbag_profile_set_motion_sync(self._profile, value)
+
+    @property
     def debounce(self):
         """The debounce time in ms."""
         return libratbag.ratbag_profile_get_debounce(self._profile)

--- a/tools/ratbagc.py.in
+++ b/tools/ratbagc.py.in
@@ -718,6 +718,12 @@ class RatbagdButton(metaclass=MetaRatbag):
         KEY_RELEASE = libratbag.RATBAG_MACRO_EVENT_KEY_RELEASED
         WAIT = libratbag.RATBAG_MACRO_EVENT_WAIT
 
+    class RepeatMode(IntEnum):
+        ONCE = libratbag.RATBAG_MACRO_REPEAT_ONCE
+        COUNT = libratbag.RATBAG_MACRO_REPEAT_COUNT
+        WHILE_HELD = libratbag.RATBAG_MACRO_REPEAT_WHILE_HELD
+        UNTIL_BUTTON_PRESSED = libratbag.RATBAG_MACRO_REPEAT_UNTIL_BUTTON_PRESSED
+
     """A table mapping a button's index to its usual function as defined by X
     and the common desktop environments."""
     BUTTON_DESCRIPTION = {

--- a/tools/ratbagc.py.in
+++ b/tools/ratbagc.py.in
@@ -494,8 +494,46 @@ class RatbagdProfile(metaclass=MetaRatbag):
         return values[:n]
 
     @property
-<<<<<<< Updated upstream
-=======
+    def autosleep(self):
+        """The autosleep timeout in seconds."""
+        return libratbag.ratbag_profile_get_autosleep(self._profile)
+
+    @autosleep.setter
+    def autosleep(self, value):
+        """Set the autosleep timeout in seconds.
+
+        @param value The new autosleep timeout, as int
+        """
+        libratbag.ratbag_profile_set_autosleep(self._profile, value)
+
+    @property
+    def autosleeps(self):
+        """The list of supported autosleep timeouts"""
+        values = [0 for i in range(300)]
+        n = libratbag.ratbag_profile_get_autosleep_list(self._profile, values)
+        return values[:n]
+
+    @property
+    def autosleep(self):
+        """The autosleep timeout in seconds."""
+        return libratbag.ratbag_profile_get_autosleep(self._profile)
+
+    @autosleep.setter
+    def autosleep(self, value):
+        """Set the autosleep timeout in seconds.
+
+        @param value The new autosleep timeout, as int
+        """
+        libratbag.ratbag_profile_set_autosleep(self._profile, value)
+
+    @property
+    def autosleeps(self):
+        """The list of supported autosleep timeouts"""
+        values = [0 for i in range(300)]
+        n = libratbag.ratbag_profile_get_autosleep_list(self._profile, values)
+        return values[:n]
+
+    @property
     def lod(self):
         """The lift off distance in mm."""
         return libratbag.ratbag_profile_get_lod(self._profile)
@@ -536,7 +574,6 @@ class RatbagdProfile(metaclass=MetaRatbag):
         return values[:n]
 
     @property
->>>>>>> Stashed changes
     def resolutions(self):
         """A list of RatbagdResolution objects with this profile's resolutions.
         Note that the list of resolutions differs between profiles but the number

--- a/tools/ratbagc.py.in
+++ b/tools/ratbagc.py.in
@@ -684,6 +684,7 @@ class RatbagdButton(metaclass=MetaRatbag):
         SPECIAL = libratbag.RATBAG_BUTTON_ACTION_TYPE_SPECIAL
         KEY = libratbag.RATBAG_BUTTON_ACTION_TYPE_KEY
         MACRO = libratbag.RATBAG_BUTTON_ACTION_TYPE_MACRO
+        DPI_LOCK = libratbag.RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK
 
     class ActionSpecial(IntEnum):
         INVALID = libratbag.RATBAG_BUTTON_ACTION_SPECIAL_INVALID
@@ -824,7 +825,7 @@ class RatbagdButton(metaclass=MetaRatbag):
     def action_type(self):
         """An enum describing the action type of the button. One of
         ActionType.NONE, ActionType.BUTTON, ActionType.SPECIAL,
-        ActionType.MACRO. This decides which
+        ActionType.MACRO, ActionType.DPI_LOCK. This decides which
         *Mapping property has a value.
         """
         return libratbag.ratbag_button_get_action_type(self._button)
@@ -838,6 +839,7 @@ class RatbagdButton(metaclass=MetaRatbag):
             RatbagdButton.ActionType.SPECIAL,
             RatbagdButton.ActionType.KEY,
             RatbagdButton.ActionType.MACRO,
+            RatbagdButton.ActionType.DPI_LOCK,
         )
 
         return [

--- a/tools/ratbagc.py.in
+++ b/tools/ratbagc.py.in
@@ -522,26 +522,6 @@ class RatbagdProfile(metaclass=MetaRatbag):
         return values[:n]
 
     @property
-    def autosleep(self):
-        """The autosleep timeout in seconds."""
-        return libratbag.ratbag_profile_get_autosleep(self._profile)
-
-    @autosleep.setter
-    def autosleep(self, value):
-        """Set the autosleep timeout in seconds.
-
-        @param value The new autosleep timeout, as int
-        """
-        libratbag.ratbag_profile_set_autosleep(self._profile, value)
-
-    @property
-    def autosleeps(self):
-        """The list of supported autosleep timeouts"""
-        values = [0 for i in range(300)]
-        n = libratbag.ratbag_profile_get_autosleep_list(self._profile, values)
-        return values[:n]
-
-    @property
     def lod(self):
         """The lift off distance in mm."""
         return libratbag.ratbag_profile_get_lod(self._profile)
@@ -559,26 +539,6 @@ class RatbagdProfile(metaclass=MetaRatbag):
         """The list of supported lift off distances"""
         values = [0.0 for i in range(300)]
         n = libratbag.ratbag_profile_get_lod_list(self._profile, values)
-        return values[:n]
-
-    @property
-    def autosleep(self):
-        """The autosleep timeout in seconds."""
-        return libratbag.ratbag_profile_get_autosleep(self._profile)
-
-    @autosleep.setter
-    def autosleep(self, value):
-        """Set the autosleep timeout in seconds.
-
-        @param value The new autosleep timeout, as int
-        """
-        libratbag.ratbag_profile_set_autosleep(self._profile, value)
-
-    @property
-    def autosleeps(self):
-        """The list of supported autosleep timeouts"""
-        values = [0 for i in range(300)]
-        n = libratbag.ratbag_profile_get_autosleep_list(self._profile, values)
         return values[:n]
 
     @property

--- a/tools/ratbagctl.body.py.in
+++ b/tools/ratbagctl.body.py.in
@@ -714,6 +714,11 @@ def func_device_name_get(ratbagd: Ratbagd, args: argparse.Namespace) -> None:
     print(device.name)
 
 
+def func_device_reset(ratbagd: Ratbagd, args: argparse.Namespace) -> None:
+    device = find_device(ratbagd, args)
+    device.reset()
+
+
 ################################################################################
 # these are definitions to be reused in the dict that defines our language
 
@@ -836,6 +841,13 @@ parser_def: List[RatbagParserSchemaElement] = [
         name: "name",
         help_str: "Returns the device name",
         func: func_device_name_get,
+    },
+    {
+        of_type: command,
+        name: "reset",
+        help_str: "Perform a factory reset on the device",
+        func: func_device_reset,
+        group: "Device",
     },
     {
         of_type: switch,

--- a/tools/ratbagctl.body.py.in
+++ b/tools/ratbagctl.body.py.in
@@ -204,7 +204,16 @@ def print_button(
         key_name = evcode_to_str(button.key)
         print(f"{header}key '{key_name}'")
     elif button.action_type == RatbagdButton.ActionType.MACRO:
-        print(f"{header}macro '{str(button.macro)}'")
+        repeat = button.macro_repeat
+        if repeat and repeat[0] == RatbagdButton.RepeatMode.COUNT:
+            repeat_str = f" (repeat: {repeat[1]}x)"
+        elif repeat and repeat[0] == RatbagdButton.RepeatMode.WHILE_HELD:
+            repeat_str = " (repeat: while held)"
+        elif repeat and repeat[0] == RatbagdButton.RepeatMode.UNTIL_BUTTON_PRESSED:
+            repeat_str = " (repeat: until button pressed)"
+        else:
+            repeat_str = ""
+        print(f"{header}macro '{str(button.macro)}'{repeat_str}")
     elif button.action_type == RatbagdButton.ActionType.DPI_LOCK:
         x, y = button.dpi_lock
         if x == y:
@@ -431,7 +440,16 @@ def func_button_action_set_macro(ratbagd: Ratbagd, args: argparse.Namespace) -> 
     if button.ActionType.MACRO not in button.action_types:
         raise RatbagCapabilityError("assigning a macro is not supported on this device")
 
-    macro_keys = args.target_macro
+    macro_keys = list(args.target_macro)
+
+    # Extract repeat:<mode> token if present (e.g. repeat:3, repeat:held)
+    repeat_arg = None
+    for i, s in enumerate(macro_keys):
+        if s.lower().startswith("repeat:"):
+            repeat_arg = s.split(":", 1)[1]
+            macro_keys.pop(i)
+            break
+
     macro = RatbagdMacro()
     for s in macro_keys:
         is_press = True
@@ -461,6 +479,18 @@ def func_button_action_set_macro(ratbagd: Ratbagd, args: argparse.Namespace) -> 
                 macro.append(RatbagdButton.Macro.KEY_RELEASE, code)
 
     button.macro = macro
+
+    if repeat_arg is not None:
+        if repeat_arg == "held":
+            button.macro_repeat = (RatbagdButton.RepeatMode.WHILE_HELD, 0)
+        elif repeat_arg == "button-pressed":
+            button.macro_repeat = (
+                RatbagdButton.RepeatMode.UNTIL_BUTTON_PRESSED,
+                0,
+            )
+        else:
+            button.macro_repeat = (RatbagdButton.RepeatMode.COUNT, int(repeat_arg))
+
     commit(device, args)
 
 
@@ -1509,7 +1539,12 @@ active profile if none is given.""",
         KEY_A                   Press and release 'a'
         +KEY_A                  Press 'a'
         -KEY_A                  Release 'a'
-        t300                    Wait 300ms""",
+        t300                    Wait 300ms
+
+  Repeat:
+        repeat:N                Repeat the macro N times
+        repeat:held             Repeat while the button is held
+        repeat:button-pressed   Repeat until another button is pressed""",
                                     pos_args: [
                                         {
                                             of_type: argument,

--- a/tools/ratbagctl.body.py.in
+++ b/tools/ratbagctl.body.py.in
@@ -205,6 +205,12 @@ def print_button(
         print(f"{header}key '{key_name}'")
     elif button.action_type == RatbagdButton.ActionType.MACRO:
         print(f"{header}macro '{str(button.macro)}'")
+    elif button.action_type == RatbagdButton.ActionType.DPI_LOCK:
+        x, y = button.dpi_lock
+        if x == y:
+            print(f"{header}dpi-lock {x}")
+        else:
+            print(f"{header}dpi-lock {x}x{y}")
     elif button.action_type == RatbagdButton.ActionType.NONE:
         print(f"{header}none")
     else:
@@ -455,6 +461,21 @@ def func_button_action_set_macro(ratbagd: Ratbagd, args: argparse.Namespace) -> 
                 macro.append(RatbagdButton.Macro.KEY_RELEASE, code)
 
     button.macro = macro
+    commit(device, args)
+
+
+def func_button_action_set_dpi_lock(ratbagd: Ratbagd, args: argparse.Namespace) -> None:
+    button, _profile, device = find_button(ratbagd, args)
+    if button.ActionType.DPI_LOCK not in button.action_types:
+        raise RatbagCapabilityError("DPI lock is not supported on this device")
+
+    dpi_str = args.target_dpi
+    if "x" in dpi_str.lower():
+        x, y = dpi_str.lower().split("x", 1)
+        button.dpi_lock = (int(x), int(y))
+    else:
+        dpi = int(dpi_str)
+        button.dpi_lock = (dpi, dpi)
     commit(device, args)
 
 
@@ -1499,6 +1520,20 @@ active profile if none is given.""",
                                         },
                                     ],
                                     func: func_button_action_set_macro,
+                                },
+                                {
+                                    of_type: command,
+                                    name: "dpi-lock",
+                                    help_str: "Set the button to lock DPI while held",
+                                    pos_args: [
+                                        {
+                                            of_type: argument,
+                                            name: "target_dpi",
+                                            metavar: "DPI",
+                                            help_str: "DPI value (e.g. 400 or 400x800)",
+                                        },
+                                    ],
+                                    func: func_button_action_set_dpi_lock,
                                 },
                                 {
                                     of_type: command,

--- a/tools/ratbagctl.body.py.in
+++ b/tools/ratbagctl.body.py.in
@@ -266,6 +266,8 @@ def print_profile(device: RatbagdDevice, profile: RatbagdProfile, level: int) ->
             print(" " * level + f"Debounce time: {profile.debounce}ms")
         if profile.lod != -1:
             print(" " * level + f"Lift off distance: {profile.lod}mm")
+        if profile.autosleep != -1:
+            print(" " * level + f"Autosleep: {profile.autosleep}s")
         if profile.buttons:
             for button in profile.buttons:
                 print_button(device, profile, button, level)
@@ -575,6 +577,25 @@ def func_lod_get_all(ratbagd: Ratbagd, args: argparse.Namespace) -> None:
 def func_lod_set(ratbagd: Ratbagd, args: argparse.Namespace) -> None:
     profile, device = find_profile(ratbagd, args)
     profile.lod = args.lod_n
+    commit(device, args)
+
+
+def func_autosleep_get(ratbagd: Ratbagd, args: argparse.Namespace) -> None:
+    profile, _device = find_profile(ratbagd, args)
+    if profile.autosleep == -1:
+        return
+    print(profile.autosleep)
+
+
+def func_autosleep_get_all(ratbagd: Ratbagd, args: argparse.Namespace) -> None:
+    profile, _device = find_profile(ratbagd, args)
+    values = profile.autosleeps
+    print(" ".join([str(x) for x in values]))
+
+
+def func_autosleep_set(ratbagd: Ratbagd, args: argparse.Namespace) -> None:
+    profile, device = find_profile(ratbagd, args)
+    profile.autosleep = args.autosleep_n
     commit(device, args)
 
 
@@ -926,6 +947,10 @@ parser_def: List[RatbagParserSchemaElement] = [
                 {
                     of_type: link,
                     dest: "lod",
+                },
+                {
+                    of_type: link,
+                    dest: "autosleep",
                 },
                 {
                     of_type: link,
@@ -1308,6 +1333,44 @@ LOD commands work on the given profile, or on the active profile if none is give
                     },
                 ],
                 func: func_lod_set,
+            },
+        ],
+    },
+    {
+        of_type: switch,
+        name: "autosleep",
+        help_str: """Access autosleep timeout information
+
+Autosleep commands work on the given profile, or on the active profile if none is given.""",
+        tag: "autosleep",
+        group: "Autosleep",
+        switch: [
+            {
+                of_type: command,
+                name: "get",
+                help_str: "Show current autosleep timeout",
+                func: func_autosleep_get,
+            },
+            {
+                of_type: command,
+                name: "get-all",
+                help_str: "Show all available autosleep timeouts",
+                func: func_autosleep_get_all,
+            },
+            {
+                of_type: command,
+                name: "set",
+                help_str: "Set the current autosleep timeout to N",
+                pos_args: [
+                    {
+                        of_type: argument,
+                        name: "autosleep_n",
+                        metavar: "N",
+                        help_str: "The autosleep timeout in seconds to set as current",
+                        arg_type: int,
+                    },
+                ],
+                func: func_autosleep_set,
             },
         ],
     },

--- a/tools/ratbagctl.body.py.in
+++ b/tools/ratbagctl.body.py.in
@@ -260,6 +260,8 @@ def print_profile(device: RatbagdDevice, profile: RatbagdProfile, level: int) ->
             print(" " * level + f"Angle Snapping: {bool(profile.angle_snapping)}")
         if profile.motion_sync != -1:
             print(" " * level + f"Motion Sync: {bool(profile.motion_sync)}")
+        if profile.ripple_control != -1:
+            print(" " * level + f"Ripple Control: {bool(profile.ripple_control)}")
         if profile.debounce != -1:
             print(" " * level + f"Debounce time: {profile.debounce}ms")
         if profile.lod != -1:
@@ -522,6 +524,19 @@ def func_motion_sync_get(ratbagd: Ratbagd, args: argparse.Namespace) -> None:
 def func_motion_sync_set(ratbagd: Ratbagd, args: argparse.Namespace) -> None:
     profile, device = find_profile(ratbagd, args)
     profile.motion_sync = 1 if args.motion_sync_n else 0
+    commit(device, args)
+
+
+def func_ripple_control_get(ratbagd: Ratbagd, args: argparse.Namespace) -> None:
+    profile, _device = find_profile(ratbagd, args)
+    if profile.ripple_control == -1:
+        return
+    print(bool(profile.ripple_control))
+
+
+def func_ripple_control_set(ratbagd: Ratbagd, args: argparse.Namespace) -> None:
+    profile, device = find_profile(ratbagd, args)
+    profile.ripple_control = 1 if args.ripple_control_n else 0
     commit(device, args)
 
 
@@ -1185,6 +1200,38 @@ Motion sync commands work on the given profile, or on the active profile if none
                     },
                 ],
                 func: func_motion_sync_set,
+            },
+        ],
+    },
+    {
+        of_type: switch,
+        name: "ripple_control",
+        help_str: """Ripple control information
+
+Ripple control commands work on the given profile, or on the active profile if none is given.""",
+        tag: "ripple_control",
+        group: "RippleControl",
+        switch: [
+            {
+                of_type: command,
+                name: "get",
+                help_str: "Show current ripple control",
+                func: func_ripple_control_get,
+            },
+            {
+                of_type: command,
+                name: "set",
+                help_str: "Set the current ripple control to N",
+                pos_args: [
+                    {
+                        of_type: argument,
+                        name: "ripple_control_n",
+                        metavar: "N",
+                        help_str: "The ripple control to set as current",
+                        arg_type: int,
+                    },
+                ],
+                func: func_ripple_control_set,
             },
         ],
     },

--- a/tools/ratbagctl.body.py.in
+++ b/tools/ratbagctl.body.py.in
@@ -258,6 +258,8 @@ def print_profile(device: RatbagdDevice, profile: RatbagdProfile, level: int) ->
                 print_resolution(device, profile, resolution, level + 2)
         if profile.angle_snapping != -1:
             print(" " * level + f"Angle Snapping: {bool(profile.angle_snapping)}")
+        if profile.motion_sync != -1:
+            print(" " * level + f"Motion Sync: {bool(profile.motion_sync)}")
         if profile.debounce != -1:
             print(" " * level + f"Debounce time: {profile.debounce}ms")
         if profile.lod != -1:
@@ -507,6 +509,19 @@ def func_angle_snapping_get(ratbagd: Ratbagd, args: argparse.Namespace) -> None:
 def func_angle_snapping_set(ratbagd: Ratbagd, args: argparse.Namespace) -> None:
     profile, device = find_profile(ratbagd, args)
     profile.angle_snapping = 1 if args.angle_snapping_n else 0
+    commit(device, args)
+
+
+def func_motion_sync_get(ratbagd: Ratbagd, args: argparse.Namespace) -> None:
+    profile, _device = find_profile(ratbagd, args)
+    if profile.motion_sync == -1:
+        return
+    print(bool(profile.motion_sync))
+
+
+def func_motion_sync_set(ratbagd: Ratbagd, args: argparse.Namespace) -> None:
+    profile, device = find_profile(ratbagd, args)
+    profile.motion_sync = 1 if args.motion_sync_n else 0
     commit(device, args)
 
 
@@ -1138,6 +1153,38 @@ Angle snapping commands work on the given profile, or on the active profile if n
                     },
                 ],
                 func: func_angle_snapping_set,
+            },
+        ],
+    },
+    {
+        of_type: switch,
+        name: "motion_sync",
+        help_str: """Motion sync information
+
+Motion sync commands work on the given profile, or on the active profile if none is given.""",
+        tag: "motion_sync",
+        group: "MotionSync",
+        switch: [
+            {
+                of_type: command,
+                name: "get",
+                help_str: "Show current motion sync",
+                func: func_motion_sync_get,
+            },
+            {
+                of_type: command,
+                name: "set",
+                help_str: "Set the current motion sync to N",
+                pos_args: [
+                    {
+                        of_type: argument,
+                        name: "motion_sync_n",
+                        metavar: "N",
+                        help_str: "The motion sync to set as current",
+                        arg_type: int,
+                    },
+                ],
+                func: func_motion_sync_set,
             },
         ],
     },

--- a/tools/ratbagctl.body.py.in
+++ b/tools/ratbagctl.body.py.in
@@ -260,6 +260,8 @@ def print_profile(device: RatbagdDevice, profile: RatbagdProfile, level: int) ->
             print(" " * level + f"Angle Snapping: {bool(profile.angle_snapping)}")
         if profile.debounce != -1:
             print(" " * level + f"Debounce time: {profile.debounce}ms")
+        if profile.lod != -1:
+            print(" " * level + f"Lift off distance: {profile.lod}mm")
         if profile.buttons:
             for button in profile.buttons:
                 print_button(device, profile, button, level)
@@ -524,6 +526,25 @@ def func_debounce_get_all(ratbagd: Ratbagd, args: argparse.Namespace) -> None:
 def func_debounce_set(ratbagd: Ratbagd, args: argparse.Namespace) -> None:
     profile, device = find_profile(ratbagd, args)
     profile.debounce = args.debounce_n
+    commit(device, args)
+
+
+def func_lod_get(ratbagd: Ratbagd, args: argparse.Namespace) -> None:
+    profile, _device = find_profile(ratbagd, args)
+    if profile.lod == -1:
+        return
+    print(profile.lod)
+
+
+def func_lod_get_all(ratbagd: Ratbagd, args: argparse.Namespace) -> None:
+    profile, _device = find_profile(ratbagd, args)
+    values = profile.lods
+    print(" ".join([str(x) for x in values]))
+
+
+def func_lod_set(ratbagd: Ratbagd, args: argparse.Namespace) -> None:
+    profile, device = find_profile(ratbagd, args)
+    profile.lod = args.lod_n
     commit(device, args)
 
 
@@ -874,6 +895,10 @@ parser_def: List[RatbagParserSchemaElement] = [
                 },
                 {
                     of_type: link,
+                    dest: "lod",
+                },
+                {
+                    of_type: link,
                     dest: "button",
                 },
                 {
@@ -1151,6 +1176,44 @@ Debounce commands work on the given profile, or on the active profile if none is
                     },
                 ],
                 func: func_debounce_set,
+            },
+        ],
+    },
+    {
+        of_type: switch,
+        name: "lod",
+        help_str: """Access lift off distance information
+
+LOD commands work on the given profile, or on the active profile if none is given.""",
+        tag: "lod",
+        group: "Lift Off Distance",
+        switch: [
+            {
+                of_type: command,
+                name: "get",
+                help_str: "Show current lift off distance",
+                func: func_lod_get,
+            },
+            {
+                of_type: command,
+                name: "get-all",
+                help_str: "Show all available lift off distances",
+                func: func_lod_get_all,
+            },
+            {
+                of_type: command,
+                name: "set",
+                help_str: "Set the current lift off distance to N",
+                pos_args: [
+                    {
+                        of_type: argument,
+                        name: "lod_n",
+                        metavar: "N",
+                        help_str: "The lift off distance to set as current",
+                        arg_type: float,
+                    },
+                ],
+                func: func_lod_set,
             },
         ],
     },

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -443,6 +443,7 @@ class RatbagdProfile(_RatbagdDBus):
         self._ripple_control = self._get_dbus_property("RippleControl")
         self._debounce = self._get_dbus_property("Debounce")
         self._lod = self._get_dbus_property("Lod")
+        self._autosleep = self._get_dbus_property("Autosleep")
         self._dirty = self._get_dbus_property("IsDirty")
         self._disabled = self._get_dbus_property("Disabled")
         self._report_rate = self._get_dbus_property("ReportRate")
@@ -520,6 +521,16 @@ class RatbagdProfile(_RatbagdDBus):
             if lod != self._lod:
                 self._lod = lod
                 self.notify("lod")
+
+        try:
+            autosleep = changed_props["Autosleep"]
+        except KeyError:
+            # Different property changed, skip.
+            pass
+        else:
+            if autosleep != self._autosleep:
+                self._autosleep = autosleep
+                self.notify("autosleep")
 
         try:
             disabled = changed_props["Disabled"]
@@ -697,6 +708,24 @@ class RatbagdProfile(_RatbagdDBus):
     def lods(self):
         """The list of supported lift off distances"""
         return self._get_dbus_property("Lods") or []
+
+    @GObject.Property
+    def autosleep(self):
+        """The autosleep timeout in seconds."""
+        return self._autosleep
+
+    @autosleep.setter
+    def autosleep(self, value):
+        """Set the autosleep timeout in seconds.
+
+        @param value The autosleep timeout, as int
+        """
+        self._set_dbus_property("Autosleep", "i", value)
+
+    @GObject.Property
+    def autosleeps(self):
+        """The list of supported autosleep timeouts"""
+        return self._get_dbus_property("Autosleeps") or []
 
     @GObject.Property
     def resolutions(self):

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -440,6 +440,7 @@ class RatbagdProfile(_RatbagdDBus):
         self._active = self._get_dbus_property("IsActive")
         self._angle_snapping = self._get_dbus_property("AngleSnapping")
         self._debounce = self._get_dbus_property("Debounce")
+        self._lod = self._get_dbus_property("Lod")
         self._dirty = self._get_dbus_property("IsDirty")
         self._disabled = self._get_dbus_property("Disabled")
         self._report_rate = self._get_dbus_property("ReportRate")
@@ -487,6 +488,16 @@ class RatbagdProfile(_RatbagdDBus):
             if debounce != self._debounce:
                 self._debounce = debounce
                 self.notify("debounce")
+
+        try:
+            lod = changed_props["Lod"]
+        except KeyError:
+            # Different property changed, skip.
+            pass
+        else:
+            if lod != self._lod:
+                self._lod = lod
+                self.notify("lod")
 
         try:
             disabled = changed_props["Disabled"]
@@ -620,6 +631,24 @@ class RatbagdProfile(_RatbagdDBus):
     def debounces(self):
         """The list of supported debounce times"""
         return self._get_dbus_property("Debounces") or []
+
+    @GObject.Property
+    def lod(self):
+        """The lift off distance in mm."""
+        return self._lod
+
+    @lod.setter
+    def lod(self, value):
+        """Set the lift off distance in mm.
+
+        @param value The lift off distance, as float
+        """
+        self._set_dbus_property("Lod", "d", value)
+
+    @GObject.Property
+    def lods(self):
+        """The list of supported lift off distances"""
+        return self._get_dbus_property("Lods") or []
 
     @GObject.Property
     def resolutions(self):

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -426,6 +426,15 @@ class RatbagdDevice(_RatbagdDBus):
         """
         self._dbus_call("Commit", "")
 
+    def reset(self):
+        """Instructs the device to perform a factory reset.
+
+        This is implemented asynchronously inside ratbagd. A Resync signal
+        is always emitted after the reset completes, regardless of success
+        or failure. Not all devices support hardware reset.
+        """
+        self._dbus_call("Reset", "")
+
 
 class RatbagdProfile(_RatbagdDBus):
     """Represents a ratbagd profile."""

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -966,6 +966,12 @@ class RatbagdButton(_RatbagdDBus):
         KEY_RELEASE = 2
         WAIT = 3
 
+    class RepeatMode(IntEnum):
+        ONCE = 0
+        COUNT = 1
+        WHILE_HELD = 2
+        UNTIL_BUTTON_PRESSED = 3
+
     """A table mapping a button's index to its usual function as defined by X
     and the common desktop environments."""
     BUTTON_DESCRIPTION = {
@@ -1056,6 +1062,24 @@ class RatbagdButton(_RatbagdDBus):
         self._set_dbus_property(
             "Mapping", "(uv)", (RatbagdButton.ActionType.MACRO, macro)
         )
+
+    @GObject.Property
+    def macro_repeat(self):
+        """A tuple (mode, count) of the macro repeat settings, or None
+        if not mapped to macro."""
+        type, _value = self._mapping()
+        if type != RatbagdButton.ActionType.MACRO:
+            return None
+        return self._get_dbus_property("MacroRepeat")
+
+    @macro_repeat.setter
+    def macro_repeat(self, value):
+        """Set the macro repeat mode and count.
+
+        @param value A tuple (mode, count).
+        """
+        value = GLib.Variant("(uu)", value)
+        self._set_dbus_property("MacroRepeat", "(uu)", value)
 
     @GObject.Property
     def special(self):

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -440,6 +440,7 @@ class RatbagdProfile(_RatbagdDBus):
         self._active = self._get_dbus_property("IsActive")
         self._angle_snapping = self._get_dbus_property("AngleSnapping")
         self._motion_sync = self._get_dbus_property("MotionSync")
+        self._ripple_control = self._get_dbus_property("RippleControl")
         self._debounce = self._get_dbus_property("Debounce")
         self._lod = self._get_dbus_property("Lod")
         self._dirty = self._get_dbus_property("IsDirty")
@@ -489,6 +490,16 @@ class RatbagdProfile(_RatbagdDBus):
             if motion_sync != self._motion_sync:
                 self._motion_sync = motion_sync
                 self.notify("motion-sync")
+
+        try:
+            ripple_control = changed_props["RippleControl"]
+        except KeyError:
+            # Different property changed, skip.
+            pass
+        else:
+            if ripple_control != self._ripple_control:
+                self._ripple_control = ripple_control
+                self.notify("ripple-control")
 
         try:
             debounce = changed_props["Debounce"]
@@ -637,6 +648,19 @@ class RatbagdProfile(_RatbagdDBus):
         @param value The motion sync option as int
         """
         self._set_dbus_property("MotionSync", "i", value)
+
+    @GObject.Property
+    def ripple_control(self):
+        """The ripple control option."""
+        return self._ripple_control
+
+    @ripple_control.setter
+    def ripple_control(self, value):
+        """Set the ripple control option.
+
+        @param value The ripple control option as int
+        """
+        self._set_dbus_property("RippleControl", "i", value)
 
     @GObject.Property
     def debounce(self):

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -936,6 +936,7 @@ class RatbagdButton(_RatbagdDBus):
         SPECIAL = 2
         KEY = 3
         MACRO = 4
+        DPI_LOCK = 5
 
     class ActionSpecial(IntEnum):
         INVALID = -1
@@ -1089,10 +1090,30 @@ class RatbagdButton(_RatbagdDBus):
         self._set_dbus_property("Mapping", "(uv)", (RatbagdButton.ActionType.KEY, key))
 
     @GObject.Property
+    def dpi_lock(self):
+        """A tuple (x, y) of the DPI lock target values, or None if not
+        mapped to DPI lock."""
+        type, value = self._mapping()
+        if type != RatbagdButton.ActionType.DPI_LOCK:
+            return None
+        return value
+
+    @dpi_lock.setter
+    def dpi_lock(self, dpi):
+        """Set the DPI lock target.
+
+        @param dpi A tuple (x, y) of DPI values.
+        """
+        dpi = GLib.Variant("(uu)", dpi)
+        self._set_dbus_property(
+            "Mapping", "(uv)", (RatbagdButton.ActionType.DPI_LOCK, dpi)
+        )
+
+    @GObject.Property
     def action_type(self):
         """An enum describing the action type of the button. One of
         ActionType.NONE, ActionType.BUTTON, ActionType.SPECIAL,
-        ActionType.MACRO. This decides which
+        ActionType.MACRO, ActionType.DPI_LOCK. This decides which
         *Mapping property has a value.
         """
         type, mapping = self._mapping()

--- a/tools/ratbagd.py
+++ b/tools/ratbagd.py
@@ -439,6 +439,7 @@ class RatbagdProfile(_RatbagdDBus):
         super().__init__("Profile", object_path)
         self._active = self._get_dbus_property("IsActive")
         self._angle_snapping = self._get_dbus_property("AngleSnapping")
+        self._motion_sync = self._get_dbus_property("MotionSync")
         self._debounce = self._get_dbus_property("Debounce")
         self._lod = self._get_dbus_property("Lod")
         self._dirty = self._get_dbus_property("IsDirty")
@@ -478,6 +479,16 @@ class RatbagdProfile(_RatbagdDBus):
             if angle_snapping != self._angle_snapping:
                 self._angle_snapping = angle_snapping
                 self.notify("angle-snapping")
+
+        try:
+            motion_sync = changed_props["MotionSync"]
+        except KeyError:
+            # Different property changed, skip.
+            pass
+        else:
+            if motion_sync != self._motion_sync:
+                self._motion_sync = motion_sync
+                self.notify("motion-sync")
 
         try:
             debounce = changed_props["Debounce"]
@@ -613,6 +624,19 @@ class RatbagdProfile(_RatbagdDBus):
         @param value The angle snapping option as int
         """
         self._set_dbus_property("AngleSnapping", "i", value)
+
+    @GObject.Property
+    def motion_sync(self):
+        """The motion sync option."""
+        return self._motion_sync
+
+    @motion_sync.setter
+    def motion_sync(self, value):
+        """Set the motion sync option.
+
+        @param value The motion sync option as int
+        """
+        self._set_dbus_property("MotionSync", "i", value)
 
     @GObject.Property
     def debounce(self):

--- a/tools/shared.c
+++ b/tools/shared.c
@@ -206,6 +206,21 @@ button_action_macro_to_str(struct ratbag_button *button)
 }
 
 char *
+button_action_dpi_lock_to_str(struct ratbag_button *button)
+{
+	char str[96];
+	int x = ratbag_button_get_dpi_lock_x(button);
+	int y = ratbag_button_get_dpi_lock_y(button);
+
+	if (x == y)
+		sprintf_safe(str, "dpi-lock %d", x);
+	else
+		sprintf_safe(str, "dpi-lock %dx%d", x, y);
+
+	return strdup_safe(str);
+}
+
+char *
 button_action_to_str(struct ratbag_button *button)
 {
 	enum ratbag_button_action_type type;
@@ -218,6 +233,7 @@ button_action_to_str(struct ratbag_button *button)
 	case RATBAG_BUTTON_ACTION_TYPE_KEY:	str = button_action_key_to_str(button); break;
 	case RATBAG_BUTTON_ACTION_TYPE_SPECIAL:	str = strdup_safe(button_action_special_to_str(button)); break;
 	case RATBAG_BUTTON_ACTION_TYPE_MACRO:	str = button_action_macro_to_str(button); break;
+	case RATBAG_BUTTON_ACTION_TYPE_DPI_LOCK:	str = button_action_dpi_lock_to_str(button); break;
 	case RATBAG_BUTTON_ACTION_TYPE_NONE:	str = strdup_safe("none"); break;
 	default:
 		error("type %d unknown\n", type);

--- a/tools/shared.h
+++ b/tools/shared.h
@@ -76,6 +76,9 @@ button_action_to_str(struct ratbag_button *button);
 char *
 button_action_macro_to_str(struct ratbag_button *button);
 
+char *
+button_action_dpi_lock_to_str(struct ratbag_button *button);
+
 enum ratbag_button_action_special
 str_to_special_action(const char *str);
 


### PR DESCRIPTION
## Summary

Adds mouse features required for upcoming Pulsar mice support: lift-off distance (LOD), motion sync, ripple control, autosleep, debounce, and device reset.
Also includes lazy profile loading and asynchronous device event monitoring (unsolicited HID reports like DPI/profile/battery changes).

The Pulsar driver itself is not part of this MR.

## Changes

  - Lift-off distance, motion sync, ripple control, and autosleep support
  - Device reset capability
  - Dynamic debounce value allocation
  - Lazy profile loading
  - Async hidraw event monitoring with ratbagd event loop integration                                                                                                                                                               
  - Updated ratbagctl CLI, Python bindings, docs, and tests s, and tests

All features are opt-in and have no effect on existing drivers.