### PR TITLE
Adds: Logitech G Pro-X 2 Dex Wireless

### DIFF
--- a/data/devices/logitech-g-pro-x-2-dex-wireless-superlight.device
+++ b/data/devices/logitech-g-pro-x-2-dex-wireless-superlight.device
@@ -1,0 +1,8 @@
+[Device]
+Name=Logitech G Pro X 2 DEX
+DeviceMatch=usb:046d:c0a0;usb:046d:40b8;usb:046d:c54d
+Driver=hidpp20
+DeviceType=mouse
+
+[Driver/hidpp20]
+DeviceIndex=1


### PR DESCRIPTION
--Description:
Adds entry for a new Logitech mice. 


-- Logs:
Wireless
ratbag debug: New device: Logitech PRO X 2 DEX
ratbag debug: Using data directory '/usr/share/libratbag'
ratbag debug: No data file found for 046d:40b8


wired
ratbag debug: New device: Logitech PRO X 2 DEX
ratbag debug: Using data directory '/usr/share/libratbag'
ratbag debug: No data file found for 046d:c0a0

