### PR TITLE
Fix/allow multiple quirks fix profile index

### DIFF
--- a/data/devices/logitech-g502-x-plus-wireless.device
+++ b/data/devices/logitech-g502-x-plus-wireless.device
@@ -1,6 +1,6 @@
 [Device]
 Name=Logitech G502 X PLUS
-DeviceMatch=usb:046d:c547;usb:046d:c098
+DeviceMatch=usb:046d:c547
 DeviceType=mouse
 Driver=hidpp20
 

--- a/data/devices/logitech-g502-x-plus-wireless.device
+++ b/data/devices/logitech-g502-x-plus-wireless.device
@@ -1,8 +1,9 @@
 [Device]
 Name=Logitech G502 X PLUS
-DeviceMatch=usb:046d:4099;usb:046d:c095
+DeviceMatch=usb:046d:c547;usb:046d:c098
 DeviceType=mouse
 Driver=hidpp20
 
 [Driver/hidpp20]
+DeviceIndex=1
 Quirk=G502X_PLUS;INDEX_OFFSET

--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -411,7 +411,7 @@ hidpp20drv_read_led_8071(struct ratbag_led *led, struct hidpp20drv_data* drv_dat
 	hidpp20_rgb_effects_get_device_info(drv_data->dev, &device_info);
 	cluster_info = drv_data->led_infos.color_leds_8071[led->index];
 	profile = &drv_data->profiles->profiles[led->profile->index];
-	if (drv_data->dev->quirk == HIDPP20_QUIRK_G502X_PLUS) {
+	if (drv_data->dev->quirk & HIDPP20_QUIRK_G502X_PLUS) {
 		// On G502X+ the second slot controls the user configurable LED.
 		// (Note: There is only 1 reported LED, it just happens to use 2nd index though)
 		h_led = &profile->leds[1];
@@ -695,7 +695,7 @@ hidpp20drv_update_led_8070_8071(struct ratbag_led *led, struct ratbag_profile* p
 
 	if (drv_data->capabilities & HIDPP_CAP_ONBOARD_PROFILES_8100) {
 		h_profile = &drv_data->profiles->profiles[profile->index];
-		if (drv_data->dev->quirk == HIDPP20_QUIRK_G502X_PLUS) {
+		if (drv_data->dev->quirk & HIDPP20_QUIRK_G502X_PLUS) {
 			// On G502X+ the second slot controls the user configurable LED.
 			// (Note: There is only 1 reported LED, it just happens to use 2nd index though)
 			h_led = &(h_profile->leds[1]);
@@ -1432,7 +1432,7 @@ hidpp20drv_init_feature(struct ratbag_device *device, uint16_t feature)
 	case HIDPP_PAGE_COLOR_LED_EFFECTS: {
 		/* The 8070 feature implemented in the G602 doesn't follow the spec,
 		 * so we ignore it */
-		if (ratbag_device_data_hidpp20_get_quirk(device->data) == HIDPP20_QUIRK_G602)
+		if (ratbag_device_data_hidpp20_get_quirk(device->data) & HIDPP20_QUIRK_G602)
 			break;
 
 		log_debug(ratbag, "device has color effects\n");
@@ -1712,8 +1712,9 @@ hidpp20drv_probe(struct ratbag_device *device)
 
 	log_debug(device->ratbag, "'%s' is using protocol v%d.%d\n", ratbag_device_get_name(device), dev->proto_major, dev->proto_minor);
 
-	if(dev->quirk != HIDPP20_QUIRK_NONE)
-		log_debug(device->ratbag, "'%s' is quirked (%s)\n", ratbag_device_get_name(device), hidpp20_get_quirk_string(dev->quirk));
+	if (dev->quirk != HIDPP20_QUIRK_NONE)
+		log_debug(device->ratbag, "'%s' has quirk flags (0x%x)\n",
+			  ratbag_device_get_name(device), dev->quirk);
 
 	/* add some defaults that will be overwritten by the device */
 	drv_data->num_profiles = 1;

--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -1712,9 +1712,24 @@ hidpp20drv_probe(struct ratbag_device *device)
 
 	log_debug(device->ratbag, "'%s' is using protocol v%d.%d\n", ratbag_device_get_name(device), dev->proto_major, dev->proto_minor);
 
-	if (dev->quirk != HIDPP20_QUIRK_NONE)
-		log_debug(device->ratbag, "'%s' has quirk flags (0x%x)\n",
-			  ratbag_device_get_name(device), dev->quirk);
+	if (dev->quirk != HIDPP20_QUIRK_NONE) {
+		enum hidpp20_quirk quirks[] = {
+			HIDPP20_QUIRK_G305,
+			HIDPP20_QUIRK_G602,
+			HIDPP20_QUIRK_G502X_PLUS,
+			HIDPP20_QUIRK_INDEX_OFFSET,
+		};
+		size_t i;
+
+		for (i = 0; i < ARRAY_LENGTH(quirks); i++) {
+			if (!(dev->quirk & quirks[i]))
+				continue;
+
+			log_debug(device->ratbag, "'%s' has quirk %s\n",
+				  ratbag_device_get_name(device),
+				  hidpp20_get_quirk_string(quirks[i]));
+		}
+	}
 
 	/* add some defaults that will be overwritten by the device */
 	drv_data->num_profiles = 1;

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -2971,7 +2971,7 @@ hidpp20_onboard_profiles_write_profile(struct hidpp20_device *device,
 	// Mice like G502X can store custom animations onboard.
 	// ratbag does not support this, so we set it to disable it to ensure
 	// that the actual lighting matches the user's settings.
-	if (device->quirk == HIDPP20_QUIRK_G502X_PLUS)
+	if (device->quirk & HIDPP20_QUIRK_G502X_PLUS)
 	{
 		// Note(sewer56): There are two known mice which use this field;
 		// G502X PLUS and G705. [And I only own one of these.] But it's not known how

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -1532,7 +1532,7 @@ hidpp20_adjustable_dpi_get_dpi_list(struct hidpp20_device *device,
 		.msg.parameters[0] = sensor->index,
 	};
 
-	if (device->quirk == HIDPP20_QUIRK_G602) {
+	if (device->quirk & HIDPP20_QUIRK_G602) {
 		msg.msg.parameters[0] = 1;
 		i = 0;
 	}
@@ -1548,7 +1548,7 @@ hidpp20_adjustable_dpi_get_dpi_list(struct hidpp20_device *device,
 	       get_unaligned_be_u16(&msg.msg.parameters[i]) != 0) {
 		uint16_t value = get_unaligned_be_u16(&msg.msg.parameters[i]);
 
-		if (device->quirk == HIDPP20_QUIRK_G602 && i == 2)
+		if ((device->quirk & HIDPP20_QUIRK_G602) && i == 2)
 			value += 0xe000;
 
 		if (value > 0xe000) {
@@ -1580,7 +1580,7 @@ hidpp20_adjustable_dpi_get_dpi(struct hidpp20_device *device,
 		.msg.parameters[0] = sensor->index,
 	};
 
-	if (device->quirk == HIDPP20_QUIRK_G602)
+	if (device->quirk & HIDPP20_QUIRK_G602)
 		msg.msg.parameters[0] = 1;
 
 	rc = hidpp20_request_command(device, &msg);
@@ -1662,7 +1662,7 @@ int hidpp20_adjustable_dpi_set_sensor_dpi(struct hidpp20_device *device,
 		.msg.parameters[0] = sensor->index,
 	};
 
-	if (device->quirk == HIDPP20_QUIRK_G602)
+	if (device->quirk & HIDPP20_QUIRK_G602)
 		msg.msg.parameters[0] = 1;
 
 	set_unaligned_be_u16(&msg.msg.parameters[1], dpi);
@@ -2279,7 +2279,7 @@ hidpp20_onboard_profiles_allocate(struct hidpp20_device *device,
 	active_profile_index = rc;
 
 	/* Apply quirk for devices that return 1-indexed profile */
-	if (device->quirk == HIDPP20_QUIRK_INDEX_OFFSET && active_profile_index > 0)
+	if ((device->quirk & HIDPP20_QUIRK_INDEX_OFFSET) && active_profile_index > 0)
 		active_profile_index--;
 
 	profiles = zalloc(sizeof(struct hidpp20_profiles));
@@ -2802,7 +2802,7 @@ hidpp20_onboard_profiles_initialize(struct hidpp20_device *device,
 						  profiles->sector_size,
 						  data);
 
-	if (rc && device->quirk == HIDPP20_QUIRK_G305) {
+	if (rc && (device->quirk & HIDPP20_QUIRK_G305)) {
 		/* The G305 has a bug where it throws an ERR_INVALID_ARGUMENT
 		   if the sector has not been written to yet. If this happens
 		   we will read the ROM profiles.*/

--- a/src/hidpp20.h
+++ b/src/hidpp20.h
@@ -876,7 +876,6 @@ _Static_assert(sizeof(union hidpp20_macro_data) == 3, "Invalid size");
 struct hidpp20_profile {
 	uint16_t address;
 	uint8_t enabled;
-	uint8_t custom_animation_index;
 	char name[16 * 3];
 	uint16_t powersave_timeout;
 	uint16_t poweroff_timeout;

--- a/src/hidpp20.h
+++ b/src/hidpp20.h
@@ -52,11 +52,11 @@ struct hidpp20_feature {
 };
 
 enum hidpp20_quirk {
-	HIDPP20_QUIRK_NONE,
-	HIDPP20_QUIRK_G305,
-	HIDPP20_QUIRK_G602,
-	HIDPP20_QUIRK_G502X_PLUS, // G502X+ uses 2nd LED slot instead of 1st.
-	HIDPP20_QUIRK_INDEX_OFFSET, // Device returns 1-indexed profile, decrement by 1.
+	HIDPP20_QUIRK_NONE = 0,
+	HIDPP20_QUIRK_G305 = 1 << 0,
+	HIDPP20_QUIRK_G602 = 1 << 1,
+	HIDPP20_QUIRK_G502X_PLUS = 1 << 2, // G502X+ uses 2nd LED slot instead of 1st.
+	HIDPP20_QUIRK_INDEX_OFFSET = 1 << 3, // Device returns 1-indexed profile, decrement by 1.
 };
 
 struct hidpp20_device {
@@ -876,6 +876,7 @@ _Static_assert(sizeof(union hidpp20_macro_data) == 3, "Invalid size");
 struct hidpp20_profile {
 	uint16_t address;
 	uint8_t enabled;
+	uint8_t custom_animation_index;
 	char name[16 * 3];
 	uint16_t powersave_timeout;
 	uint16_t poweroff_timeout;

--- a/src/libratbag-data.c
+++ b/src/libratbag-data.c
@@ -221,14 +221,17 @@ init_data_hidpp20(struct ratbag *ratbag,
 	str = g_key_file_get_string(keyfile, group, "Quirk", NULL);
 	data->hidpp20.quirk = HIDPP20_QUIRK_NONE;
 	if (str) {
-		if (streq(str, "G305"))
-			data->hidpp20.quirk = HIDPP20_QUIRK_G305;
-		else if(streq(str, "G602"))
-			data->hidpp20.quirk = HIDPP20_QUIRK_G602;
-		else if(streq(str, "G502X_PLUS"))
-			data->hidpp20.quirk = HIDPP20_QUIRK_G502X_PLUS;
-		else if(streq(str, "INDEX_OFFSET"))
-			data->hidpp20.quirk = HIDPP20_QUIRK_INDEX_OFFSET;
+		_cleanup_(g_strfreevp) char **quirks = g_strsplit(str, ";", -1);
+		for (char **q = quirks; q && *q; q++) {
+			if (streq(*q, "G305"))
+				data->hidpp20.quirk |= HIDPP20_QUIRK_G305;
+			else if (streq(*q, "G602"))
+				data->hidpp20.quirk |= HIDPP20_QUIRK_G602;
+			else if (streq(*q, "G502X_PLUS"))
+				data->hidpp20.quirk |= HIDPP20_QUIRK_G502X_PLUS;
+			else if (streq(*q, "INDEX_OFFSET"))
+				data->hidpp20.quirk |= HIDPP20_QUIRK_INDEX_OFFSET;
+		}
 	}
 }
 


### PR DESCRIPTION
I noticed adding both `G502X_PLUS` + `INDEX_OFFSET` quirks to "Quirk" line in .device file had no effect. This PR fixes that, allowing more quirks to work simultaneously.

This PR is also including new/updated G502 X Plus profiles to use both quirks wired + wirelessly.

I will send a PR to piper in sequence to make G502 X Plus work wirelessly on it too.