### PR TITLE
fix: clear stale modifiers when binding keys

### DIFF
--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -585,10 +585,12 @@ hidpp20drv_update_button_8100(struct ratbag_button *button)
 		}
 		profile->buttons[button->index].subany.type = type;
 		profile->buttons[button->index].subany.subtype = subtype;
-		if (subtype == HIDPP20_BUTTON_HID_TYPE_KEYBOARD)
+		if (subtype == HIDPP20_BUTTON_HID_TYPE_KEYBOARD) {
+			profile->buttons[button->index].keyboard_keys.modifier_flags = 0;
 			profile->buttons[button->index].keyboard_keys.key = code;
-		else
+		} else {
 			profile->buttons[button->index].consumer_control.consumer_control = code;
+		}
 		break;
 	case RATBAG_BUTTON_ACTION_TYPE_SPECIAL:
 		code = hidpp20_onboard_profiles_get_code_from_special(action->action.special);


### PR DESCRIPTION
Device: Logitech G502 X PLUS

Encountered an issue where re-binding keys which previously had modifiers assigned (e.g. ALT+KEY_LEFT), resulted in the modifier being retained. This small change clears modifiers before assigning new keys or macros. Keys are still able to be assigned modifiers, as assignment hasn't changed.

I didn't see a PR template, so I'm just doing my best here...

- Assigned the back button the default setting
  - Changed back button to send comma key
    - before: sent `ALT+,`
    - after: sent `,` :heavy_check_mark: 
- Assigned back button to send `ALT+LEFT_ARROW`
  - Changed back button to send comma key
    - before: sent `ALT+,`
    - after: sent `,` :heavy_check_mark: 
- Assigned back button to send comma key
  - Changed back button to send `ALT+,`
    - before: sent `ALT+,`
    - after: sent `ALT+,` :heavy_check_mark:

Closes https://github.com/libratbag/libratbag/issues/1853
Closes https://github.com/libratbag/piper/issues/835