### PR TITLE
swig: use the Python 3 C API instead of the removed PyInt_* aliases

### DIFF
--- a/src/libratbag.i
+++ b/src/libratbag.i
@@ -21,12 +21,12 @@
   $1 = (unsigned int *) malloc(($2 + 1) * sizeof(unsigned int));
   for (i = 0; i < $2; i++) {
     PyObject *s = PyList_GetItem($input, i);
-    if (!PyInt_Check(s)) {
+    if (!PyLong_Check(s)) {
        free($1);
        PyErr_SetString(PyExc_ValueError, "List items must be integers");
        return NULL;
     }
-    $1[i] = PyInt_AsLong(s);
+    $1[i] = PyLong_AsLong(s);
   }
   $1[i] = 0;
 }
@@ -34,7 +34,7 @@
 %typemap(argout) (unsigned int *resolutions, size_t nres) {
   unsigned int i;
   for (i = 0; i < $2; i++) {
-    PyList_SetItem($input, i, PyInt_FromLong($1[i]));
+    PyList_SetItem($input, i, PyLong_FromLong($1[i]));
   }
 }
 
@@ -61,24 +61,24 @@
 
 /* uintXX_t mapping: Python -> C */
 %typemap(in) uint8_t {
-    $1 = (uint8_t) PyInt_AsLong($input);
+    $1 = (uint8_t) PyLong_AsLong($input);
 }
 %typemap(in) uint16_t {
-    $1 = (uint16_t) PyInt_AsLong($input);
+    $1 = (uint16_t) PyLong_AsLong($input);
 }
 %typemap(in) uint32_t {
-    $1 = (uint32_t) PyInt_AsLong($input);
+    $1 = (uint32_t) PyLong_AsLong($input);
 }
 
 /* uintXX_t mapping: C -> Python */
 %typemap(out) uint8_t {
-    $result = PyInt_FromLong((long) $1);
+    $result = PyLong_FromLong((long) $1);
 }
 %typemap(out) uint16_t {
-    $result = PyInt_FromLong((long) $1);
+    $result = PyLong_FromLong((long) $1);
 }
 %typemap(out) uint32_t {
-    $result = PyInt_FromLong((long) $1);
+    $result = PyLong_FromLong((long) $1);
 }
 
 /*  Parse the header file to generate wrappers */


### PR DESCRIPTION
libratbag currently fails to build against SWIG 4.5.0.

`src/libratbag.i` calls `PyInt_Check()`, `PyInt_AsLong()` and `PyInt_FromLong()` (9 uses). These are Python 2 functions; they only ever worked because SWIG emitted compatibility macros mapping them onto their `PyLong_*` counterparts in the generated wrapper. SWIG 4.5.0 dropped those macros, so the generated `libratbag.c` no longer compiles:

```
_libratbag.so.p/libratbag.c: In function ‘_wrap_ratbag_device_get_vendor_id’:
_libratbag.so.p/libratbag.c:4583:17: error: implicit declaration of function ‘PyInt_FromLong’; did you mean ‘PyLong_FromLong’? [-Wimplicit-function-declaration]
_libratbag.so.p/libratbag.c:4583:15: error: assignment to ‘PyObject *’ from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
_libratbag.so.p/libratbag.c: In function ‘_wrap_ratbag_profile_get_report_rate_list’:
_libratbag.so.p/libratbag.c:5168:12: error: implicit declaration of function ‘PyInt_Check’; did you mean ‘PySet_Check’? [-Wimplicit-function-declaration]
_libratbag.so.p/libratbag.c:5173:17: error: implicit declaration of function ‘PyInt_AsLong’; did you mean ‘PyLong_AsLong’? [-Wimplicit-function-declaration]
_libratbag.so.p/libratbag.c:5182:38: error: passing argument 3 of ‘PyList_SetItem’ makes pointer from integer without a cast [-Wint-conversion]
ninja: build stopped: subcommand failed.
```

Calling the `PyLong_*` functions directly fixes it. The bindings are generated with `swig -py3`, so there is no Python 2 build to keep working, and the macros being replaced expanded to exactly these functions.

Built and verified on Arch Linux with swig 4.5.0, Python 3.14, meson 1.12.0, gcc 15: `_libratbag.so` and `_hidpp.so` link cleanly with the change and fail without it.