### PR TITLE
driver-hidpp20: fix wrong active DPI after reboot

### DIFF
--- a/src/driver-hidpp20.c
+++ b/src/driver-hidpp20.c
@@ -1201,13 +1201,17 @@ hidpp20drv_read_profile_8100(struct ratbag_profile *profile)
 
 	profile->is_active = (profile->index == drv_data->profiles->active_profile_index);
 
-	if (profile->is_active)
-		dpi_index = hidpp20_onboard_profiles_get_current_dpi_index(drv_data->dev);
-
-	if (dpi_index < 0)
-		dpi_index = 0xff;
-
 	p = &drv_data->profiles->profiles[profile->index];
+
+	if (profile->is_active) {
+		dpi_index = hidpp20_onboard_profiles_get_current_dpi_index(drv_data->dev);
+		/* The HID++ command may return a stale value after reboot.
+		 * Prefer the switched_dpi stored in the profile data, which
+		 * is what the device firmware actually uses to set the DPI
+		 * when loading the profile from onboard memory. */
+		if (dpi_index < 0 || dpi_index > 4 || (unsigned int)dpi_index != p->switched_dpi)
+			dpi_index = p->switched_dpi;
+	}
 
 	ratbag_profile_for_each_resolution(profile, res) {
 		struct hidpp20_sensor *sensor;
@@ -1531,6 +1535,19 @@ hidpp20drv_commit(struct ratbag_device *device)
 	if (drv_data->capabilities & HIDPP_CAP_ONBOARD_PROFILES_8100) {
 		list_for_each(profile, &device->profiles, link)
 			drv_data->profiles->profiles[profile->index].enabled = profile->is_enabled;
+
+		/* Update switched_dpi in the profile data before committing
+		 * so the correct DPI index is persisted to onboard memory.
+		 * The device firmware uses switched_dpi to set the DPI when
+		 * loading the profile after a reboot. */
+		list_for_each(profile, &device->profiles, link) {
+			if (profile->is_active) {
+				ratbag_profile_for_each_resolution(profile, resolution) {
+					if (resolution->is_active)
+						drv_data->profiles->profiles[profile->index].switched_dpi = resolution->index;
+				}
+			}
+		}
 
 		rc = hidpp20_onboard_profiles_commit(drv_data->dev,
 						     drv_data->profiles);


### PR DESCRIPTION
Fixes piper#970

After reboot, the HID++ `GET_CURRENT_DPI_INDEX` command (0xB0) may return a stale value that doesn't match the DPI index the device firmware actually loaded from the profile's `switched_dpi` field.

## Root Cause

The device firmware uses `switched_dpi` from the profile data in onboard memory to set the active DPI after reboot. However, libratbag determines the active resolution solely via the HID++ 0xB0 command, which can return a wrong/stale value.

Additionally, `switched_dpi` was never updated when the user changed the active DPI, so the stale value was written back to flash on the next commit.

## Fix

**Read path** (`hidpp20drv_read_profile_8100`): When the HID++ command result disagrees with `switched_dpi` stored in the profile data, prefer `switched_dpi` — this is what the firmware actually uses.

**Write path** (`hidpp20drv_commit`): Update `switched_dpi` in the profile struct before committing to onboard memory, so the correct DPI index is persisted and used by the firmware on next boot.