### PR TITLE
ratbagd: line buffer stdout/stderr

### DIFF
--- a/ratbagd/ratbagd.c
+++ b/ratbagd/ratbagd.c
@@ -625,6 +625,9 @@ int main(int argc, char *argv[])
 	setrlimit(RLIMIT_CORE, &corelimit);
 #endif
 
+	setlinebuf(stdout);
+	setlinebuf(stderr);
+
 	if (argc > 1) {
 		if (streq(argv[1], "--version")) {
 			printf("%s\n", RATBAG_VERSION);


### PR DESCRIPTION
When stdout is a TTY, printing is line buffered, but when running under a service manager and stdout is a pipe/file printing is fully buffered by default, so you don't see any logging until several KB is printed, making debugging confusing. Always set line buffered on stdout/stderr to fix this.