### PR TITLE
Add Logitech G602 DPI settings support

### DIFF
--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -58,6 +58,7 @@
 #define HIDPP_CAP_ADJUSTABLE_REPORT_RATE_8060		(1 << 8)
 #define HIDPP_CAP_BATTERY_VOLTAGE_1001			(1 << 9)
 #define HIDPP_CAP_RGB_EFFECTS_8071			(1 << 10)
+#define HIDPP_CAP_G602_8080				(1 << 11)
 
 #define HIDPP_HIDDEN_FEATURE				(1 << 6)
 
@@ -71,6 +72,7 @@ struct hidpp20drv_data {
 	struct hidpp20_profiles *profiles;
 	struct hidpp20_led *leds;
 	union hidpp20_generic_led_zone_info led_infos;
+	union hidpp20_g602_onboard_profile *g602_profile;
 
 	unsigned int report_rates[4];
 	unsigned int num_report_rates;
@@ -907,7 +909,28 @@ hidpp20drv_read_resolution_dpi(struct ratbag_profile *profile)
 		return 0;
 	}
 
-	if (drv_data->capabilities & HIDPP_CAP_SWITCHABLE_RESOLUTION_2201) {
+	if (drv_data->capabilities & HIDPP_CAP_G602_8080) {
+		int active = hidpp20_g602_get_active_dpi_stage(drv_data->dev);
+		if (active < 0)
+			return active;
+		uint8_t uactive = active;
+
+		struct hidpp20_sensor *sensor;
+		sensor = &drv_data->sensors[0];
+
+		int num_of_dpis = (sensor->dpi_max - sensor->dpi_min) / sensor->dpi_steps + 1;
+		unsigned int *dpis = zalloc(sizeof(unsigned int) * num_of_dpis);
+		for (int i = 0; i < num_of_dpis; i++) {
+			dpis[i] = (i * sensor->dpi_steps) + sensor->dpi_min;
+		}
+		ratbag_profile_for_each_resolution(profile, res) {
+			int value = drv_data->g602_profile->profile.stages[res->index] * 250;
+			res->is_active = (res->index == uactive);
+			ratbag_resolution_set_resolution(res, value, value);
+			ratbag_resolution_set_dpi_list(res, dpis, num_of_dpis);
+		}
+		free(dpis);
+	} else if (drv_data->capabilities & HIDPP_CAP_SWITCHABLE_RESOLUTION_2201) {
 		rc = hidpp20drv_read_resolution_dpi_2201(device);
 		if (rc < 0)
 			return rc;
@@ -968,6 +991,20 @@ hidpp20drv_update_resolution_dpi_8100(struct ratbag_resolution *resolution,
 }
 
 static int
+hidpp20drv_update_resolution_dpi_8080(struct ratbag_resolution *resolution,
+				      int dpi_x, int dpi_y)
+{
+	struct ratbag_profile *profile = resolution->profile;
+	struct ratbag_device *device = profile->device;
+	struct hidpp20drv_data *drv_data = ratbag_get_drv_data(device);
+	int dpi = dpi_x; /* dpi_x == dpi_y if we don't have the individual resolution cap */
+
+	drv_data->g602_profile->profile.stages[resolution->index] = dpi / 250;
+
+	return RATBAG_SUCCESS;
+}
+
+static int
 hidpp20drv_update_resolution_dpi(struct ratbag_resolution *resolution,
 				 int dpi_x, int dpi_y)
 {
@@ -987,6 +1024,9 @@ hidpp20drv_update_resolution_dpi(struct ratbag_resolution *resolution,
 
 	if (drv_data->capabilities & HIDPP_CAP_ONBOARD_PROFILES_8100)
 		return hidpp20drv_update_resolution_dpi_8100(resolution, dpi_x, dpi_y);
+
+	if (drv_data->capabilities & HIDPP_CAP_G602_8080)
+		return hidpp20drv_update_resolution_dpi_8080(resolution, dpi_x, dpi_y);
 
 	if (!(drv_data->capabilities & HIDPP_CAP_SWITCHABLE_RESOLUTION_2201))
 		return -ENOTSUP;
@@ -1367,6 +1407,19 @@ hidpp20drv_init_feature(struct ratbag_device *device, uint16_t feature)
 		drv_data->capabilities |= HIDPP_CAP_SWITCHABLE_RESOLUTION_2201;
 		break;
 	}
+	case HIDPP_PAGE_G602_ONBOARD_PROFILE: {
+		log_debug(ratbag, "device has G602 onboard profile\n");
+		union hidpp20_g602_onboard_profile *profile = zalloc(sizeof(*profile));
+		rc = hidpp20_g602_read_profile(drv_data->dev, profile->data);
+		if (rc < 0) {
+			free(profile);
+			return 0;
+		}
+		drv_data->g602_profile = profile;
+		drv_data->capabilities |= HIDPP_CAP_G602_8080;
+		drv_data->num_resolutions = 5;
+		break;
+	}
 	case HIDPP_PAGE_SPECIAL_KEYS_BUTTONS: {
 		log_debug(ratbag, "device has programmable keys/buttons\n");
 		drv_data->capabilities |= HIDPP_CAP_BUTTON_KEY_1b04;
@@ -1548,6 +1601,27 @@ hidpp20drv_commit(struct ratbag_device *device)
 		}
 	}
 
+	if (drv_data->capabilities & HIDPP_CAP_G602_8080) {
+		rc = hidpp20_g602_write_profile(drv_data->dev,
+						     drv_data->g602_profile->data);
+		if (rc) {
+			log_error(device->ratbag, "hidpp20: failed to commit profile (%d)\n", rc);
+			return RATBAG_ERROR_DEVICE;
+		}
+
+		list_for_each(profile, &device->profiles, link) {
+			ratbag_profile_for_each_resolution(profile, resolution) {
+				if (resolution->is_active) {
+					rc = hidpp20_g602_set_active_dpi_stage(drv_data->dev, resolution->index);
+					if (rc) {
+						log_error(device->ratbag, "hidpp20: failed to set active resolution (%d)\n", rc);
+						return RATBAG_ERROR_DEVICE;
+					}
+				}
+			}
+		}
+	}
+
 	return RATBAG_SUCCESS;
 }
 
@@ -1623,6 +1697,7 @@ hidpp20drv_remove(struct ratbag_device *device)
 	free(drv_data->controls);
 	free(drv_data->sensors);
 	free(drv_data->leds);
+	free(drv_data->g602_profile);
 	if (drv_data->dev)
 		hidpp20_device_destroy(drv_data->dev);
 	free(drv_data);

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -1777,6 +1777,164 @@ int hidpp20_adjustable_report_rate_set_report_rate(struct hidpp20_device *device
 }
 
 /* -------------------------------------------------------------------------- */
+/* 0x8080 - G602 Onboard Profile                                              */
+/* -------------------------------------------------------------------------- */
+
+#define CMD_G602_ONBOARD_PROFILE_BEGIN_TRANSACTION	0x20
+#define CMD_G602_ONBOARD_PROFILE_TRANSFER_CHUNK		0x30
+#define CMD_G602_ONBOARD_PROFILE_WRITE_COMMIT		0x40
+#define CMD_G602_ONBOARD_PROFILE_GET_ACTIVE_STAGE	0x50
+#define CMD_G602_ONBOARD_PROFILE_SET_ACTIVE_STAGE	0x60
+#define HIDPP20_G602_CHUNK_DATA_SIZE			15
+
+int
+hidpp20_g602_read_profile(struct hidpp20_device *device, uint8_t *profile)
+{
+	/* Profile should be a 45 byte buffer */
+	int rc;
+	uint8_t feature_index = hidpp_root_get_feature_idx(device, HIDPP_PAGE_G602_ONBOARD_PROFILE);
+	if (feature_index == 0)
+		return -ENOTSUP;
+
+	union hidpp20_message msg = {
+		.msg.report_id = REPORT_ID_LONG,
+		.msg.device_idx = device->index,
+		.msg.sub_id = feature_index,
+		.msg.address = CMD_G602_ONBOARD_PROFILE_BEGIN_TRANSACTION,
+		.msg.parameters[0] = 0x80,
+		.msg.parameters[1] = 0x2a
+	};
+
+	rc = hidpp20_request_command(device, &msg);
+	if (rc)
+		return rc;
+
+	unsigned i;
+	for (i = 1; i < 4; i++) {
+		union hidpp20_message msg = {
+			.msg.report_id = REPORT_ID_LONG,
+			.msg.device_idx = device->index,
+			.msg.sub_id = feature_index,
+			.msg.address = CMD_G602_ONBOARD_PROFILE_TRANSFER_CHUNK,
+			.msg.parameters[0] = i
+		};
+
+		rc = hidpp20_request_command(device, &msg);
+
+		if (rc)
+			return rc;
+		if (msg.msg.parameters[0] != i) {
+			/* Failed the echo back sanity check */
+			return -EPROTO;
+		}
+
+		memcpy(profile + (i-1) * HIDPP20_G602_CHUNK_DATA_SIZE, &msg.msg.parameters[1], HIDPP20_G602_CHUNK_DATA_SIZE);
+	}
+
+	return 0;
+}
+
+int
+hidpp20_g602_write_profile(struct hidpp20_device *device, const uint8_t *profile)
+{
+	int rc;
+	uint8_t feature_index = hidpp_root_get_feature_idx(device, HIDPP_PAGE_G602_ONBOARD_PROFILE);
+	if (feature_index == 0)
+		return -ENOTSUP;
+
+	union hidpp20_message begin_msg = {
+		.msg.report_id = REPORT_ID_LONG,
+		.msg.device_idx = device->index,
+		.msg.sub_id = feature_index,
+		.msg.address = CMD_G602_ONBOARD_PROFILE_BEGIN_TRANSACTION,
+		.msg.parameters[0] = 0x81,
+		.msg.parameters[1] = 0x2a
+	};
+
+	rc = hidpp20_request_command(device, &begin_msg);
+	if (rc)
+		return rc;
+
+	unsigned i;
+	for (i = 1; i < 4; i++) {
+		union hidpp20_message msg = {
+			.msg.report_id = REPORT_ID_LONG,
+			.msg.device_idx = device->index,
+			.msg.sub_id = feature_index,
+			.msg.address = CMD_G602_ONBOARD_PROFILE_TRANSFER_CHUNK,
+			.msg.parameters[0] = i
+		};
+
+		memcpy(&msg.msg.parameters[1], profile + (i-1) * HIDPP20_G602_CHUNK_DATA_SIZE, HIDPP20_G602_CHUNK_DATA_SIZE);
+
+		rc = hidpp20_request_command(device, &msg);
+
+		if (rc)
+			return rc;
+	}
+
+	union hidpp20_message commit_msg = {
+		.msg.report_id = REPORT_ID_LONG,
+		.msg.device_idx = device->index,
+		.msg.sub_id = feature_index,
+		.msg.address = CMD_G602_ONBOARD_PROFILE_WRITE_COMMIT,
+		.msg.parameters[0] = 0x82,
+		.msg.parameters[1] = 0x01
+	};
+
+	rc = hidpp20_request_command(device, &commit_msg);
+	if (rc)
+		return rc;
+
+	return 0;
+}
+
+int
+hidpp20_g602_get_active_dpi_stage(struct hidpp20_device *device)
+{
+	int rc;
+	uint8_t feature_index = hidpp_root_get_feature_idx(device, HIDPP_PAGE_G602_ONBOARD_PROFILE);
+	if (feature_index == 0)
+		return -ENOTSUP;
+
+	union hidpp20_message msg = {
+		.msg.report_id = REPORT_ID_LONG,
+		.msg.device_idx = device->index,
+		.msg.sub_id = feature_index,
+		.msg.address = CMD_G602_ONBOARD_PROFILE_GET_ACTIVE_STAGE,
+	};
+
+	rc = hidpp20_request_command(device, &msg);
+	if (rc)
+		return rc;
+
+	return msg.msg.parameters[0];
+}
+
+int
+hidpp20_g602_set_active_dpi_stage(struct hidpp20_device *device, uint8_t stage)
+{
+	int rc;
+	uint8_t feature_index = hidpp_root_get_feature_idx(device, HIDPP_PAGE_G602_ONBOARD_PROFILE);
+	if (feature_index == 0)
+		return -ENOTSUP;
+
+	union hidpp20_message msg = {
+		.msg.report_id = REPORT_ID_LONG,
+		.msg.device_idx = device->index,
+		.msg.sub_id = feature_index,
+		.msg.address = CMD_G602_ONBOARD_PROFILE_SET_ACTIVE_STAGE,
+		.msg.parameters[0] = stage
+	};
+
+	rc = hidpp20_request_command(device, &msg);
+	if (rc)
+		return rc;
+
+	return 0;
+}
+
+/* -------------------------------------------------------------------------- */
 /* 0x8100 - Onboard Profiles                                                  */
 /* -------------------------------------------------------------------------- */
 

--- a/src/hidpp20.h
+++ b/src/hidpp20.h
@@ -574,6 +574,34 @@ enum hidpp20_color_led_zone_effect {
 #define HIDPP20_RGB_EFFECTS_SLOT_INFO_EFCT_NAME_21_31	0x06
 
 /* -------------------------------------------------------------------------- */
+/* 0x8080 - G602 Onboard Profile                                              */
+/* -------------------------------------------------------------------------- */
+
+#define HIDPP_PAGE_G602_ONBOARD_PROFILE		0x8080
+#define HIDPP20_G602_PROFILE_SIZE		45
+
+int hidpp20_g602_read_profile(struct hidpp20_device *device, uint8_t *profile);
+int hidpp20_g602_write_profile(struct hidpp20_device *device, const uint8_t *profile);
+int hidpp20_g602_get_active_dpi_stage(struct hidpp20_device *device);
+int hidpp20_g602_set_active_dpi_stage(struct hidpp20_device *device, uint8_t stage);
+
+union hidpp20_g602_onboard_profile {
+	uint8_t data[HIDPP20_G602_PROFILE_SIZE];
+	struct {
+		uint8_t reserved0;
+		uint8_t report_rate;
+		uint8_t reserved1;
+		uint8_t dpi_shift;
+		uint8_t stages[5];
+		uint8_t reserved2;
+		uint8_t tail[5];
+		uint8_t chunk2[15];
+		uint8_t chunk3[15];
+	} __attribute__((packed)) profile;
+};
+_Static_assert(sizeof(union hidpp20_g602_onboard_profile) == HIDPP20_G602_PROFILE_SIZE, "Invalid size");
+
+/* -------------------------------------------------------------------------- */
 /* 0x8100 - Onboard Profiles                                                  */
 /* -------------------------------------------------------------------------- */
 


### PR DESCRIPTION
This adds proper initial support for the Logitech G602, starting with the DPI settings. Ratbag can now read/write the 5 DPI settings and set the active one.

The G602 has its own special feature for managing its configuration, `0x8080`, which seems to be specific to it and is why it didn't really work before. I'm working on mapping out the rest of the profile so this will be followed up with support for button mapping.

Previous work in #1224 was referenced to help understand the mouse more. This also is a step towards closing #434.

To be transparent, AI was used to help read wireshark dumps, teach me about USB, and get me up to speed on the codebase. I wrote all of the code though and can answer for it.