### PR TITLE
hidpp20: support onboard macro writes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+builddir*
+_docker-install
+__pycache__
+*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+builddir*/
+_docker-install/

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,33 @@
+ARG UBUNTU_VERSION=26.04
+FROM ubuntu:${UBUNTU_VERSION}
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        check \
+        gcc \
+        g++ \
+        git \
+        libevdev-dev \
+        libglib2.0-dev \
+        libjson-glib-dev \
+        libsystemd-dev \
+        libudev-dev \
+        libunistring-dev \
+        meson \
+        ninja-build \
+        pkg-config \
+        python3 \
+        python3-dev \
+        python3-evdev \
+        python3-gi \
+        python3-pip \
+        swig \
+        systemd-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -45,6 +45,27 @@ And to build or re-build after code-changes, run:
 
     ninja -C builddir
     sudo ninja -C builddir install
+
+Building with Docker
+--------------------
+
+This fork can also be built in a Docker container so the compiler and Meson
+dependencies do not need to be installed on the host. The helper script builds
+an Ubuntu image, compiles the project, runs the tests, and stages the install
+tree under `_docker-install/`:
+
+    ./scripts/docker-build.sh
+
+The staged files can then be installed onto the host with:
+
+    sudo ./scripts/docker-install.sh
+
+By default this uses Ubuntu 26.04 and installs with prefix `/usr`, matching the
+usual system DBus and systemd locations. On common Ubuntu architectures the
+library directory is set to the matching multiarch path. The defaults can be
+overridden:
+
+    UBUNTU_VERSION=24.04 PREFIX=/usr/local LIBDIR=lib TESTS=false ./scripts/docker-build.sh
     
 To remove/uninstall simply run:
 

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+image="${LIBRATBAG_BUILD_IMAGE:-libratbag-build}"
+ubuntu_version="${UBUNTU_VERSION:-26.04}"
+builddir="${BUILD_DIR:-builddir-docker}"
+destdir="${DESTDIR:-_docker-install}"
+prefix="${PREFIX:-/usr}"
+tests="${TESTS:-true}"
+documentation="${DOCUMENTATION:-false}"
+
+case "$(uname -m)" in
+    x86_64) default_libdir="lib/x86_64-linux-gnu" ;;
+    aarch64|arm64) default_libdir="lib/aarch64-linux-gnu" ;;
+    armv7l) default_libdir="lib/arm-linux-gnueabihf" ;;
+    *) default_libdir="lib" ;;
+esac
+libdir="${LIBDIR:-${default_libdir}}"
+
+docker build \
+    --build-arg "UBUNTU_VERSION=${ubuntu_version}" \
+    -f "${repo_root}/Dockerfile.build" \
+    -t "${image}:${ubuntu_version}" \
+    "${repo_root}"
+
+docker run --rm \
+    -u "$(id -u):$(id -g)" \
+    -v "${repo_root}:/src" \
+    -w /src \
+    "${image}:${ubuntu_version}" \
+    bash -lc "
+        set -euo pipefail
+        rm -rf '${destdir}'
+        meson setup '${builddir}' --prefix='${prefix}' --libdir='${libdir}' -Dtests='${tests}' -Ddocumentation='${documentation}' --reconfigure || \
+            meson setup '${builddir}' --prefix='${prefix}' --libdir='${libdir}' -Dtests='${tests}' -Ddocumentation='${documentation}'
+        meson compile -C '${builddir}'
+        if [ '${tests}' = true ]; then
+            meson test -C '${builddir}' --print-errorlogs
+        fi
+        DESTDIR=\"/src/${destdir}\" meson install -C '${builddir}'
+    "
+
+cat <<EOF
+
+Build complete.
+
+Staged files are in:
+  ${repo_root}/${destdir}
+
+To install them onto this machine, run:
+  sudo ${repo_root}/scripts/docker-install.sh
+EOF

