### PR TITLE
razer: add a driver for Razer mice, starting with the DeathAdder V3

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ features exposed by these mice and abstracts away hardware-specific and
 kernel-specific quirks.
 
 libratbag currently supports devices from Logitech, Etekcity, GSkill,
-Roccat, Steelseries. See [the device
+Razer, Roccat, Steelseries. See [the device
 files](https://github.com/libratbag/libratbag/tree/master/data/devices) for
 a complete list of supported devices.
 

--- a/data/devices/device.example
+++ b/data/devices/device.example
@@ -77,6 +77,27 @@ DpiRange=100:16000@100
 # Device quirks
 # Quirk=DOUBLE_DPI;STRIX_PROFILE
 
+[Driver/razer]
+# Number of buttons. Reported so they show up in the UI, this driver does
+# not remap them.
+Buttons=6
+
+# The number of DPI stages the device stores, 1 to 5.
+DpiStages=5
+
+# DPI range in the form min:max@step
+# Mutually exclusive with DpiList
+DpiRange=100:30000@100
+
+# The list of available resolutions, separated by semicolons.
+# Mutually exclusive with DpiRange
+# DpiList=400;800;1600;3200
+
+# The transaction id groups request and response and is model specific:
+# 31 (0x1f) for the DeathAdder V3 generation, 255 (0xff) for older Razer
+# mice. Optional, defaults to 31.
+# TransactionId=31
+
 # Replace `FEED` in the group name with firmware version of the device.
 # To find the right value, see the output of ratbagd and search a message like:
 # "ratbag error: Device with firmware version FEED is not supported"

--- a/data/devices/razer-deathadder-v3.device
+++ b/data/devices/razer-deathadder-v3.device
@@ -1,0 +1,13 @@
+[Device]
+DeviceMatch=usb:1532:00b2
+DeviceType=mouse
+Driver=razer
+Name=Razer DeathAdder V3
+
+[Driver/razer]
+# reported so they show up in the UI; this driver does not remap them
+Buttons=6
+DpiRange=100:30000@100
+DpiStages=5
+# 31 == 0x1f, verified against the device (firmware v1.2); older Razer mice use 0xff
+TransactionId=31

--- a/meson.build
+++ b/meson.build
@@ -176,6 +176,7 @@ src_libratbag = [
 	'src/driver-hidpp10.c',
 	'src/driver-logitech-g300.c',
 	'src/driver-logitech-g600.c',
+	'src/driver-razer.c',
 	'src/driver-roccat.c',
 	'src/driver-roccat-kone-emp.c',
 	'src/driver-roccat-kone-pure.c',

--- a/src/driver-razer.c
+++ b/src/driver-razer.c
@@ -1,0 +1,822 @@
+/*
+ * Copyright © 2026 Dennis Schweizer
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+/*
+ * Driver for Razer mice speaking the "Razer report" control protocol.
+ *
+ * The protocol is a 90 byte HID feature report on report id 0. Every command
+ * is answered by reading the same feature report back. The wire format was
+ * cross-checked against OpenRazer's kernel driver and verified against a
+ * DeathAdder V3 (1532:00b2, firmware 1.2) before this driver was written.
+ *
+ * Finding the control interface
+ * -----------------------------
+ * The feature report is declared in the vendor usage page 0xff00, but that
+ * page sits *inside* the Generic Desktop/Mouse application collection:
+ *
+ *     05 01 09 02 a1 01                  Generic Desktop, Mouse, Application
+ *       [...]
+ *       06 00 ff 09 02                   usage page 0xff00, usage 0x02
+ *       15 00 25 01 75 08 95 5a b1 01    feature, 0x5a = 90 bytes
+ *     c0
+ *
+ * ratbag_hidraw_has_vendor_page() cannot see this: the descriptor parser
+ * records the usage page of the first application collection only, so the
+ * interface is filed under Generic Desktop and the vendor page is never
+ * indexed. The remaining two interfaces of the device are keyboard
+ * collections (usage 0x06), which is what razer_test_hidraw() tells apart.
+ *
+ * The descriptor check comes first and nothing is sent before it passes:
+ * a request to the keyboard collections stalls the control transfer, the
+ * device resets and udev re-adds it, which loops. A firmware request then
+ * confirms that the one remaining candidate really speaks the protocol.
+ *
+ * No lighting
+ * -----------
+ * The DeathAdder V3 has no addressable lighting zone, only a DPI indicator
+ * LED with no documented protocol; OpenRazer creates poll_rate, dpi and
+ * dpi_stages for 0x00b2 and no LED attribute at all. This driver reports
+ * zero LEDs. Models that do have zones need a device data key and a led
+ * count in ratbag_device_init_profiles(), not a restructuring.
+ *
+ * Two details differ from OpenRazer and are deliberate here:
+ *
+ *   - DPI stage ids are 1-based. The device reports stages as id 1..5, so
+ *     this driver writes them back the same way. OpenRazer writes 0-based
+ *     ids when setting stages.
+ *
+ *   - The last two bytes of a stage record are not reserved. On the
+ *     DeathAdder V3 they hold a third copy of the stage's DPI value.
+ *     OpenRazer zeroes them; this driver preserves what the device
+ *     reported and only rewrites the field for stages it actually changes.
+ */
+
+#include "config.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "libratbag-private.h"
+#include "libratbag-hidraw.h"
+#include "libratbag-data.h"
+
+#define RAZER_REPORT_LEN		90
+#define RAZER_REPORT_ID			0x00
+/* buffer handed to the hidraw helpers: report id byte + report */
+#define RAZER_BUF_LEN			(RAZER_REPORT_LEN + 1)
+
+/*
+ * Transaction id. Razer uses this to group request and response; the value
+ * is model specific. 0x1f covers the DeathAdder V3 generation, older models
+ * use 0xff. Kept in the device data so other models can be added without
+ * touching this file.
+ */
+#define RAZER_DEFAULT_TRANSACTION_ID	0x1f
+
+/* the application collection the control interface reports for report id 0 */
+#define HID_USAGE_PAGE_GENERIC_DESKTOP	0x01
+#define HID_USAGE_MOUSE			0x02
+
+#define RAZER_NUM_PROFILES		1
+#define RAZER_MAX_DPI_STAGES		5
+#define RAZER_STAGE_RECORD_LEN		7
+
+/* variable storage selectors */
+#define RAZER_NOSTORE			0x00
+#define RAZER_VARSTORE			0x01
+
+/* command classes */
+#define RAZER_CLASS_MISC		0x00
+#define RAZER_CLASS_DPI			0x04
+
+/* command ids */
+#define RAZER_CMD_GET_FIRMWARE		0x81
+#define RAZER_CMD_GET_SERIAL		0x82
+#define RAZER_CMD_SET_POLL_RATE2	0x40
+#define RAZER_CMD_GET_POLL_RATE2	0xc0
+#define RAZER_CMD_SET_DPI		0x05
+#define RAZER_CMD_GET_DPI		0x85
+#define RAZER_CMD_SET_DPI_STAGES	0x06
+#define RAZER_CMD_GET_DPI_STAGES	0x86
+
+/* response status codes */
+#define RAZER_STATUS_NEW		0x00
+#define RAZER_STATUS_BUSY		0x01
+#define RAZER_STATUS_SUCCESS		0x02
+#define RAZER_STATUS_FAILURE		0x03
+#define RAZER_STATUS_TIMEOUT		0x04
+#define RAZER_STATUS_NOT_SUPPORTED	0x05
+
+/* the device needs a moment before the answer can be read back */
+#define RAZER_WAIT_US			1000
+#define RAZER_RETRY_WAIT_US		10000
+#define RAZER_NUM_RETRIES		5
+
+struct razer_report {
+	uint8_t status;
+	uint8_t transaction_id;
+	uint16_t remaining_packets;	/* big endian */
+	uint8_t protocol_type;
+	uint8_t data_size;
+	uint8_t command_class;
+	uint8_t command_id;
+	uint8_t arguments[80];
+	uint8_t crc;
+	uint8_t reserved;
+} __attribute__((packed));
+
+_Static_assert(sizeof(struct razer_report) == RAZER_REPORT_LEN,
+	       "struct razer_report must match the 90 byte wire format");
+
+struct razer_data {
+	uint8_t transaction_id;
+	unsigned int stage_count;
+	/*
+	 * Trailing per-stage field as read from the device. Observed to
+	 * mirror the DPI, but its meaning is not documented, so it is
+	 * carried over untouched for stages that stay unchanged.
+	 */
+	uint16_t stage_trailer[RAZER_MAX_DPI_STAGES];
+};
+
+/*
+ * The DeathAdder V3 reports rates in a bitmask-like encoding rather than as
+ * a divisor. Highest rate is the lowest bit.
+ */
+static const struct razer_rate_map {
+	unsigned int hz;
+	uint8_t code;
+} razer_rate_map[] = {
+	{ 8000, 0x01 },
+	{ 4000, 0x02 },
+	{ 2000, 0x04 },
+	{ 1000, 0x08 },
+	{  500, 0x10 },
+	{  250, 0x20 },
+	{  125, 0x40 },
+};
+
+static uint8_t
+razer_rate_to_code(unsigned int hz)
+{
+	for (size_t i = 0; i < ARRAY_LENGTH(razer_rate_map); i++) {
+		if (razer_rate_map[i].hz == hz)
+			return razer_rate_map[i].code;
+	}
+	return 0;
+}
+
+static unsigned int
+razer_code_to_rate(uint8_t code)
+{
+	for (size_t i = 0; i < ARRAY_LENGTH(razer_rate_map); i++) {
+		if (razer_rate_map[i].code == code)
+			return razer_rate_map[i].hz;
+	}
+	return 0;
+}
+
+static struct razer_report
+razer_init_report(uint8_t transaction_id, uint8_t command_class,
+		  uint8_t command_id, uint8_t data_size)
+{
+	struct razer_report report;
+
+	memset(&report, 0, sizeof(report));
+	report.status = RAZER_STATUS_NEW;
+	report.transaction_id = transaction_id;
+	report.command_class = command_class;
+	report.command_id = command_id;
+	report.data_size = data_size;
+
+	return report;
+}
+
+/* simple XOR over bytes 2..87, the two trailing bytes are excluded */
+static uint8_t
+razer_crc(const struct razer_report *report)
+{
+	const uint8_t *bytes = (const uint8_t *)report;
+	uint8_t crc = 0;
+
+	for (unsigned int i = 2; i < 88; i++)
+		crc ^= bytes[i];
+
+	return crc;
+}
+
+static const char *
+razer_status_string(uint8_t status)
+{
+	switch (status) {
+	case RAZER_STATUS_NEW:		return "new command";
+	case RAZER_STATUS_BUSY:		return "busy";
+	case RAZER_STATUS_SUCCESS:	return "success";
+	case RAZER_STATUS_FAILURE:	return "failure";
+	case RAZER_STATUS_TIMEOUT:	return "timeout";
+	case RAZER_STATUS_NOT_SUPPORTED:return "not supported";
+	default:			return "unknown";
+	}
+}
+
+/**
+ * Send one command and read its answer back.
+ *
+ * @return 0 on success or a negative errno
+ */
+static int
+razer_transact_n(struct ratbag_device *device,
+		 struct razer_report *request,
+		 struct razer_report *response,
+		 int retries)
+{
+	uint8_t buf[RAZER_BUF_LEN];
+	uint8_t status = RAZER_STATUS_NEW;
+	int rc = -ETIMEDOUT;
+
+	request->crc = razer_crc(request);
+
+	for (int retry = 0; retry < retries; retry++) {
+		memset(buf, 0, sizeof(buf));
+		memcpy(buf + 1, request, RAZER_REPORT_LEN);
+
+		rc = ratbag_hidraw_set_feature_report(device, RAZER_REPORT_ID,
+						      buf, sizeof(buf));
+		if (rc < 0)
+			goto retry;
+
+		usleep(RAZER_WAIT_US);
+
+		memset(buf, 0, sizeof(buf));
+		rc = ratbag_hidraw_get_feature_report(device, RAZER_REPORT_ID,
+						      buf, sizeof(buf));
+		if (rc < 0)
+			goto retry;
+		if (rc < (int)RAZER_BUF_LEN) {
+			rc = -EIO;
+			goto retry;
+		}
+
+		memcpy(response, buf + 1, RAZER_REPORT_LEN);
+
+		/* the answer has to belong to the command we just sent */
+		if (response->command_class != request->command_class ||
+		    response->command_id != request->command_id) {
+			rc = -EINVAL;
+			goto retry;
+		}
+
+		status = response->status;
+
+		/* some commands answer 'busy' but have taken effect anyway */
+		if (status == RAZER_STATUS_SUCCESS || status == RAZER_STATUS_BUSY)
+			return 0;
+
+		switch (status) {
+		case RAZER_STATUS_NOT_SUPPORTED:
+			/* retrying will not make the device grow the feature */
+			log_debug(device->ratbag,
+				  "razer: command %02x/%02x not supported\n",
+				  request->command_class, request->command_id);
+			return -ENOTSUP;
+		case RAZER_STATUS_FAILURE:
+			rc = -EINVAL;
+			break;
+		case RAZER_STATUS_TIMEOUT:
+			rc = -ETIMEDOUT;
+			break;
+		default:
+			rc = -EIO;
+			break;
+		}
+
+retry:
+		log_debug(device->ratbag,
+			  "razer: command %02x/%02x failed (%d, status %s), %d retries left\n",
+			  request->command_class, request->command_id, rc,
+			  razer_status_string(status),
+			  retries - retry - 1);
+		usleep(RAZER_RETRY_WAIT_US);
+	}
+
+	return rc;
+}
+
+static int
+razer_transact(struct ratbag_device *device,
+	       struct razer_report *request,
+	       struct razer_report *response)
+{
+	return razer_transact_n(device, request, response, RAZER_NUM_RETRIES);
+}
+
+static int
+razer_get_firmware_version(struct ratbag_device *device,
+			   unsigned int *major, unsigned int *minor)
+{
+	struct razer_data *drv_data = ratbag_get_drv_data(device);
+	struct razer_report request, response;
+	int rc;
+
+	request = razer_init_report(drv_data->transaction_id,
+				    RAZER_CLASS_MISC, RAZER_CMD_GET_FIRMWARE, 0x02);
+
+	rc = razer_transact(device, &request, &response);
+	if (rc)
+		return rc;
+
+	*major = response.arguments[0];
+	*minor = response.arguments[1];
+
+	return 0;
+}
+
+static int
+razer_get_report_rate(struct ratbag_device *device, unsigned int *hz)
+{
+	struct razer_data *drv_data = ratbag_get_drv_data(device);
+	struct razer_report request, response;
+	unsigned int rate;
+	int rc;
+
+	request = razer_init_report(drv_data->transaction_id,
+				    RAZER_CLASS_MISC, RAZER_CMD_GET_POLL_RATE2, 0x01);
+
+	rc = razer_transact(device, &request, &response);
+	if (rc)
+		return rc;
+
+	/*
+	 * The device echoes data_size 1 but puts the answer in
+	 * arguments[1], so the declared size cannot be used here.
+	 */
+	rate = razer_code_to_rate(response.arguments[1]);
+	if (!rate) {
+		log_debug(device->ratbag,
+			  "razer: unknown report rate code 0x%02x\n",
+			  response.arguments[1]);
+		return -EINVAL;
+	}
+
+	*hz = rate;
+
+	return 0;
+}
+
+static int
+razer_set_report_rate(struct ratbag_device *device, unsigned int hz)
+{
+	struct razer_data *drv_data = ratbag_get_drv_data(device);
+	struct razer_report request, response;
+	uint8_t code;
+	int rc;
+
+	code = razer_rate_to_code(hz);
+	if (!code) {
+		log_error(device->ratbag,
+			  "razer: unsupported report rate %u Hz\n", hz);
+		return -EINVAL;
+	}
+
+	/*
+	 * Razer sends this command twice, once with arguments[0] == 0 and
+	 * once with 1. Both are needed for the change to stick.
+	 */
+	for (uint8_t pass = 0; pass <= 1; pass++) {
+		request = razer_init_report(drv_data->transaction_id,
+					    RAZER_CLASS_MISC,
+					    RAZER_CMD_SET_POLL_RATE2, 0x02);
+		request.arguments[0] = pass;
+		request.arguments[1] = code;
+
+		rc = razer_transact(device, &request, &response);
+		if (rc)
+			return rc;
+	}
+
+	return 0;
+}
+
+struct razer_stage {
+	uint8_t id;		/* 1-based */
+	uint16_t dpi_x;
+	uint16_t dpi_y;
+	uint16_t trailer;
+};
+
+static int
+razer_get_dpi_stages(struct ratbag_device *device,
+		     struct razer_stage stages[RAZER_MAX_DPI_STAGES],
+		     unsigned int *count, unsigned int *active)
+{
+	struct razer_data *drv_data = ratbag_get_drv_data(device);
+	struct razer_report request, response;
+	unsigned int n;
+	int rc;
+
+	request = razer_init_report(drv_data->transaction_id,
+				    RAZER_CLASS_DPI, RAZER_CMD_GET_DPI_STAGES, 0x26);
+	request.arguments[0] = RAZER_VARSTORE;
+
+	rc = razer_transact(device, &request, &response);
+	if (rc)
+		return rc;
+
+	*active = response.arguments[1];
+	n = response.arguments[2];
+
+	if (n == 0 || n > RAZER_MAX_DPI_STAGES) {
+		log_error(device->ratbag,
+			  "razer: device reports %u dpi stages, expected 1..%d\n",
+			  n, RAZER_MAX_DPI_STAGES);
+		return -EINVAL;
+	}
+
+	for (unsigned int i = 0; i < n; i++) {
+		const uint8_t *rec = &response.arguments[3 + i * RAZER_STAGE_RECORD_LEN];
+
+		stages[i].id = rec[0];
+		stages[i].dpi_x = (rec[1] << 8) | rec[2];
+		stages[i].dpi_y = (rec[3] << 8) | rec[4];
+		stages[i].trailer = (rec[5] << 8) | rec[6];
+	}
+
+	*count = n;
+
+	return 0;
+}
+
+static int
+razer_set_dpi_stages(struct ratbag_device *device,
+		     const struct razer_stage stages[RAZER_MAX_DPI_STAGES],
+		     unsigned int count, unsigned int active)
+{
+	struct razer_data *drv_data = ratbag_get_drv_data(device);
+	struct razer_report request, response;
+	uint8_t data_size;
+
+	assert(count > 0 && count <= RAZER_MAX_DPI_STAGES);
+
+	data_size = 3 + count * RAZER_STAGE_RECORD_LEN;
+
+	request = razer_init_report(drv_data->transaction_id,
+				    RAZER_CLASS_DPI, RAZER_CMD_SET_DPI_STAGES,
+				    data_size);
+	request.arguments[0] = RAZER_VARSTORE;
+	request.arguments[1] = active;
+	request.arguments[2] = count;
+
+	for (unsigned int i = 0; i < count; i++) {
+		uint8_t *rec = &request.arguments[3 + i * RAZER_STAGE_RECORD_LEN];
+
+		rec[0] = stages[i].id;
+		rec[1] = stages[i].dpi_x >> 8;
+		rec[2] = stages[i].dpi_x & 0xff;
+		rec[3] = stages[i].dpi_y >> 8;
+		rec[4] = stages[i].dpi_y & 0xff;
+		rec[5] = stages[i].trailer >> 8;
+		rec[6] = stages[i].trailer & 0xff;
+	}
+
+	return razer_transact(device, &request, &response);
+}
+
+static int
+razer_set_active_dpi(struct ratbag_device *device,
+		     unsigned int dpi_x, unsigned int dpi_y)
+{
+	struct razer_data *drv_data = ratbag_get_drv_data(device);
+	struct razer_report request, response;
+
+	request = razer_init_report(drv_data->transaction_id,
+				    RAZER_CLASS_DPI, RAZER_CMD_SET_DPI, 0x07);
+	request.arguments[0] = RAZER_VARSTORE;
+	request.arguments[1] = dpi_x >> 8;
+	request.arguments[2] = dpi_x & 0xff;
+	request.arguments[3] = dpi_y >> 8;
+	request.arguments[4] = dpi_y & 0xff;
+
+	return razer_transact(device, &request, &response);
+}
+
+/**
+ * Pick the interface that speaks the control protocol: the mouse collection,
+ * never the keyboard ones. See "Finding the control interface" at the top of
+ * this file for why ratbag_hidraw_has_vendor_page() is no help and why the
+ * descriptor is checked before anything is sent.
+ */
+static int
+razer_test_hidraw(struct ratbag_device *device)
+{
+	struct razer_data *drv_data = ratbag_get_drv_data(device);
+	struct razer_report request, response;
+
+	if (ratbag_hidraw_get_usage_page(device, 0) != HID_USAGE_PAGE_GENERIC_DESKTOP ||
+	    ratbag_hidraw_get_usage(device, 0) != HID_USAGE_MOUSE)
+		return 0;
+
+	request = razer_init_report(drv_data->transaction_id,
+				    RAZER_CLASS_MISC, RAZER_CMD_GET_FIRMWARE, 0x02);
+
+	return razer_transact_n(device, &request, &response, 1) == 0;
+}
+
+/*
+ * Buttons are reported so that they show up in the UI, but this driver does
+ * not remap them - the request was to leave everything except DPI alone.
+ * No action type is enabled, so libratbag refuses writes for them.
+ */
+static void
+razer_init_button(struct ratbag_button *button, size_t button_count)
+{
+	struct ratbag_button_action actions[8] = {
+		BUTTON_ACTION_BUTTON(1),
+		BUTTON_ACTION_BUTTON(2),
+		BUTTON_ACTION_BUTTON(3),
+		BUTTON_ACTION_BUTTON(4),
+		BUTTON_ACTION_BUTTON(5),
+		BUTTON_ACTION_BUTTON(6),
+		BUTTON_ACTION_BUTTON(7),
+		BUTTON_ACTION_BUTTON(8),
+	};
+
+	if (button->index >= ARRAY_LENGTH(actions))
+		return;
+
+	/* the last button is the DPI cycle button underneath the mouse */
+	if (button_count >= 1 && button->index == button_count - 1) {
+		actions[button->index].type = RATBAG_BUTTON_ACTION_TYPE_SPECIAL;
+		actions[button->index].action.special =
+			RATBAG_BUTTON_ACTION_SPECIAL_RESOLUTION_CYCLE_UP;
+	}
+
+	ratbag_button_set_action(button, &actions[button->index]);
+}
+
+static int
+razer_read_settings(struct ratbag_device *device)
+{
+	struct razer_data *drv_data = ratbag_get_drv_data(device);
+	struct razer_stage stages[RAZER_MAX_DPI_STAGES] = {0};
+	struct ratbag_profile *profile;
+	struct ratbag_resolution *resolution;
+	unsigned int count = 0, active = 0, hz = 0;
+	int rc;
+
+	rc = razer_get_dpi_stages(device, stages, &count, &active);
+	if (rc)
+		return rc;
+
+	if (count != drv_data->stage_count) {
+		log_error(device->ratbag,
+			  "razer: device reports %u dpi stages, %u were configured\n",
+			  count, drv_data->stage_count);
+		return -EINVAL;
+	}
+
+	ratbag_device_for_each_profile(device, profile) {
+		ratbag_profile_for_each_resolution(profile, resolution) {
+			const struct razer_stage *stage = &stages[resolution->index];
+
+			resolution->dpi_x = stage->dpi_x;
+			resolution->dpi_y = stage->dpi_y;
+			/* stage ids are 1-based, resolution indices are not */
+			resolution->is_active = (stage->id == active);
+			resolution->is_default = resolution->is_active;
+
+			drv_data->stage_trailer[resolution->index] = stage->trailer;
+		}
+
+		rc = razer_get_report_rate(device, &hz);
+		if (rc == 0)
+			profile->hz = hz;
+		else
+			log_debug(device->ratbag,
+				  "razer: could not read the report rate\n");
+	}
+
+	return 0;
+}
+
+static int
+razer_probe(struct ratbag_device *device)
+{
+	struct razer_data *drv_data;
+	struct ratbag_profile *profile;
+	struct ratbag_resolution *resolution;
+	struct ratbag_button *button;
+	const struct dpi_range *dpirange;
+	const struct dpi_list *dpilist;
+	unsigned int button_count, stage_count;
+	unsigned int major = 0, minor = 0;
+	int rc;
+
+	static const unsigned int report_rates[] = {
+		125, 250, 500, 1000, 2000, 4000, 8000,
+	};
+
+	/*
+	 * The transaction id has to be known before probing the interfaces,
+	 * because razer_test_hidraw() talks to the device to find the right
+	 * one.
+	 */
+	drv_data = zalloc(sizeof(*drv_data));
+	ratbag_set_drv_data(device, drv_data);
+
+	rc = ratbag_device_data_razer_get_transaction_id(device->data);
+	drv_data->transaction_id = (rc == -1) ? RAZER_DEFAULT_TRANSACTION_ID
+					      : (uint8_t)rc;
+
+	rc = ratbag_find_hidraw(device, razer_test_hidraw);
+	if (rc) {
+		log_debug(device->ratbag,
+			  "razer: no control interface found on this device\n");
+		goto err;
+	}
+
+	rc = ratbag_device_data_razer_get_dpi_stage_count(device->data);
+	stage_count = (rc == -1) ? RAZER_MAX_DPI_STAGES : (unsigned int)rc;
+	if (stage_count == 0 || stage_count > RAZER_MAX_DPI_STAGES) {
+		log_error(device->ratbag,
+			  "razer: DpiStages must be 1..%d, got %u\n",
+			  RAZER_MAX_DPI_STAGES, stage_count);
+		rc = -EINVAL;
+		goto err;
+	}
+	drv_data->stage_count = stage_count;
+
+	rc = ratbag_device_data_razer_get_button_count(device->data);
+	button_count = (rc == -1) ? 0 : (unsigned int)rc;
+
+	ratbag_device_init_profiles(device, RAZER_NUM_PROFILES, stage_count,
+				    button_count, 0);
+
+	dpirange = ratbag_device_data_razer_get_dpi_range(device->data);
+	dpilist = ratbag_device_data_razer_get_dpi_list(device->data);
+
+	ratbag_device_for_each_profile(device, profile) {
+		profile->is_active = true;
+
+		ratbag_profile_set_report_rate_list(profile, report_rates,
+						    ARRAY_LENGTH(report_rates));
+
+		ratbag_profile_for_each_resolution(profile, resolution) {
+			ratbag_resolution_set_cap(resolution,
+						  RATBAG_RESOLUTION_CAP_SEPARATE_XY_RESOLUTION);
+
+			if (dpirange)
+				ratbag_resolution_set_dpi_list_from_range(resolution,
+									  dpirange->min,
+									  dpirange->max);
+			if (dpilist)
+				ratbag_resolution_set_dpi_list(resolution,
+							       (unsigned int *)dpilist->entries,
+							       dpilist->nentries);
+		}
+
+		ratbag_profile_for_each_button(profile, button)
+			razer_init_button(button, button_count);
+	}
+
+	rc = razer_get_firmware_version(device, &major, &minor);
+	if (rc == 0) {
+		_cleanup_free_ char *fw = asprintf_safe("%u.%u", major, minor);
+		ratbag_device_set_firmware_version(device, fw);
+	}
+
+	rc = razer_read_settings(device);
+	if (rc) {
+		log_error(device->ratbag,
+			  "razer: failed to read the device settings\n");
+		goto err;
+	}
+
+	return 0;
+
+err:
+	free(drv_data);
+	ratbag_set_drv_data(device, NULL);
+	return rc;
+}
+
+static int
+razer_commit(struct ratbag_device *device)
+{
+	struct razer_data *drv_data = ratbag_get_drv_data(device);
+	struct ratbag_profile *profile;
+	struct ratbag_resolution *resolution;
+	int rc;
+
+	ratbag_device_for_each_profile(device, profile) {
+		struct razer_stage stages[RAZER_MAX_DPI_STAGES] = {0};
+		struct ratbag_resolution *active_res = NULL;
+		bool resolutions_dirty = false;
+
+		if (!profile->dirty)
+			continue;
+
+		ratbag_profile_for_each_resolution(profile, resolution) {
+			struct razer_stage *stage = &stages[resolution->index];
+
+			stage->id = resolution->index + 1;
+			stage->dpi_x = resolution->dpi_x;
+			stage->dpi_y = resolution->dpi_y;
+
+			/*
+			 * The trailing field mirrors the DPI on every stage
+			 * the device reported. Track that for stages we
+			 * change and keep the original value otherwise.
+			 */
+			stage->trailer = resolution->dirty
+					       ? resolution->dpi_x
+					       : drv_data->stage_trailer[resolution->index];
+
+			if (resolution->dirty)
+				resolutions_dirty = true;
+
+			if (resolution->is_active)
+				active_res = resolution;
+		}
+
+		if (resolutions_dirty) {
+			unsigned int active = active_res ? active_res->index + 1 : 1;
+
+			rc = razer_set_dpi_stages(device, stages,
+						  drv_data->stage_count, active);
+			if (rc) {
+				log_error(device->ratbag,
+					  "razer: failed to write the dpi stages\n");
+				return rc;
+			}
+
+			for (unsigned int i = 0; i < drv_data->stage_count; i++)
+				drv_data->stage_trailer[i] = stages[i].trailer;
+
+			/*
+			 * Writing the stages stores them, but does not switch
+			 * the sensor over. Apply the active stage explicitly
+			 * so the change is felt right away.
+			 */
+			if (active_res) {
+				rc = razer_set_active_dpi(device,
+							  active_res->dpi_x,
+							  active_res->dpi_y);
+				if (rc) {
+					log_error(device->ratbag,
+						  "razer: failed to apply the active dpi\n");
+					return rc;
+				}
+			}
+		}
+
+		if (profile->rate_dirty) {
+			rc = razer_set_report_rate(device, profile->hz);
+			if (rc) {
+				log_error(device->ratbag,
+					  "razer: failed to write the report rate\n");
+				return rc;
+			}
+		}
+	}
+
+	return 0;
+}
+
+static void
+razer_remove(struct ratbag_device *device)
+{
+	ratbag_close_hidraw(device);
+	free(ratbag_get_drv_data(device));
+}
+
+struct ratbag_driver razer_driver = {
+	.name = "Razer",
+	.id = "razer",
+	.probe = razer_probe,
+	.remove = razer_remove,
+	.commit = razer_commit,
+};

--- a/src/libratbag-data.c
+++ b/src/libratbag-data.c
@@ -57,6 +57,7 @@ enum driver {
 	GSKILL,
 	LOGITECH_G300,
 	LOGITECH_G600,
+	RAZER,
 	STEELSERIES,
 	ASUS,
 	SINOWEALTH,
@@ -85,6 +86,14 @@ struct data_hidpp10 {
 
 struct data_sinowealth {
 	struct list supported_devices;
+};
+
+struct data_razer {
+	int transaction_id;
+	int button_count;
+	int dpi_stage_count;
+	struct dpi_list *dpi_list;
+	struct dpi_range *dpi_range;
 };
 
 struct data_steelseries {
@@ -122,6 +131,7 @@ struct ratbag_device_data {
 		struct data_hidpp20 hidpp20;
 		struct data_hidpp10 hidpp10;
 		struct data_sinowealth sinowealth;
+		struct data_razer razer;
 		struct data_steelseries steelseries;
 		struct data_asus asus;
 	};
@@ -308,6 +318,51 @@ init_data_sinowealth(struct ratbag *ratbag,
 		}
 
 		list_insert(&data->sinowealth.supported_devices, &device->link);
+	}
+}
+
+static void
+init_data_razer(struct ratbag *ratbag,
+		GKeyFile *keyfile,
+		struct ratbag_device_data *data)
+{
+	const char *group = "Driver/razer";
+	GError *error = NULL;
+	_cleanup_(freep) char *dpi_range = NULL;
+	int num;
+
+	data->razer.transaction_id = -1;
+	data->razer.button_count = -1;
+	data->razer.dpi_stage_count = -1;
+	data->razer.dpi_list = NULL;
+	data->razer.dpi_range = NULL;
+
+	/*
+	 * The transaction id groups request and response and is model
+	 * specific; newer devices use 0x1f, older ones 0xff.
+	 */
+	num = g_key_file_get_integer(keyfile, group, "TransactionId", &error);
+	if (!error && num > 0 && num <= 0xff)
+		data->razer.transaction_id = num;
+	g_clear_error(&error);
+
+	num = g_key_file_get_integer(keyfile, group, "Buttons", &error);
+	if (!error && num >= 0)
+		data->razer.button_count = num;
+	g_clear_error(&error);
+
+	num = g_key_file_get_integer(keyfile, group, "DpiStages", &error);
+	if (!error && num > 0)
+		data->razer.dpi_stage_count = num;
+	g_clear_error(&error);
+
+	dpi_range = g_key_file_get_string(keyfile, group, "DpiRange", NULL);
+	if (dpi_range) {
+		data->razer.dpi_range = dpi_range_from_string(dpi_range);
+	} else {
+		dpi_range = g_key_file_get_string(keyfile, group, "DpiList", NULL);
+		if (dpi_range)
+			data->razer.dpi_list = dpi_list_from_string(dpi_range);
 	}
 }
 
@@ -508,6 +563,7 @@ static const struct driver_map {
 	{ GSKILL, "gskill", NULL },
 	{ LOGITECH_G300, "logitech_g300", NULL},
 	{ LOGITECH_G600, "logitech_g600", NULL},
+	{ RAZER, "razer", init_data_razer },
 	{ STEELSERIES, "steelseries", init_data_steelseries },
 	{ ASUS, "asus", init_data_asus },
 	{ SINOWEALTH, "sinowealth", init_data_sinowealth },
@@ -562,6 +618,10 @@ ratbag_device_data_destroy(struct ratbag_device_data *data)
 
 		break;
 	}
+	case RAZER:
+		dpi_list_free(data->razer.dpi_list);
+		free(data->razer.dpi_range);
+		break;
 	case STEELSERIES:
 		dpi_list_free(data->steelseries.dpi_list);
 		free(data->steelseries.dpi_range);
@@ -1059,4 +1119,46 @@ ratbag_device_data_asus_get_quirks(const struct ratbag_device_data *data)
 {
 	assert(data->drivertype == ASUS);
 	return data->asus.quirks;
+}
+
+/* Razer */
+
+int
+ratbag_device_data_razer_get_transaction_id(const struct ratbag_device_data *data)
+{
+	assert(data->drivertype == RAZER);
+
+	return data->razer.transaction_id;
+}
+
+int
+ratbag_device_data_razer_get_button_count(const struct ratbag_device_data *data)
+{
+	assert(data->drivertype == RAZER);
+
+	return data->razer.button_count;
+}
+
+int
+ratbag_device_data_razer_get_dpi_stage_count(const struct ratbag_device_data *data)
+{
+	assert(data->drivertype == RAZER);
+
+	return data->razer.dpi_stage_count;
+}
+
+struct dpi_list *
+ratbag_device_data_razer_get_dpi_list(const struct ratbag_device_data *data)
+{
+	assert(data->drivertype == RAZER);
+
+	return data->razer.dpi_list;
+}
+
+struct dpi_range *
+ratbag_device_data_razer_get_dpi_range(const struct ratbag_device_data *data)
+{
+	assert(data->drivertype == RAZER);
+
+	return data->razer.dpi_range;
 }

--- a/src/libratbag-data.h
+++ b/src/libratbag-data.h
@@ -103,6 +103,32 @@ ratbag_device_data_hidpp20_get_quirks(const struct ratbag_device_data *data);
 const struct list *
 ratbag_device_data_sinowealth_get_supported_devices(const struct ratbag_device_data *data);
 
+/* Razer */
+
+/**
+ * @return The transaction id or -1 if not set
+ */
+int
+ratbag_device_data_razer_get_transaction_id(const struct ratbag_device_data *data);
+
+/**
+ * @return The button count or -1 if not set
+ */
+int
+ratbag_device_data_razer_get_button_count(const struct ratbag_device_data *data);
+
+/**
+ * @return The number of onboard DPI stages or -1 if not set
+ */
+int
+ratbag_device_data_razer_get_dpi_stage_count(const struct ratbag_device_data *data);
+
+struct dpi_list *
+ratbag_device_data_razer_get_dpi_list(const struct ratbag_device_data *data);
+
+struct dpi_range *
+ratbag_device_data_razer_get_dpi_range(const struct ratbag_device_data *data);
+
 /* SteelSeries */
 
 /**

--- a/src/libratbag-private.h
+++ b/src/libratbag-private.h
@@ -589,6 +589,7 @@ extern struct ratbag_driver hidpp10_driver;
 extern struct ratbag_driver logitech_g300_driver;
 extern struct ratbag_driver logitech_g600_driver;
 extern struct ratbag_driver marsgaming_driver;
+extern struct ratbag_driver razer_driver;
 extern struct ratbag_driver roccat_driver;
 extern struct ratbag_driver roccat_kone_pure_driver;
 extern struct ratbag_driver roccat_emp_driver;

--- a/src/libratbag.c
+++ b/src/libratbag.c
@@ -572,6 +572,7 @@ ratbag_create_context(const struct ratbag_interface *interface,
 	ratbag_register_driver(ratbag, &logitech_g300_driver);
 	ratbag_register_driver(ratbag, &logitech_g600_driver);
 	ratbag_register_driver(ratbag, &marsgaming_driver);
+	ratbag_register_driver(ratbag, &razer_driver);
 	ratbag_register_driver(ratbag, &roccat_driver);
 	ratbag_register_driver(ratbag, &roccat_kone_pure_driver);
 	ratbag_register_driver(ratbag, &roccat_emp_driver);

--- a/test/data-parse-test.py
+++ b/test/data-parse-test.py
@@ -228,6 +228,45 @@ def check_section_hidpp20(section: configparser.SectionProxy):
         pass
 
 
+def check_section_razer(section: configparser.SectionProxy):
+    permitted_keys = (
+        "Buttons",
+        "DpiList",
+        "DpiRange",
+        "DpiStages",
+        "TransactionId",
+    )
+    for key in section:
+        assert key in permitted_keys
+
+    try:
+        check_dpi_list_str(section["DpiList"])
+        assert "DpiRange" not in section.keys()
+    except KeyError:
+        # No such section - not an error.
+        pass
+
+    try:
+        check_dpi_range_str(section["DpiRange"])
+        assert "DpiList" not in section.keys()
+    except KeyError:
+        # No such section - not an error.
+        pass
+
+    try:
+        # the driver reads five stage records out of one 80 byte payload
+        assert 1 <= int(section["DpiStages"]) <= 5
+    except KeyError:
+        # No such section - not an error.
+        pass
+
+    try:
+        assert 0 < int(section["TransactionId"]) <= 0xFF
+    except KeyError:
+        # No such section - not an error.
+        pass
+
+
 def check_section_steelseries(section: configparser.SectionProxy):
     permitted_keys = (
         "Buttons",
@@ -274,6 +313,10 @@ def check_section_driver(driver: str, section: configparser.SectionProxy):
 
     if driver == "hidpp20":
         check_section_hidpp20(section)
+        return
+
+    if driver == "razer":
+        check_section_razer(section)
         return
 
     if driver == "steelseries":


### PR DESCRIPTION
Adds a `razer` driver to libratbag and the first device for it, the wired
DeathAdder V3 (`1532:00b2`). A first step towards #103, and a base the other
Razer requests (#1690, #1797) can build on.

Scope: DPI stages and report rate are configurable, buttons are reported but
not remapped, no LEDs. Everything below was verified against the device
(firmware 1.2) rather than taken from OpenRazer on faith.

## Commits

| | |
|---|---|
| `libratbag-data` | the `[Driver/razer]` group, its accessors, `device.example`, `data-parse-test.py` |
| `razer` | the driver, registration, `meson.build` |
| `data` | `razer-deathadder-v3.device` |
| `README` | Razer in the vendor list |

Each one builds on its own. `meson test` is green (7 ok, 0 fail, 3 skipped
for the usual missing bits), `black`/`ruff` at the versions pinned in
`main.yml` pass on the test change.

## Three things worth a look in review

### 1. The interface check does I/O, which no other driver does

`razer_test_hidraw()` filters on the descriptor and *then* sends a firmware
request to confirm. Every other driver uses a pure descriptor predicate, so
this deserves an explanation.

The control protocol is a 90 byte feature report on report id 0, declared in
the vendor usage page 0xff00 — but that page sits inside the Generic
Desktop/Mouse application collection:

```
05 01 09 02 a1 01                  Generic Desktop, Mouse, Application
  [...]
  06 00 ff 09 02                   usage page 0xff00, usage 0x02
  15 00 25 01 75 08 95 5a b1 01    feature, 0x5a = 90 bytes
c0
```

`ratbag_hidraw_has_vendor_page()` never sees it. The parser records the usage
page of the first application collection per report id only
(`libratbag-hidraw.c`, `case HID_COLLECTION`), so this interface is filed
under Generic Desktop. Filtering on the vendor page binds nothing at all.

`ratbag_hidraw_has_report(device, 0)` does not separate them either: the
device exposes three interfaces, and two of them are keyboard collections,
one of which also has no report id. What does separate them is the
application usage — mouse (0x02) against keyboard (0x06).

The descriptor check has to come first for a practical reason: a request to
the keyboard collections stalls the control transfer with `-EPROTO`, the
device resets, udev re-adds it and ratbagd probes again, endlessly. That is
what the confirming request is guarded by, and it is why it is a guard rather
than the whole test.

If you would rather have a pure descriptor predicate, dropping the request is
a two-line change and I am happy to do it — a wrong interface would then fail
later in `razer_read_settings()` instead.

The parser limitation itself looks worth fixing separately, so that
`has_vendor_page()` works for descriptors of this shape. I have left it alone
here.

### 2. Two deviations from OpenRazer

Both confirmed by writing and reading back:

- **DPI stage ids are 1-based.** The device reports its stages as id 1..5 and
  takes them back that way. OpenRazer writes 0-based ids when setting stages.
- **The last two bytes of a stage record are not reserved.** They hold a third
  copy of the stage's DPI. OpenRazer zeroes them; this driver preserves what
  the device reported for stages it does not touch.

### 3. No lighting, on purpose

The DeathAdder V3 has no addressable zone, only a DPI indicator LED with no
documented protocol. OpenRazer agrees — in `razer_mouse_probe()`:

```c
case USB_DEVICE_ID_RAZER_DEATHADDER_V3:          /* 0x00B2 */
    CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_poll_rate);
    CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_dpi);
    CREATE_DEVICE_FILE(&hdev->dev, &dev_attr_dpi_stages);
    break;
```

Three attributes, none of them lighting, while neighbouring models in the
same switch get `scroll_led_brightness` and the `matrix_effect_*` family.
None of the 14 occurrences of that constant is in a LED or brightness
function.

So the driver reports zero LEDs. Razer models that do have zones need a
device data key and a led count in `ratbag_device_init_profiles()` — no
restructuring.

## Testing

On the device, through `ratbagctl` against a `ratbagd` built from this
branch: reading and setting each of the five stages, separate X/Y
resolutions, switching the active stage, each of the seven report rates from
125 to 8000 Hz, and persistence across a daemon restart. Also confirmed that
the device is exported exactly once per daemon run, i.e. no re-enumeration
loop.

Piper drives it as-is; it has no drawing for this model yet.
