### PR TITLE
ci: pin black and ruff versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ env:
     libjson-glib-dev libsystemd-dev libudev-dev libunistring-dev
     python3-dev python3-evdev swig python3-sphinx
   UBUNTU_DEP_TEST: check python3-gi python3-lxml valgrind
-  PIP_PACKAGES: meson ninja libevdev pyudev pytest sphinx_rtd_theme black ruff
+  PIP_PACKAGES: meson ninja libevdev pyudev pytest sphinx_rtd_theme black==25.12.0 ruff==0.15.12
 
 jobs:
   build-and-dist:


### PR DESCRIPTION
Avoid CI breaking on their updates.
Keeping black at 25 to avoid having to reformat and then sync with Piper.