--- a/scripts/docker-install.sh
+++ b/scripts/docker-install.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+destdir="${DESTDIR:-_docker-install}"
+stage="${repo_root}/${destdir}"
+
+if [ ! -d "${stage}/usr" ]; then
+    echo "No staged install found at ${stage}/usr"
+    echo "Run scripts/docker-build.sh first."
+    exit 1
+fi
+
+if [ "${EUID}" -ne 0 ]; then
+    echo "Please run this script with sudo so it can install into /usr."
+    exit 1
+fi
+
+if [ "${SKIP_SYSTEMD:-false}" != true ] && command -v systemctl >/dev/null 2>&1; then
+    systemctl stop ratbagd.service || true
+fi
+
+cp -a "${stage}/usr/." /usr/
+while IFS= read -r path; do
+    chown root:root "/${path#${stage}/}"
+done < <(find "${stage}/usr" -mindepth 1)
+
+if [ "${SKIP_SYSTEMD:-false}" != true ] && command -v systemctl >/dev/null 2>&1; then
+    systemctl daemon-reload || true
+    systemctl reload dbus.service || true
+    systemctl enable ratbagd.service || true
+    systemctl restart ratbagd.service || true
+fi
+
+echo "Installed staged libratbag files from ${stage}/usr into /usr."
+
+if ! python3 -c 'import evdev' >/dev/null 2>&1; then
+    echo
+    echo "ratbagctl needs the host Python evdev module."
+    echo "Install it with: sudo apt install python3-evdev"
+fi

--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -527,6 +527,10 @@ hidpp20drv_update_button_1b04(struct ratbag_button *button)
 	return rc;
 }
 
