### PR TITLE
Update data/devices/logitech-g502-x-pluis.device 046d:c547

### DIFF
--- a/data/devices/logitech-g502-x-plus.device
+++ b/data/devices/logitech-g502-x-plus.device
@@ -1,8 +1,9 @@
 [Device]
 Name=Logitech G502 X PLUS
-DeviceMatch=usb:046d:4099;usb:046d:c095
+DeviceMatch=usb:046d:4099;usb:046d:c095;usb:046d:c547
 DeviceType=mouse
 Driver=hidpp20
 
 [Driver/hidpp20]
 Quirk=G502X_PLUS
+DeviceIndex=1


### PR DESCRIPTION
My g502 X Plus USB Receiver is being register with this ID: `046d:c547`:

```bash
lsusb | grep -i logit                           
Bus 003 Device 019: ID 046d:c547 Logitech, Inc. USB Receiver
```

Piper now shows it:
<img width="957" height="636" alt="image" src="https://github.com/user-attachments/assets/f675d0f6-798a-4c82-8c4e-b55018801ad7" />


Solves:
- https://github.com/libratbag/libratbag/issues/1805