### PR TITLE
data: enable INDEX_OFFSET on G502 X and G502 X Wireless

### DIFF
--- a/data/devices/logitech-g502-x-wireless.device
+++ b/data/devices/logitech-g502-x-wireless.device
@@ -3,3 +3,6 @@ Name=Logitech G502 X Wireless
 DeviceMatch=usb:046d:c098;usb:046d:409f
 DeviceType=mouse
 Driver=hidpp20
+
+[Driver/hidpp20]
+Quirk=INDEX_OFFSET

--- a/data/devices/logitech-g502-x.device
+++ b/data/devices/logitech-g502-x.device
@@ -3,3 +3,6 @@ Name=Logitech G502 X
 DeviceMatch=usb:046d:c099
 DeviceType=mouse
 Driver=hidpp20
+
+[Driver/hidpp20]
+Quirk=INDEX_OFFSET


### PR DESCRIPTION
f9d1574 enabled this for the G502 X PLUS, which is the RGB variant. I can confirm the normal G502 X Wireless has this as well, resulting in profile weirdness.  I do _not_ have a base model G502 X, but comments on issue #1606 as well as logic suggest it very likely suffers from this unless proven otherwise.