### PR TITLE
feature: Add support for Glorious Model I

### DIFF
--- a/data/devices/glorious-model-i.device
+++ b/data/devices/glorious-model-i.device
@@ -1,0 +1,11 @@
+[Device]
+Name=Glorious Model I
+DeviceMatch=usb:22d4:1503
+DeviceType=mouse
+Driver=sinowealth
+
+[Driver/sinowealth/devices/V103]
+Buttons=9
+DeviceName=Glorious Model I
+LedType=RBG
+SensorType=PMW3360


### PR DESCRIPTION
No one has created a device file for the Model I, so I decided I might try it and quickly created this.
Not sure how well it'll work considering this is the Model O device file but with some information replaced, including 9 buttons instead of 6.
I'm a novice with Git/GitHub and barely understand what I'm doing with libratbag so I'd appreciate any help with implementing support for the Model I/learning how to use PRs and GitHub stuff.