+static void
+hidpp20drv_clear_macro_8100(struct ratbag_button *button,
+			    struct hidpp20_profile *profile);
+
 static int
 hidpp20drv_update_button_8100(struct ratbag_button *button)
 {
@@ -543,6 +547,7 @@ hidpp20drv_update_button_8100(struct ratbag_button *button)
 
 	switch (action->type) {
 	case RATBAG_BUTTON_ACTION_TYPE_BUTTON:
+		hidpp20drv_clear_macro_8100(button, profile);
 		profile->buttons[button->index].button.type = HIDPP20_BUTTON_HID_TYPE;
 		profile->buttons[button->index].button.subtype = HIDPP20_BUTTON_HID_TYPE_MOUSE;
 		profile->buttons[button->index].button.buttons = action->action.button;
@@ -550,6 +555,7 @@ hidpp20drv_update_button_8100(struct ratbag_button *button)
 	case RATBAG_BUTTON_ACTION_TYPE_MACRO:
 		return hidpp20drv_update_macro_8100(button, profile);
 	case RATBAG_BUTTON_ACTION_TYPE_KEY:
+		hidpp20drv_clear_macro_8100(button, profile);
 		type = HIDPP20_BUTTON_HID_TYPE;
 		subtype = HIDPP20_BUTTON_HID_TYPE_KEYBOARD;
 		code = ratbag_hidraw_get_keyboard_usage_from_keycode(device, action->action.key);
@@ -567,6 +573,7 @@ hidpp20drv_update_button_8100(struct ratbag_button *button)
 			profile->buttons[button->index].consumer_control.consumer_control = code;
 		break;
 	case RATBAG_BUTTON_ACTION_TYPE_SPECIAL:
+		hidpp20drv_clear_macro_8100(button, profile);
 		code = hidpp20_onboard_profiles_get_code_from_special(action->action.special);
 		if (code == 0)
 			return -EINVAL;
@@ -574,7 +581,9 @@ hidpp20drv_update_button_8100(struct ratbag_button *button)
 		profile->buttons[button->index].special.special = code;
 		break;
 	case RATBAG_BUTTON_ACTION_TYPE_NONE:
-		profile->buttons[button->index].disabled.type = HIDPP20_BUTTON_HID_TYPE_NOOP;
+		hidpp20drv_clear_macro_8100(button, profile);
+		profile->buttons[button->index].subany.type = HIDPP20_BUTTON_HID_TYPE;
+		profile->buttons[button->index].subany.subtype = HIDPP20_BUTTON_HID_TYPE_NOOP;
 		break;
 	default:
 		return -ENOTSUP;
@@ -1144,6 +1153,15 @@ out:
 	profile->dirty_macros |= 1U << button->index;
 
 	return 0;
+}
+
+static void
+hidpp20drv_clear_macro_8100(struct ratbag_button *button,
+			    struct hidpp20_profile *profile)
+{
+	free(profile->macros[button->index]);
+	profile->macros[button->index] = NULL;
+	profile->dirty_macros &= ~(1U << button->index);
 }
 
 static int

--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -81,6 +81,10 @@ struct hidpp20drv_data {
 	unsigned int num_leds;
 };
 
+static int
+hidpp20drv_update_macro_8100(struct ratbag_button *button,
+			     struct hidpp20_profile *profile);
+
 static void
 hidpp20drv_read_button_1b04(struct ratbag_button *button)
 {
@@ -530,8 +534,6 @@ hidpp20drv_update_button_8100(struct ratbag_button *button)
 	struct hidpp20drv_data *drv_data = ratbag_get_drv_data(device);
 	struct hidpp20_profile *profile;
 	struct ratbag_button_action *action = &button->action;
-	unsigned int modifiers, key;
-	int rc;
 	uint8_t code, type, subtype;
 
 	if (!(drv_data->capabilities & HIDPP_CAP_ONBOARD_PROFILES_8100))
@@ -546,33 +548,7 @@ hidpp20drv_update_button_8100(struct ratbag_button *button)
 		profile->buttons[button->index].button.buttons = action->action.button;
 		break;
 	case RATBAG_BUTTON_ACTION_TYPE_MACRO:
-		type = HIDPP20_BUTTON_HID_TYPE;
-		subtype = HIDPP20_BUTTON_HID_TYPE_KEYBOARD;
-		rc = ratbag_action_keycode_from_macro(action,
-						      &key,
-						      &modifiers);
-		if (rc < 0) {
-			log_error(device->ratbag,
-				  "Error while writing macro for button %d\n",
-				  button->index);
-		}
-
-		code = ratbag_hidraw_get_keyboard_usage_from_keycode(device, key);
-		if (code == 0) {
-			subtype = HIDPP20_BUTTON_HID_TYPE_CONSUMER_CONTROL;
-			code = ratbag_hidraw_get_consumer_usage_from_keycode(device, key);
-			if (code == 0)
-				return -EINVAL;
-		}
-		profile->buttons[button->index].subany.type = type;
-		profile->buttons[button->index].subany.subtype = subtype;
-		if (subtype == HIDPP20_BUTTON_HID_TYPE_KEYBOARD) {
-			profile->buttons[button->index].keyboard_keys.key = code;
-			profile->buttons[button->index].keyboard_keys.modifier_flags = modifiers;
-		} else {
-			profile->buttons[button->index].consumer_control.consumer_control = code;
-		}
-		break;
+		return hidpp20drv_update_macro_8100(button, profile);
 	case RATBAG_BUTTON_ACTION_TYPE_KEY:
 		type = HIDPP20_BUTTON_HID_TYPE;
 		subtype = HIDPP20_BUTTON_HID_TYPE_KEYBOARD;
@@ -1068,6 +1044,106 @@ hidpp20drv_update_report_rate(struct ratbag_profile *profile, int hz)
 	}
 
 	return -ENOTSUP;
+}
+
+static uint8_t
+hidpp20drv_macro_modifier_from_keycode(unsigned int key)
+{
+	switch (key) {
+	case KEY_LEFTCTRL: return 0x01;
+	case KEY_LEFTSHIFT: return 0x02;
+	case KEY_LEFTALT: return 0x04;
+	case KEY_LEFTMETA: return 0x08;
+	case KEY_RIGHTCTRL: return 0x10;
+	case KEY_RIGHTSHIFT: return 0x20;
+	case KEY_RIGHTALT: return 0x40;
+	case KEY_RIGHTMETA: return 0x80;
+	default: return 0x00;
+	}
+}
+
+static int
+hidpp20drv_update_macro_8100(struct ratbag_button *button,
+			     struct hidpp20_profile *profile)
+{
+	struct ratbag_device *device = button->profile->device;
+	struct ratbag_macro *macro = button->action.macro;
+	union hidpp20_macro_data *data;
+	uint8_t sector = 0;
+	unsigned int i, index;
+
+	if (!macro)
+		return -EINVAL;
+
+	if (profile->buttons[button->index].any.type == HIDPP20_BUTTON_MACRO)
+		sector = profile->buttons[button->index].macro.zero;
+
+	data = zalloc((MAX_MACRO_EVENTS + 1) * sizeof(*data));
+	if (!data)
+		return -ENOMEM;
+
+	index = 0;
+	for (i = 0; i < MAX_MACRO_EVENTS; i++) {
+		struct ratbag_macro_event *event = &macro->events[i];
+		uint8_t modifier;
+		uint8_t key;
+
+		switch (event->type) {
+		case RATBAG_MACRO_EVENT_NONE:
+			goto out;
+		case RATBAG_MACRO_EVENT_INVALID:
+			free(data);
+			return -EINVAL;
+		case RATBAG_MACRO_EVENT_WAIT:
+			if (event->event.timeout > UINT16_MAX) {
+				free(data);
+				return -EINVAL;
+			}
+
+			data[index].delay.type = HIDPP20_MACRO_DELAY;
+			data[index].delay.time = event->event.timeout;
+			index++;
+			break;
+		case RATBAG_MACRO_EVENT_KEY_PRESSED:
+		case RATBAG_MACRO_EVENT_KEY_RELEASED:
+			modifier = hidpp20drv_macro_modifier_from_keycode(event->event.key);
+			key = 0;
+
+			if (!modifier) {
+				key = ratbag_hidraw_get_keyboard_usage_from_keycode(device,
+										    event->event.key);
+				if (key == 0) {
+					free(data);
+					return -EINVAL;
+				}
+			}
+
+			data[index].key.type = event->type == RATBAG_MACRO_EVENT_KEY_PRESSED ?
+					       HIDPP20_MACRO_KEY_PRESS :
+					       HIDPP20_MACRO_KEY_RELEASE;
+			data[index].key.modifier = modifier;
+			data[index].key.key = key;
+			index++;
+			break;
+		default:
+			free(data);
+			return -EINVAL;
+		}
+	}
+
+out:
+	data[index].end.type = HIDPP20_MACRO_END;
+
+	free(profile->macros[button->index]);
+	profile->macros[button->index] = data;
+
+	profile->buttons[button->index].macro.type = HIDPP20_BUTTON_MACRO;
+	profile->buttons[button->index].macro.page = button->index;
+	profile->buttons[button->index].macro.zero = sector;
+	profile->buttons[button->index].macro.offset = 0;
+	profile->dirty_macros |= 1U << button->index;
+
+	return 0;
 }
 
 static int

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -2746,7 +2746,6 @@ hidpp20_onboard_profiles_find_free_macro_sectors(struct hidpp20_device *device,
 {
 	uint16_t sector;
 	unsigned int i;
-	int rc;
 
 	for (sector = profiles->num_profiles + 1; sector < profiles->sector_count; sector++) {
 		if (sector + count > profiles->sector_count)
@@ -2754,12 +2753,6 @@ hidpp20_onboard_profiles_find_free_macro_sectors(struct hidpp20_device *device,
 
 		for (i = 0; i < count; i++) {
 			if (used[sector + i])
-				break;
-
-			rc = hidpp20_onboard_profiles_is_empty_sector(device,
-								     profiles,
-								     sector + i);
-			if (rc <= 0)
 				break;
 		}
 

--- a/src/hidpp20.c
+++ b/src/hidpp20.c
@@ -1971,11 +1971,14 @@ hidpp20_onboard_profiles_write_end(struct hidpp20_device *device,
 		.msg.address = CMD_ONBOARD_PROFILES_MEMORY_WRITE_END,
 	};
 
-	rc = hidpp20_request_command(device, &msg);
-	if (rc)
-		return rc;
+	rc = hidpp20_request_command_allow_error(device, &msg, true);
+	/* Some devices commit the write but report a hardware error here. */
+	if (rc == HIDPP20_ERR_HARDWARE_ERROR)
+		return 0;
+	if (rc > 0)
+		return -EPROTO;
 
-	return 0;
+	return rc;
 }
 
 static int
@@ -2314,14 +2317,15 @@ hidpp20_onboard_profiles_allocate(struct hidpp20_device *device,
 
 static int
 hidpp20_onboard_profiles_macro_next(struct hidpp20_device *device,
-				    uint8_t memory[32],
+				    uint8_t *memory,
+				    uint16_t sector_size,
 				    uint16_t *index,
 				    union hidpp20_macro_data *macro)
 {
 	int rc = 0;
 	unsigned int step = 1;
 
-	if (*index >= 32 - sizeof(union hidpp20_macro_data)) {
+	if (*index >= sector_size - sizeof(union hidpp20_macro_data)) {
 		hidpp_log_error(&device->base, "error while parsing macro.\n");
 		return -EFAULT;
 	}
@@ -2350,7 +2354,7 @@ hidpp20_onboard_profiles_macro_next(struct hidpp20_device *device,
 		rc = -EFAULT;
 	}
 
-	if ((*index + step) & 0xF0)
+	if (*index + step > (unsigned int)sector_size - 1)
 		/* the next item will be on the following chunk */
 		return -ENOMEM;
 
@@ -2399,6 +2403,7 @@ hidpp20_onboard_profiles_read_macro(struct hidpp20_device *device,
 
 		rc = hidpp20_onboard_profiles_macro_next(device,
 							 memory,
+							 profiles->sector_size,
 							 &mem_index,
 							 &macro[index]);
 		if (rc == -EFAULT)
@@ -2550,6 +2555,309 @@ hidpp20_onboard_profiles_write_dict(struct hidpp20_device *device,
 		hidpp_log_error(&device->base, "failed to write profile dictionary\n");
 
 	return rc;
+}
+
+static union hidpp20_macro_data
+hidpp20_onboard_profiles_macro_data_to_device(union hidpp20_macro_data macro)
+{
+	if (macro.any.type == HIDPP20_MACRO_DELAY)
+		macro.delay.time = hidpp_cpu_to_be_u16(macro.delay.time);
+
+	return macro;
+}
+
+static int
+hidpp20_onboard_profiles_write_macro_sector(struct hidpp20_device *device,
+					    struct hidpp20_profiles *profiles,
+					    uint16_t sector,
+					    uint8_t *data)
+{
+	int rc;
+
+	hidpp_log_buf_raw(&device->base, "macro: ", data, 16);
+
+	rc = hidpp20_onboard_profiles_write_sector(device,
+						   sector,
+						   profiles->sector_size,
+						   data,
+						   false);
+	if (rc)
+		hidpp_log_error(&device->base,
+				"failed to write macro sector 0x%04x\n",
+				sector);
+
+	return rc;
+}
+
+static int
+hidpp20_onboard_profiles_write_macro(struct hidpp20_device *device,
+				     struct hidpp20_profiles *profiles,
+				     struct hidpp20_profile *profile,
+				     unsigned int button_index,
+				     uint16_t sector)
+{
+	_cleanup_free_ uint8_t *data = NULL;
+	union hidpp20_macro_data *macro = profile->macros[button_index];
+	uint16_t current_sector = sector;
+	uint8_t offset = 0;
+	uint8_t macro_area;
+	int rc;
+
+	if (!macro)
+		return -EINVAL;
+
+	if (current_sector >= profiles->sector_count)
+		return -ENOSPC;
+
+	profile->buttons[button_index].macro.zero = current_sector;
+	profile->buttons[button_index].macro.offset = 0;
+
+	data = hidpp20_onboard_profiles_allocate_sector(profiles);
+	if (!data)
+		return -ENOMEM;
+
+	memset(data, 0xff, profiles->sector_size);
+	macro_area = profiles->sector_size;
+
+	while (macro->any.type != HIDPP20_MACRO_END) {
+		union hidpp20_macro_data stored;
+
+		if (offset + 2 * sizeof(*macro) > macro_area) {
+			union hidpp20_macro_data jump = {
+				.jump.type = HIDPP20_MACRO_JUMP,
+				.jump.offset = 0,
+				.jump.page = current_sector + 1,
+			};
+
+			if (current_sector + 1 >= profiles->sector_count)
+				return -ENOSPC;
+
+			memcpy(data + offset, &jump, sizeof(jump));
+
+			rc = hidpp20_onboard_profiles_write_macro_sector(device,
+									 profiles,
+									 current_sector,
+									 data);
+			if (rc)
+				return rc;
+
+			current_sector++;
+			offset = 0;
+			memset(data, 0xff, profiles->sector_size);
+		}
+
+		stored = hidpp20_onboard_profiles_macro_data_to_device(*macro);
+		memcpy(data + offset, &stored, sizeof(stored));
+		offset += sizeof(stored);
+		macro++;
+	}
+
+	memcpy(data + offset, macro, sizeof(*macro));
+
+	rc = hidpp20_onboard_profiles_write_macro_sector(device,
+							 profiles,
+							 current_sector,
+							 data);
+	if (rc)
+		return rc;
+
+	return 0;
+}
+
+static unsigned int
+hidpp20_onboard_profiles_macro_sector_count(union hidpp20_macro_data *macro,
+					    uint16_t sector_size,
+					    uint8_t offset)
+{
+	unsigned int records = 0;
+	unsigned int sectors = 1;
+	unsigned int macro_area = sector_size;
+
+	while (macro && macro->any.type != HIDPP20_MACRO_END) {
+		records++;
+		macro++;
+	}
+
+	while (records > ((macro_area - offset) / sizeof(union hidpp20_macro_data)) - 1) {
+		records -= ((macro_area - offset) / sizeof(union hidpp20_macro_data)) - 1;
+		offset = 0;
+		sectors++;
+	}
+
+	return sectors;
+}
+
+static void
+hidpp20_onboard_profiles_mark_macro_used(struct hidpp20_profile *profile,
+					 unsigned int button_index,
+					 uint16_t sector_size,
+					 bool used[UINT8_MAX + 1])
+{
+	uint8_t sector = profile->buttons[button_index].macro.zero;
+	unsigned int count;
+	unsigned int i;
+
+	if (!profile->macros[button_index])
+		return;
+
+	count = hidpp20_onboard_profiles_macro_sector_count(
+		profile->macros[button_index],
+		sector_size,
+		profile->buttons[button_index].macro.offset);
+
+	for (i = 0; i < count && sector + i <= UINT8_MAX; i++)
+		used[sector + i] = true;
+}
+
+static int
+hidpp20_onboard_profiles_is_empty_sector(struct hidpp20_device *device,
+					 struct hidpp20_profiles *profiles,
+					 uint16_t sector)
+{
+	_cleanup_free_ uint8_t *data = NULL;
+	unsigned int i;
+	int rc;
+
+	data = hidpp20_onboard_profiles_allocate_sector(profiles);
+	if (!data)
+		return -ENOMEM;
+
+	rc = hidpp20_onboard_profiles_read_sector(device,
+						  sector,
+						  profiles->sector_size,
+						  data);
+	if (rc)
+		return rc;
+
+	for (i = 0; i < (unsigned int)profiles->sector_size - 1; i++) {
+		if (data[i] != 0xff)
+			return 0;
+	}
+
+	return data[profiles->sector_size - 1] == 0xff ||
+	       data[profiles->sector_size - 1] == 0x00;
+}
+
+static int
+hidpp20_onboard_profiles_find_free_macro_sectors(struct hidpp20_device *device,
+						 struct hidpp20_profiles *profiles,
+						 bool used[UINT8_MAX + 1],
+						 unsigned int count)
+{
+	uint16_t sector;
+	unsigned int i;
+	int rc;
+
+	for (sector = profiles->num_profiles + 1; sector < profiles->sector_count; sector++) {
+		if (sector + count > profiles->sector_count)
+			return -ENOSPC;
+
+		for (i = 0; i < count; i++) {
+			if (used[sector + i])
+				break;
+
+			rc = hidpp20_onboard_profiles_is_empty_sector(device,
+								     profiles,
+								     sector + i);
+			if (rc <= 0)
+				break;
+		}
+
+		if (i == count)
+			return sector;
+	}
+
+	return -ENOSPC;
+}
+
+static int
+hidpp20_onboard_profiles_write_macros(struct hidpp20_device *device,
+				      struct hidpp20_profiles *profiles_list)
+{
+	struct hidpp20_profile *profile;
+	bool used[UINT8_MAX + 1] = {0};
+	unsigned int p, b, i;
+	int rc;
+
+	for (p = 0; p <= profiles_list->num_profiles && p <= UINT8_MAX; p++)
+		used[p] = true;
+
+	for (p = 0; p < profiles_list->num_profiles; p++) {
+		profile = &profiles_list->profiles[p];
+
+		for (b = 0; b < profiles_list->num_buttons; b++) {
+			if (profile->buttons[b].any.type != HIDPP20_BUTTON_MACRO)
+				continue;
+
+			if (profile->dirty_macros & (1U << b))
+				continue;
+
+			hidpp20_onboard_profiles_mark_macro_used(profile,
+								 b,
+								 profiles_list->sector_size,
+								 used);
+		}
+	}
+
+	for (p = 0; p < profiles_list->num_profiles; p++) {
+		profile = &profiles_list->profiles[p];
+
+		for (b = 0; b < profiles_list->num_buttons; b++) {
+			unsigned int count;
+			uint8_t sector;
+
+			if (!(profile->dirty_macros & (1U << b)))
+				continue;
+
+			if (profile->buttons[b].any.type != HIDPP20_BUTTON_MACRO)
+				continue;
+
+			if (!profile->macros[b])
+				return -EINVAL;
+
+			count = hidpp20_onboard_profiles_macro_sector_count(profile->macros[b],
+									    profiles_list->sector_size,
+									    0);
+			sector = profile->buttons[b].macro.zero;
+
+			rc = -ENOSPC;
+			if (sector > profiles_list->num_profiles &&
+			    sector + count <= profiles_list->sector_count) {
+				for (i = 0; i < count; i++) {
+					if (used[sector + i])
+						break;
+				}
+				if (i == count)
+					rc = sector;
+			}
+
+			if (rc < 0)
+				rc = hidpp20_onboard_profiles_find_free_macro_sectors(device,
+										      profiles_list,
+										      used,
+										      count);
+			if (rc < 0)
+				return rc;
+
+			rc = hidpp20_onboard_profiles_write_macro(device,
+								  profiles_list,
+								  profile,
+								  b,
+								  rc);
+			if (rc)
+				return rc;
+
+			hidpp20_onboard_profiles_mark_macro_used(profile,
+								 b,
+								 profiles_list->sector_size,
+								 used);
+		}
+	}
+
+	for (p = 0; p < profiles_list->num_profiles; p++)
+		profiles_list->profiles[p].dirty_macros = 0;
+
+	return 0;
 }
 
 static void
@@ -2997,6 +3305,10 @@ hidpp20_onboard_profiles_commit(struct hidpp20_device *device,
 	unsigned int i;
 	bool enabled_profile = false;
 	int rc;
+
+	rc = hidpp20_onboard_profiles_write_macros(device, profiles_list);
+	if (rc < 0)
+		return rc;
 
 	for (i = 0; i < profiles_list->num_profiles; i++) {
 		profile = &profiles_list->profiles[i];

--- a/src/hidpp20.h
+++ b/src/hidpp20.h
@@ -886,6 +886,7 @@ struct hidpp20_profile {
 	uint16_t dpi[HIDPP20_DPI_COUNT];
 	union hidpp20_button_binding buttons[32];
 	union hidpp20_macro_data *macros[32];
+	uint32_t dirty_macros;
 	struct hidpp20_led leds[HIDPP20_LED_COUNT];
 	struct hidpp20_led alt_leds[HIDPP20_LED_COUNT];
 };


### PR DESCRIPTION
HID++ 2.0 onboard profile macro updates were converted through ratbag_action_keycode_from_macro(), which only supports simple single-key macros. Multi-key macros failed to commit and Piper rolled the device back to the previous state.

Translate ratbag macro events into HID++ macro records, write them to onboard macro sectors, and update the button binding to point at the macro data. Reuse an existing macro sector for edits when possible and allocate an empty sector for new macro bindings.

Also parse macros across the device's full onboard sector instead of stopping at 16-byte boundaries. Some devices report ERR_HARDWARE_ERROR when finalizing a successful memory write, matching the existing reset helper behavior, so accept that response for write-end.

Tested on a Logitech G604 over a Lightspeed receiver with ratbagctl multi-key macros and persistence across ratbagd restarts.